### PR TITLE
fix: use chown for nginx patch (no sudo bash)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -95,9 +95,16 @@ jobs:
       - name: Patch nginx with API proxy
         continue-on-error: true
         run: |
-          if [ -f server/patch-nginx.sh ]; then
-            sudo bash server/patch-nginx.sh
-          fi
+          CONF=$(grep -rl "daterabbit" /etc/nginx/sites-enabled/ 2>/dev/null | head -1)
+          [ -z "$CONF" ] && CONF=$(grep -rl "daterabbit" /etc/nginx/sites-available/ 2>/dev/null | head -1)
+          if [ -z "$CONF" ]; then echo "WARN: No nginx config found"; exit 0; fi
+          echo "Found: $CONF"
+          if grep -q "proxy_pass.*3004" "$CONF" 2>/dev/null; then echo "Already patched"; exit 0; fi
+          ORIG_OWNER=$(stat -c '%U:%G' "$CONF" 2>/dev/null || echo "root:root")
+          sudo chown $(whoami) "$CONF"
+          python3 server/patch-nginx.py "$CONF"
+          sudo chown $ORIG_OWNER "$CONF"
+          sudo systemctl reload nginx && echo "Nginx patched and reloaded"
 
       - name: Verify deployment
         if: always()
@@ -189,9 +196,16 @@ jobs:
       - name: Patch nginx with API proxy
         continue-on-error: true
         run: |
-          if [ -f server/patch-nginx.sh ]; then
-            sudo bash server/patch-nginx.sh
-          fi
+          CONF=$(grep -rl "daterabbit" /etc/nginx/sites-enabled/ 2>/dev/null | head -1)
+          [ -z "$CONF" ] && CONF=$(grep -rl "daterabbit" /etc/nginx/sites-available/ 2>/dev/null | head -1)
+          if [ -z "$CONF" ]; then echo "WARN: No nginx config found"; exit 0; fi
+          echo "Found: $CONF"
+          if grep -q "proxy_pass.*3004" "$CONF" 2>/dev/null; then echo "Already patched"; exit 0; fi
+          ORIG_OWNER=$(stat -c '%U:%G' "$CONF" 2>/dev/null || echo "root:root")
+          sudo chown $(whoami) "$CONF"
+          python3 server/patch-nginx.py "$CONF"
+          sudo chown $ORIG_OWNER "$CONF"
+          sudo systemctl reload nginx && echo "Nginx patched and reloaded"
 
       - name: Verify deployment
         if: always()

--- a/server/patch-nginx.py
+++ b/server/patch-nginx.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Patch nginx config to add /api/ proxy block for DateRabbit backend."""
+import sys
+import shutil
+
+if len(sys.argv) < 2:
+    print("Usage: python3 patch-nginx.py <nginx-config-path>")
+    sys.exit(1)
+
+conf_path = sys.argv[1]
+
+proxy_block = """    # API proxy to NestJS backend
+    location /api/ {
+        proxy_pass http://127.0.0.1:3004;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_cache_bypass $http_upgrade;
+        client_max_body_size 10m;
+    }
+
+"""
+
+with open(conf_path, 'r') as f:
+    content = f.read()
+
+# Backup
+shutil.copy2(conf_path, conf_path + '.bak')
+
+# Insert before first 'location / {' (the catch-all)
+marker = '    location / {'
+if marker not in content:
+    # Try without leading spaces
+    marker = 'location / {'
+
+if marker in content:
+    content = content.replace(marker, proxy_block + marker, 1)
+    with open(conf_path, 'w') as f:
+        f.write(content)
+    print(f"Proxy block inserted before '{marker}'")
+else:
+    print("WARN: Could not find 'location / {' block")
+    sys.exit(0)


### PR DESCRIPTION
Uses sudo chown (allowed) instead of sudo bash (not allowed) to patch nginx config