### PR TITLE
fix: nginx proxy for API + paymentIntentId tracking

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,6 +53,7 @@ jobs:
 
       - name: Create backend .env if missing
         run: |
+          mkdir -p /var/www/daterabbit/api
           if [ ! -f /var/www/daterabbit/api/.env ]; then
             cat > /var/www/daterabbit/api/.env << 'ENVEOF'
           PORT=3004
@@ -64,8 +65,11 @@ jobs:
           DB_PASSWORD=daterabbit
           DB_NAME=daterabbit
           JWT_SECRET=daterabbit-dev-jwt-secret-change-in-prod
+          STRIPE_SECRET_KEY=
+          STRIPE_WEBHOOK_SECRET=
+          APP_URL=https://daterabbit.smartlaunchhub.com
           ENVEOF
-            echo ".env created with defaults"
+            echo ".env created with defaults (add Stripe keys manually!)"
           else
             echo ".env already exists"
           fi
@@ -81,6 +85,15 @@ jobs:
           rsync -rlD backend/daterabbit-api/dist/ /var/www/daterabbit/api/dist/
           cd /var/www/daterabbit/api
           npm ci --production
+
+      - name: Setup nginx config
+        run: |
+          if [ -f server/nginx-daterabbit.conf ]; then
+            sudo cp server/nginx-daterabbit.conf /etc/nginx/sites-available/daterabbit
+            sudo ln -sf /etc/nginx/sites-available/daterabbit /etc/nginx/sites-enabled/daterabbit
+            sudo nginx -t && sudo systemctl reload nginx
+            echo "Nginx config updated and reloaded"
+          fi
 
       - name: Restart backend
         run: |
@@ -98,6 +111,9 @@ jobs:
           sudo pm2 show daterabbit 2>&1 | grep -E "(status|restarts|uptime)" || true
           echo "=== PM2 error logs (last 5) ==="
           sudo pm2 logs daterabbit --nostream --lines 5 --err 2>&1 || true
+          echo "=== API smoke test ==="
+          curl -s -o /dev/null -w "GET /api/payments/earnings: %{http_code}\n" http://localhost:3004/api/payments/earnings || true
+          curl -s -o /dev/null -w "POST /api/webhooks/stripe: %{http_code}\n" -X POST http://localhost:3004/api/webhooks/stripe || true
 
       - name: Run seed script
         if: github.event.inputs.seed == 'yes'
@@ -166,6 +182,15 @@ jobs:
           cd /var/www/daterabbit/api
           npm ci --production
 
+      - name: Setup nginx config
+        run: |
+          if [ -f server/nginx-daterabbit.conf ]; then
+            sudo cp server/nginx-daterabbit.conf /etc/nginx/sites-available/daterabbit
+            sudo ln -sf /etc/nginx/sites-available/daterabbit /etc/nginx/sites-enabled/daterabbit
+            sudo nginx -t && sudo systemctl reload nginx
+            echo "Nginx config updated and reloaded"
+          fi
+
       - name: Restart backend
         run: |
           cd /var/www/daterabbit/api
@@ -182,3 +207,5 @@ jobs:
           sudo pm2 show daterabbit 2>&1 | grep -E "(status|restarts|uptime)" || true
           echo "=== PM2 error logs (last 5) ==="
           sudo pm2 logs daterabbit --nostream --lines 5 --err 2>&1 || true
+          echo "=== API smoke test ==="
+          curl -s -o /dev/null -w "GET /api/payments/earnings: %{http_code}\n" http://localhost:3004/api/payments/earnings || true

--- a/backend/daterabbit-api/src/bookings/entities/booking.entity.ts
+++ b/backend/daterabbit-api/src/bookings/entities/booking.entity.ts
@@ -66,6 +66,9 @@ export class Booking {
   @Column({ type: 'enum', enum: BookingStatus, default: BookingStatus.PENDING })
   status: BookingStatus;
 
+  @Column({ nullable: true })
+  paymentIntentId: string;
+
   @Column({ type: 'text', nullable: true })
   cancellationReason: string;
 

--- a/backend/daterabbit-api/src/payments/payments.service.ts
+++ b/backend/daterabbit-api/src/payments/payments.service.ts
@@ -129,6 +129,10 @@ export class PaymentsService {
       },
     });
 
+    await this.bookingsRepo.update(bookingId, {
+      paymentIntentId: paymentIntent.id,
+    });
+
     return { clientSecret: paymentIntent.client_secret! };
   }
 

--- a/server/nginx-daterabbit.conf
+++ b/server/nginx-daterabbit.conf
@@ -1,0 +1,39 @@
+server {
+    listen 80;
+    server_name daterabbit.smartlaunchhub.com;
+
+    root /var/www/daterabbit;
+    index index.html;
+
+    # API proxy to NestJS backend
+    location /api/ {
+        proxy_pass http://127.0.0.1:3004;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_cache_bypass $http_upgrade;
+        client_max_body_size 10m;
+    }
+
+    # Uploads served from backend
+    location /uploads/ {
+        alias /var/www/daterabbit/api/uploads/;
+        expires 30d;
+        add_header Cache-Control "public, immutable";
+    }
+
+    # Static files (Expo web build)
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    # Cache static assets
+    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
+        expires 30d;
+        add_header Cache-Control "public, immutable";
+    }
+}


### PR DESCRIPTION
## Summary
- **Nginx proxy config**: Added `server/nginx-daterabbit.conf` that proxies `/api/` to NestJS backend on port 3004. Without this, all API calls returned SPA HTML (GET) or 405 (POST) from nginx.
- **paymentIntentId on Booking**: Added column to track Stripe PaymentIntent IDs per booking. `payments.service.ts` now saves it after creating a PaymentIntent.
- **Deploy improvements**: Nginx config auto-installed on deploy, Stripe env vars in default `.env`, API smoke test in verification step.

## Problem
The DateRabbit API was unreachable through the public URL — nginx served the Expo SPA for all routes including `/api/*`. The payments module code was working but completely inaccessible.

## Test plan
- [ ] Deploy to staging → verify nginx reloads without errors
- [ ] `curl https://daterabbit.smartlaunchhub.com/api/payments/earnings` → should return 401 (not HTML)
- [ ] `curl -X POST https://daterabbit.smartlaunchhub.com/api/webhooks/stripe` → should return 400/503 (not 405)
- [ ] Check PM2 logs for clean startup
- [ ] Manually add `STRIPE_SECRET_KEY` and `STRIPE_WEBHOOK_SECRET` to server `.env` when ready

🤖 Generated with [Claude Code](https://claude.com/claude-code)