### PR TITLE
fix: booking form web alert + Terms/Privacy pages

### DIFF
--- a/.ai/bugs.json
+++ b/.ai/bugs.json
@@ -293,28 +293,24 @@
       "id": "BUG-023",
       "type": "bug",
       "severity": "medium",
-      "status": "open",
+      "status": "pending_review",
       "title": "Booking form submit button non-functional on web",
-      "description": "Booking form renders correctly with all fields, but Send Request button does not trigger handleSubmit on web. React Native Web state selections may not persist correctly through Playwright interactions. API works (direct call returns 201).",
+      "description": "Booking form renders correctly with all fields, but Send Request button does not trigger handleSubmit on web. Root cause: Alert.alert() is a no-op on web — success callback with navigation was inside Alert.alert, so nothing happened after successful booking.",
       "platform": "web",
       "created": "2026-02-27",
-      "steps_to_reproduce": [
-        "Navigate to booking form for any companion",
-        "Select activity, duration, date, time, enter location",
-        "Click Send Request",
-        "Nothing happens, no error, no navigation"
-      ],
+      "fix": "Created cross-platform showAlert() helper that uses window.alert on web and Alert.alert on native. Success navigation now triggers correctly after alert dismissal.",
       "found_by": "e2e-browser"
     },
     {
       "id": "BUG-024",
       "type": "bug",
       "severity": "low",
-      "status": "open",
+      "status": "pending_review",
       "title": "Terms/Privacy pages crash on web",
-      "description": "Clicking Terms or Privacy links from welcome page opens new tab that shows chrome error page. Routes not implemented.",
+      "description": "Clicking Terms or Privacy links from welcome page opened new tab to non-existent daterabbit.com URLs.",
       "platform": "web",
       "created": "2026-02-27",
+      "fix": "Created in-app /terms and /privacy routes with full content. Updated welcome.tsx and register.tsx to use router.push() instead of external URLs.",
       "found_by": "e2e-browser"
     }
   ]

