### PR TITLE
fix: seed copies .env from deploy dir

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -100,5 +100,6 @@ jobs:
       - name: Run seed script
         if: github.event.inputs.seed == 'yes'
         run: |
+          cp /var/www/daterabbit/api/.env backend/daterabbit-api/.env
           cd backend/daterabbit-api
           npx ts-node src/seed/seed.ts 2>&1


### PR DESCRIPTION
Copy .env from /var/www/daterabbit/api/.env for seed DB credentials