### PR TITLE
ci: add seed workflow dispatch

### DIFF
--- a/.github/workflows/seed.yml
+++ b/.github/workflows/seed.yml
@@ -1,0 +1,28 @@
+name: Seed Database
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirm:
+        description: 'Type "seed" to confirm database seeding'
+        required: true
+        default: ''
+
+jobs:
+  seed:
+    if: github.event.inputs.confirm == 'seed'
+    runs-on: self-hosted
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Run seed script
+        run: |
+          cd /var/www/daterabbit/api
+          npx ts-node -r tsconfig-paths/register src/seed/seed.ts
+        env:
+          NODE_ENV: development


### PR DESCRIPTION
## Summary
- Adds manual `Seed Database` workflow trigger via GitHub Actions
- Go to Actions → Seed Database → Run workflow → type "seed" to confirm
- Runs the seed script on the server to populate test data

🤖 Generated with [Claude Code](https://claude.com/claude-code)