--- a/app/app/(auth)/register.tsx
+++ b/app/app/(auth)/register.tsx
@@ -244,8 +244,8 @@ export default function RegisterScreen() {
 
         <Text style={styles.terms}>
           By creating an account, you agree to our{' '}
-          <Text style={styles.termsLink}>Terms of Service</Text> and{' '}
-          <Text style={styles.termsLink}>Privacy Policy</Text>
+          <Text style={styles.termsLink} onPress={() => router.push('/terms')}>Terms of Service</Text> and{' '}
+          <Text style={styles.termsLink} onPress={() => router.push('/privacy')}>Privacy Policy</Text>
         </Text>
       </ScrollView>
     </KeyboardAvoidingView>

--- a/app/app/(auth)/welcome.tsx
+++ b/app/app/(auth)/welcome.tsx
@@ -111,13 +111,13 @@ export default function WelcomeScreen() {
         <View style={styles.footer}>
           <Text
             style={styles.footerLink}
-            onPress={() => openLink('https://daterabbit.com/terms')}
+            onPress={() => router.push('/terms')}
           >
             Terms
           </Text>
           <Text
             style={styles.footerLink}
-            onPress={() => openLink('https://daterabbit.com/privacy')}
+            onPress={() => router.push('/privacy')}
           >
             Privacy
           </Text>

--- a/app/app/_layout.tsx
+++ b/app/app/_layout.tsx
@@ -76,6 +76,8 @@ export default function RootLayout() {
         <Stack.Screen name="settings/notifications" />
         <Stack.Screen name="settings/verification" />
         <Stack.Screen name="settings/delete-account" />
+        <Stack.Screen name="terms" />
+        <Stack.Screen name="privacy" />
       </Stack>
     </>
   );

--- a/app/app/booking/[id].tsx
+++ b/app/app/booking/[id].tsx
@@ -7,6 +7,7 @@ import {
   TouchableOpacity,
   TextInput,
   Alert,
+  Platform,
   ActivityIndicator,
 } from 'react-native';
 import { router, useLocalSearchParams } from 'expo-router';
@@ -62,6 +63,16 @@ const timeSlots = [
   '8:00 PM', '9:00 PM',
 ];
 
+// Cross-platform alert — Alert.alert is a no-op on web
+function showAlert(title: string, message: string, onOk?: () => void) {
+  if (Platform.OS === 'web') {
+    window.alert(`${title}\n\n${message}`);
+    onOk?.();
+  } else {
+    Alert.alert(title, message, onOk ? [{ text: 'OK', onPress: onOk }] : undefined);
+  }
+}
+
 export default function BookingScreen() {
   const { id } = useLocalSearchParams<{ id: string }>();
   const insets = useSafeAreaInsets();
@@ -86,7 +97,7 @@ export default function BookingScreen() {
     setIsLoadingCompanion(true);
     companionsApi.getById(id)
       .then((data) => setCompanion(data))
-      .catch(() => Alert.alert('Error', 'Could not load companion profile.'))
+      .catch(() => showAlert('Error', 'Could not load companion profile.'))
       .finally(() => setIsLoadingCompanion(false));
   }, [id]);
 
@@ -100,7 +111,7 @@ export default function BookingScreen() {
 
   const handleSubmit = async () => {
     if (!isValid || !companion) {
-      Alert.alert('Missing Information', 'Please fill in all required fields.');
+      showAlert('Missing Information', 'Please fill in all required fields.');
       return;
     }
 
@@ -134,19 +145,14 @@ export default function BookingScreen() {
     setIsSubmitting(false);
 
     if (!result.success) {
-      Alert.alert('Error', result.error || 'Failed to send request');
+      showAlert('Error', result.error || 'Failed to send request');
       return;
     }
 
-    Alert.alert(
+    showAlert(
       'Request Sent!',
       `Your date request has been sent to ${companion.name}. You'll be notified when they respond.`,
-      [
-        {
-          text: 'View My Bookings',
-          onPress: () => router.replace('/(tabs)/male/bookings'),
-        },
-      ]
+      () => router.replace('/(tabs)/male/bookings'),
     );
   };
 

--- a/app/app/privacy.tsx
+++ b/app/app/privacy.tsx
@@ -1,0 +1,130 @@
+import React from 'react';
+import { View, Text, StyleSheet, ScrollView, TouchableOpacity } from 'react-native';
+import { router } from 'expo-router';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { Icon } from '../src/components/Icon';
+import { useTheme, spacing, typography, PAGE_PADDING } from '../src/constants/theme';
+
+export default function PrivacyScreen() {
+  const insets = useSafeAreaInsets();
+  const { colors } = useTheme();
+
+  return (
+    <View style={[styles.container, { backgroundColor: colors.background }]}>
+      <View style={[styles.header, { paddingTop: insets.top + spacing.sm, backgroundColor: colors.white, borderBottomColor: colors.border }]}>
+        <TouchableOpacity style={[styles.backButton, { backgroundColor: colors.surface }]} onPress={() => router.back()}>
+          <Icon name="arrow-left" size={24} color={colors.text} />
+        </TouchableOpacity>
+        <Text style={[styles.headerTitle, { color: colors.text }]}>Privacy Policy</Text>
+        <View style={{ width: 44 }} />
+      </View>
+
+      <ScrollView
+        style={styles.scrollView}
+        contentContainerStyle={[styles.content, { paddingBottom: insets.bottom + spacing.xl }]}
+      >
+        <Text style={[styles.lastUpdated, { color: colors.textSecondary }]}>Last updated: February 2026</Text>
+
+        <Section title="1. Information We Collect" colors={colors}>
+          We collect information you provide during registration (name, email, date of birth, location), profile data (photos, bio, hourly rate for companions), and usage data (bookings, messages, reviews).
+        </Section>
+
+        <Section title="2. How We Use Your Information" colors={colors}>
+          Your information is used to: provide and improve our services, facilitate bookings between users, process payments, send important notifications, and ensure platform safety.
+        </Section>
+
+        <Section title="3. Identity Verification" colors={colors}>
+          For safety, we require identity verification (government ID and selfie). Verification data is processed securely and used solely for identity confirmation. We do not store raw ID images after verification is complete.
+        </Section>
+
+        <Section title="4. Information Sharing" colors={colors}>
+          We share limited profile information with other users (name, photos, bio, rating). Payment information is processed by Stripe and never stored on our servers. We do not sell your personal data to third parties.
+        </Section>
+
+        <Section title="5. Location Data" colors={colors}>
+          Location data is used to show nearby companions and calculate distances. You can control location permissions through your device settings. We do not track your location in the background.
+        </Section>
+
+        <Section title="6. Messages & Communications" colors={colors}>
+          Messages between users are stored securely on our servers. We may review messages if a safety concern is reported. We send transactional emails (booking confirmations, OTP codes) to your registered email.
+        </Section>
+
+        <Section title="7. Data Retention" colors={colors}>
+          Account data is retained while your account is active. Upon account deletion, personal data is removed within 30 days. Anonymized usage data may be retained for analytics.
+        </Section>
+
+        <Section title="8. Data Security" colors={colors}>
+          We use industry-standard security measures including encryption in transit (TLS), secure password hashing, and access controls. Despite our efforts, no system is 100% secure.
+        </Section>
+
+        <Section title="9. Your Rights" colors={colors}>
+          You have the right to: access your personal data, correct inaccurate data, delete your account and data, export your data, and opt out of marketing communications.
+        </Section>
+
+        <Section title="10. Cookies & Analytics" colors={colors}>
+          We use essential cookies for authentication and session management. We may use analytics tools to understand usage patterns. You can control cookies through your browser settings.
+        </Section>
+
+        <Section title="11. Children's Privacy" colors={colors}>
+          DateRabbit is not intended for users under 18. We do not knowingly collect data from minors. If we discover an underage account, it will be immediately terminated.
+        </Section>
+
+        <Section title="12. Contact" colors={colors}>
+          For privacy inquiries, contact us at privacy@daterabbit.com.
+        </Section>
+      </ScrollView>
+    </View>
+  );
+}
+
+function Section({ title, children, colors }: { title: string; children: string; colors: any }) {
+  return (
+    <View style={styles.section}>
+      <Text style={[styles.sectionTitle, { color: colors.text }]}>{title}</Text>
+      <Text style={[styles.sectionBody, { color: colors.textSecondary }]}>{children}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: spacing.lg,
+    paddingBottom: spacing.md,
+    borderBottomWidth: 1,
+  },
+  backButton: {
+    width: 44,
+    height: 44,
+    borderRadius: 22,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  headerTitle: {
+    fontFamily: typography.fonts.heading,
+    fontSize: typography.sizes.lg,
+    fontWeight: '600',
+  },
+  scrollView: { flex: 1 },
+  content: { padding: PAGE_PADDING },
+  lastUpdated: {
+    fontFamily: typography.fonts.body,
+    fontSize: typography.sizes.sm,
+    marginBottom: spacing.lg,
+  },
+  section: { marginBottom: spacing.lg },
+  sectionTitle: {
+    fontFamily: typography.fonts.bodySemiBold,
+    fontSize: typography.sizes.md,
+    fontWeight: '600',
+    marginBottom: spacing.sm,
+  },
+  sectionBody: {
+    fontFamily: typography.fonts.body,
+    fontSize: typography.sizes.md,
+    lineHeight: 24,
+  },
+});

--- a/app/app/terms.tsx
+++ b/app/app/terms.tsx
@@ -1,0 +1,126 @@
+import React from 'react';
+import { View, Text, StyleSheet, ScrollView, TouchableOpacity, Platform } from 'react-native';
+import { router } from 'expo-router';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { Icon } from '../src/components/Icon';
+import { useTheme, spacing, typography, borderRadius, PAGE_PADDING } from '../src/constants/theme';
+
+export default function TermsScreen() {
+  const insets = useSafeAreaInsets();
+  const { colors } = useTheme();
+
+  return (
+    <View style={[styles.container, { backgroundColor: colors.background }]}>
+      <View style={[styles.header, { paddingTop: insets.top + spacing.sm, backgroundColor: colors.white, borderBottomColor: colors.border }]}>
+        <TouchableOpacity style={[styles.backButton, { backgroundColor: colors.surface }]} onPress={() => router.back()}>
+          <Icon name="arrow-left" size={24} color={colors.text} />
+        </TouchableOpacity>
+        <Text style={[styles.headerTitle, { color: colors.text }]}>Terms of Service</Text>
+        <View style={{ width: 44 }} />
+      </View>
+
+      <ScrollView
+        style={styles.scrollView}
+        contentContainerStyle={[styles.content, { paddingBottom: insets.bottom + spacing.xl }]}
+      >
+        <Text style={[styles.lastUpdated, { color: colors.textSecondary }]}>Last updated: February 2026</Text>
+
+        <Section title="1. Acceptance of Terms" colors={colors}>
+          By accessing or using DateRabbit ("the Platform"), you agree to be bound by these Terms of Service. If you do not agree, do not use the Platform.
+        </Section>
+
+        <Section title="2. Eligibility" colors={colors}>
+          You must be at least 18 years old to use DateRabbit. By registering, you confirm that you meet this age requirement and that all information you provide is accurate.
+        </Section>
+
+        <Section title="3. Account Registration" colors={colors}>
+          You are responsible for maintaining the confidentiality of your account credentials. You agree to notify us immediately of any unauthorized use of your account.
+        </Section>
+
+        <Section title="4. Platform Services" colors={colors}>
+          DateRabbit connects seekers with companions for social experiences. The Platform facilitates bookings, payments, and communication between users. DateRabbit is not a party to any arrangement between users.
+        </Section>
+
+        <Section title="5. Companion Guidelines" colors={colors}>
+          Companions set their own hourly rates and availability. Companions must complete identity verification before accepting bookings. All interactions must remain respectful and within legal boundaries.
+        </Section>
+
+        <Section title="6. Seeker Guidelines" colors={colors}>
+          Seekers must complete identity verification before booking. Cancellation policies apply as described in each booking. Harassment or inappropriate behavior will result in account termination.
+        </Section>
+
+        <Section title="7. Payments & Fees" colors={colors}>
+          A 15% service fee is applied to all bookings. Payments are processed securely through Stripe. Refunds are handled on a case-by-case basis according to our cancellation policy.
+        </Section>
+
+        <Section title="8. Prohibited Conduct" colors={colors}>
+          Users may not: solicit illegal activities, harass other users, create fake accounts, circumvent Platform payments, or share another user's personal information without consent.
+        </Section>
+
+        <Section title="9. Account Termination" colors={colors}>
+          We reserve the right to suspend or terminate accounts that violate these Terms. You may delete your account at any time through the Settings page.
+        </Section>
+
+        <Section title="10. Limitation of Liability" colors={colors}>
+          DateRabbit is not liable for any interactions between users. We provide the Platform "as is" without warranties of any kind.
+        </Section>
+
+        <Section title="11. Contact" colors={colors}>
+          For questions about these Terms, contact us at support@daterabbit.com.
+        </Section>
+      </ScrollView>
+    </View>
+  );
+}
+
+function Section({ title, children, colors }: { title: string; children: string; colors: any }) {
+  return (
+    <View style={styles.section}>
+      <Text style={[styles.sectionTitle, { color: colors.text }]}>{title}</Text>
+      <Text style={[styles.sectionBody, { color: colors.textSecondary }]}>{children}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: spacing.lg,
+    paddingBottom: spacing.md,
+    borderBottomWidth: 1,
+  },
+  backButton: {
+    width: 44,
+    height: 44,
+    borderRadius: 22,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  headerTitle: {
+    fontFamily: typography.fonts.heading,
+    fontSize: typography.sizes.lg,
+    fontWeight: '600',
+  },
+  scrollView: { flex: 1 },
+  content: { padding: PAGE_PADDING },
+  lastUpdated: {
+    fontFamily: typography.fonts.body,
+    fontSize: typography.sizes.sm,
+    marginBottom: spacing.lg,
+  },
+  section: { marginBottom: spacing.lg },
+  sectionTitle: {
+    fontFamily: typography.fonts.bodySemiBold,
+    fontSize: typography.sizes.md,
+    fontWeight: '600',
+    marginBottom: spacing.sm,
+  },
+  sectionBody: {
+    fontFamily: typography.fonts.body,
+    fontSize: typography.sizes.md,
+    lineHeight: 24,
+  },
+});


### PR DESCRIPTION
## Summary
- **BUG-023**: Booking form submit button was non-functional on web because `Alert.alert()` is a no-op in browsers. Created cross-platform `showAlert()` helper that uses `window.alert` on web. Booking success now properly shows confirmation and navigates to bookings page.
- **BUG-024**: Terms/Privacy links opened external URLs to non-existent `daterabbit.com`. Created in-app `/terms` and `/privacy` routes with full legal content. Updated welcome and register pages to use `router.push()`.

## Changes
- `app/app/booking/[id].tsx` — cross-platform alert helper
- `app/app/terms.tsx` — new Terms of Service page
- `app/app/privacy.tsx` — new Privacy Policy page
- `app/app/_layout.tsx` — registered new routes
- `app/app/(auth)/welcome.tsx` — in-app links
- `app/app/(auth)/register.tsx` — clickable Terms/Privacy links

## Test plan
- [ ] Open booking form, fill all fields, click Send Request → should show alert and navigate to bookings
- [ ] Click Terms link on welcome page → should open in-app Terms page
- [ ] Click Privacy link on welcome page → should open in-app Privacy page
- [ ] Click Terms/Privacy on register page → should navigate to respective pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)