### PR TITLE
feat: Stripe frontend integration

### DIFF
--- a/app/app.json
+++ b/app/app.json
@@ -29,6 +29,9 @@
     },
     "plugins": [
       "expo-router"
-    ]
+    ],
+    "extra": {
+      "stripePublishableKey": "pk_test_51T5TlyPIXSgCWIzOHEKqYS4Pqjt8VNkMlPx2aZ6MIqJQf1UWTEJvEdcSfrLj9z3qRzG49fQrF0FxEGqaNLNpSIX00Hb8bFncl"
+    }
   }
 }

--- a/app/app/(tabs)/male/bookings.tsx
+++ b/app/app/(tabs)/male/bookings.tsx
@@ -163,6 +163,7 @@ function BookingCard({ booking, type, colors, onCancel, formatDate }: BookingCar
       case 'accepted': return { bg: colors.success + '20', text: colors.success };
       case 'cancelled': return { bg: colors.error + '20', text: colors.error };
       case 'completed': return { bg: colors.primary + '20', text: colors.primary };
+      case 'paid': return { bg: colors.success + '20', text: colors.success };
       default: return { bg: colors.warning + '20', text: colors.warning };
     }
   };
@@ -193,6 +194,20 @@ function BookingCard({ booking, type, colors, onCancel, formatDate }: BookingCar
 
       {type === 'upcoming' && (
         <View style={styles.actions}>
+          {booking.status === 'confirmed' && !booking.isPaid && (
+            <Button
+              title={`Pay $${booking.total}`}
+              onPress={() => router.push(`/payment/${booking.id}`)}
+              size="sm"
+              style={{ flex: 1 }}
+            />
+          )}
+          {booking.isPaid && (
+            <View style={[styles.paidBadge, { backgroundColor: colors.success + '20' }]}>
+              <Icon name="check-circle" size={14} color={colors.success} />
+              <Text style={[styles.paidText, { color: colors.success }]}>Paid</Text>
+            </View>
+          )}
           <Button
             title="Message"
             onPress={() => router.push(`/chat/${booking.id}`)}
@@ -200,7 +215,7 @@ function BookingCard({ booking, type, colors, onCancel, formatDate }: BookingCar
             size="sm"
             style={{ flex: 1 }}
           />
-          {canCancel && (
+          {canCancel && !booking.isPaid && (
             <Button
               title="Cancel"
               onPress={onCancel}
@@ -353,5 +368,18 @@ const styles = StyleSheet.create({
     fontFamily: typography.fonts.body,
     fontSize: typography.sizes.sm,
     marginBottom: spacing.xs,
+  },
+  paidBadge: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+    borderRadius: borderRadius.md,
+    gap: spacing.xs,
+  },
+  paidText: {
+    fontFamily: typography.fonts.bodySemiBold,
+    fontSize: typography.sizes.sm,
   },
 });

--- a/app/app/_layout.tsx
+++ b/app/app/_layout.tsx
@@ -10,6 +10,7 @@ import {
   SpaceGrotesk_700Bold,
 } from '@expo-google-fonts/space-grotesk';
 import { colors } from '../src/constants/theme';
+import { StripeProvider } from '../src/components/StripeProvider';
 
 export default function RootLayout() {
   const { isAuthenticated, hasSeenOnboarding, user } = useAuthStore();
@@ -34,7 +35,7 @@ export default function RootLayout() {
   }
 
   return (
-    <>
+    <StripeProvider>
       <StatusBar style="dark" />
       <Stack
         screenOptions={{
@@ -71,6 +72,9 @@ export default function RootLayout() {
         <Stack.Screen name="chat/[id]" />
         <Stack.Screen name="profile/[id]" />
         <Stack.Screen name="reviews/[id]" />
+        <Stack.Screen name="payment/[bookingId]" />
+        <Stack.Screen name="stripe/return" />
+        <Stack.Screen name="stripe/refresh" />
         <Stack.Screen name="favorites/index" />
         <Stack.Screen name="settings/edit-profile" />
         <Stack.Screen name="settings/notifications" />
@@ -79,7 +83,7 @@ export default function RootLayout() {
         <Stack.Screen name="terms" />
         <Stack.Screen name="privacy" />
       </Stack>
-    </>
+    </StripeProvider>
   );
 }
 

--- a/app/app/payment/[bookingId].tsx
+++ b/app/app/payment/[bookingId].tsx
@@ -1,0 +1,314 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, StyleSheet, ScrollView, ActivityIndicator, Platform } from 'react-native';
+import { useLocalSearchParams, useRouter } from 'expo-router';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { Card } from '../../src/components/Card';
+import { Button } from '../../src/components/Button';
+import { Icon } from '../../src/components/Icon';
+import { UserImage } from '../../src/components/UserImage';
+import { StripePaymentForm } from '../../src/components/StripePaymentForm';
+import { useTheme, spacing, typography, borderRadius } from '../../src/constants/theme';
+import { useEarningsStore } from '../../src/store/earningsStore';
+import { useBookingsStore } from '../../src/store/bookingsStore';
+import { showAlert } from '../../src/utils/alert';
+
+export default function PaymentScreen() {
+  const { bookingId } = useLocalSearchParams<{ bookingId: string }>();
+  const insets = useSafeAreaInsets();
+  const router = useRouter();
+  const { colors } = useTheme();
+  const { createPaymentIntent } = useEarningsStore();
+  const { bookings, fetchMyBookings } = useBookingsStore();
+
+  const [clientSecret, setClientSecret] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const booking = bookings.find((b) => b.id === bookingId);
+
+  useEffect(() => {
+    const init = async () => {
+      if (!bookingId) return;
+
+      // Fetch bookings if we don't have them
+      if (!booking) {
+        await fetchMyBookings('upcoming');
+      }
+
+      // Create payment intent
+      const result = await createPaymentIntent(bookingId);
+      if (result.success && result.clientSecret) {
+        setClientSecret(result.clientSecret);
+      } else {
+        setError(result.error || 'Failed to initialize payment');
+      }
+      setLoading(false);
+    };
+
+    init();
+  }, [bookingId]);
+
+  const handlePaymentSuccess = () => {
+    showAlert('Payment Successful!', 'Your booking has been paid. Have a great time!');
+    fetchMyBookings('upcoming');
+    router.back();
+  };
+
+  if (loading) {
+    return (
+      <View style={[styles.container, styles.center, { backgroundColor: colors.background }]}>
+        <ActivityIndicator size="large" color={colors.primary} />
+        <Text style={[styles.loadingText, { color: colors.textSecondary }]}>
+          Setting up payment...
+        </Text>
+      </View>
+    );
+  }
+
+  if (error) {
+    return (
+      <View style={[styles.container, styles.center, { backgroundColor: colors.background }]}>
+        <View style={[styles.errorIcon, { backgroundColor: colors.error + '20' }]}>
+          <Icon name="alert-circle" size={48} color={colors.error} />
+        </View>
+        <Text style={[styles.errorTitle, { color: colors.text }]}>Payment Error</Text>
+        <Text style={[styles.errorMessage, { color: colors.textSecondary }]}>{error}</Text>
+        <Button
+          title="Go Back"
+          onPress={() => router.back()}
+          variant="outline"
+          style={{ marginTop: spacing.lg }}
+        />
+      </View>
+    );
+  }
+
+  const companion = booking?.companion || { name: 'Companion', photo: undefined };
+
+  return (
+    <ScrollView
+      style={[styles.container, { backgroundColor: colors.background }]}
+      contentContainerStyle={[styles.content, { paddingTop: insets.top + spacing.md }]}
+    >
+      {/* Header */}
+      <View style={styles.header}>
+        <Button
+          title="Back"
+          onPress={() => router.back()}
+          variant="outline"
+          size="sm"
+          icon="arrow-left"
+        />
+        <Text style={[styles.title, { color: colors.text }]}>Payment</Text>
+        <View style={{ width: 70 }} />
+      </View>
+
+      {/* Booking Summary */}
+      {booking && (
+        <Card style={styles.summaryCard}>
+          <View style={styles.summaryHeader}>
+            <UserImage name={companion.name} uri={companion.photo} size={56} />
+            <View style={styles.summaryInfo}>
+              <Text style={[styles.companionName, { color: colors.text }]}>{companion.name}</Text>
+              <Text style={[styles.activityText, { color: colors.textSecondary }]}>
+                {booking.activity || 'Date'}
+              </Text>
+              <Text style={[styles.dateText, { color: colors.textSecondary }]}>
+                {new Date(booking.date).toLocaleDateString('en-US', {
+                  weekday: 'short',
+                  month: 'short',
+                  day: 'numeric',
+                  hour: 'numeric',
+                  minute: '2-digit',
+                })}
+                {' '}&bull; {booking.duration || 1}h
+              </Text>
+            </View>
+          </View>
+
+          <View style={[styles.divider, { borderBottomColor: colors.border + '30' }]} />
+
+          {/* Price Breakdown */}
+          <View style={styles.priceRow}>
+            <Text style={[styles.priceLabel, { color: colors.textSecondary }]}>
+              ${booking.hourlyRate}/hr &times; {booking.duration || 1}h
+            </Text>
+            <Text style={[styles.priceValue, { color: colors.text }]}>
+              ${booking.subtotal.toFixed(2)}
+            </Text>
+          </View>
+          <View style={styles.priceRow}>
+            <Text style={[styles.priceLabel, { color: colors.textSecondary }]}>Platform fee</Text>
+            <Text style={[styles.priceValue, { color: colors.text }]}>
+              ${booking.platformFee.toFixed(2)}
+            </Text>
+          </View>
+          <View style={[styles.divider, { borderBottomColor: colors.border + '30' }]} />
+          <View style={styles.priceRow}>
+            <Text style={[styles.totalLabel, { color: colors.text }]}>Total</Text>
+            <Text style={[styles.totalValue, { color: colors.primary }]}>
+              ${booking.total.toFixed(2)}
+            </Text>
+          </View>
+        </Card>
+      )}
+
+      {/* Payment Form */}
+      <View style={styles.paymentSection}>
+        <Text style={[styles.sectionTitle, { color: colors.text }]}>Payment Details</Text>
+        {clientSecret && booking && (
+          <StripePaymentForm
+            clientSecret={clientSecret}
+            amount={booking.total}
+            onSuccess={handlePaymentSuccess}
+          />
+        )}
+
+        {Platform.OS !== 'web' && (
+          <Card style={[styles.nativeNotice, { backgroundColor: colors.warning + '15' }]}>
+            <Icon name="globe" size={20} color={colors.warning} />
+            <Text style={[styles.nativeNoticeText, { color: colors.textSecondary }]}>
+              To pay, please open DateRabbit in your web browser.
+            </Text>
+          </Card>
+        )}
+      </View>
+
+      {/* Security Notice */}
+      <View style={styles.securityRow}>
+        <Icon name="lock" size={14} color={colors.textMuted} />
+        <Text style={[styles.securityText, { color: colors.textMuted }]}>
+          Payments processed securely by Stripe
+        </Text>
+      </View>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  center: {
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: spacing.xl,
+  },
+  content: {
+    padding: spacing.lg,
+    paddingBottom: spacing.xxxl,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginBottom: spacing.lg,
+  },
+  title: {
+    fontFamily: typography.fonts.heading,
+    fontSize: typography.sizes.xl,
+  },
+  summaryCard: {
+    marginBottom: spacing.lg,
+  },
+  summaryHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: spacing.md,
+  },
+  summaryInfo: {
+    flex: 1,
+    marginLeft: spacing.md,
+  },
+  companionName: {
+    fontFamily: typography.fonts.bodySemiBold,
+    fontSize: typography.sizes.lg,
+  },
+  activityText: {
+    fontFamily: typography.fonts.body,
+    fontSize: typography.sizes.sm,
+    marginTop: 2,
+  },
+  dateText: {
+    fontFamily: typography.fonts.body,
+    fontSize: typography.sizes.sm,
+    marginTop: 2,
+  },
+  divider: {
+    borderBottomWidth: 1,
+    marginVertical: spacing.md,
+  },
+  priceRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginBottom: spacing.sm,
+  },
+  priceLabel: {
+    fontFamily: typography.fonts.body,
+    fontSize: typography.sizes.sm,
+  },
+  priceValue: {
+    fontFamily: typography.fonts.bodyMedium,
+    fontSize: typography.sizes.sm,
+  },
+  totalLabel: {
+    fontFamily: typography.fonts.heading,
+    fontSize: typography.sizes.md,
+  },
+  totalValue: {
+    fontFamily: typography.fonts.heading,
+    fontSize: typography.sizes.lg,
+  },
+  paymentSection: {
+    marginBottom: spacing.lg,
+  },
+  sectionTitle: {
+    fontFamily: typography.fonts.heading,
+    fontSize: typography.sizes.lg,
+    marginBottom: spacing.md,
+  },
+  nativeNotice: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+    marginTop: spacing.md,
+  },
+  nativeNoticeText: {
+    fontFamily: typography.fonts.body,
+    fontSize: typography.sizes.sm,
+    flex: 1,
+  },
+  securityRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: spacing.xs,
+  },
+  securityText: {
+    fontFamily: typography.fonts.body,
+    fontSize: typography.sizes.xs,
+  },
+  loadingText: {
+    fontFamily: typography.fonts.body,
+    fontSize: typography.sizes.md,
+    marginTop: spacing.md,
+  },
+  errorIcon: {
+    width: 96,
+    height: 96,
+    borderRadius: 48,
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginBottom: spacing.lg,
+  },
+  errorTitle: {
+    fontFamily: typography.fonts.heading,
+    fontSize: typography.sizes.xl,
+    marginBottom: spacing.sm,
+  },
+  errorMessage: {
+    fontFamily: typography.fonts.body,
+    fontSize: typography.sizes.md,
+    textAlign: 'center',
+  },
+});

--- a/app/app/stripe/refresh.tsx
+++ b/app/app/stripe/refresh.tsx
@@ -1,0 +1,81 @@
+import React, { useState } from 'react';
+import { View, Text, StyleSheet, Platform, Linking } from 'react-native';
+import { useRouter } from 'expo-router';
+import * as WebBrowser from 'expo-web-browser';
+import { Icon } from '../../src/components/Icon';
+import { Button } from '../../src/components/Button';
+import { useTheme, spacing, typography } from '../../src/constants/theme';
+import { useEarningsStore } from '../../src/store/earningsStore';
+
+export default function StripeRefreshScreen() {
+  const router = useRouter();
+  const { colors } = useTheme();
+  const { startStripeOnboarding } = useEarningsStore();
+  const [retrying, setRetrying] = useState(false);
+
+  const handleRetry = async () => {
+    setRetrying(true);
+    const result = await startStripeOnboarding();
+    setRetrying(false);
+
+    if (result.success && result.url) {
+      if (Platform.OS === 'web') {
+        Linking.openURL(result.url);
+      } else {
+        await WebBrowser.openAuthSessionAsync(result.url, 'daterabbit://');
+      }
+    }
+  };
+
+  return (
+    <View style={[styles.container, { backgroundColor: colors.background }]}>
+      <View style={[styles.iconCircle, { backgroundColor: colors.warning + '20' }]}>
+        <Icon name="refresh-cw" size={48} color={colors.warning} />
+      </View>
+      <Text style={[styles.title, { color: colors.text }]}>Session Expired</Text>
+      <Text style={[styles.subtitle, { color: colors.textSecondary }]}>
+        Your Stripe onboarding session has expired. Please try again to complete your account setup.
+      </Text>
+      <Button
+        title={retrying ? 'Redirecting...' : 'Try Again'}
+        onPress={handleRetry}
+        disabled={retrying}
+        style={{ marginTop: spacing.lg }}
+      />
+      <Button
+        title="Back to Earnings"
+        onPress={() => router.replace('/(tabs)/female/earnings')}
+        variant="outline"
+        style={{ marginTop: spacing.sm }}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: spacing.xl,
+  },
+  iconCircle: {
+    width: 96,
+    height: 96,
+    borderRadius: 48,
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginBottom: spacing.lg,
+  },
+  title: {
+    fontFamily: typography.fonts.heading,
+    fontSize: typography.sizes.xl,
+    marginBottom: spacing.sm,
+  },
+  subtitle: {
+    fontFamily: typography.fonts.body,
+    fontSize: typography.sizes.md,
+    textAlign: 'center',
+    lineHeight: 24,
+  },
+});

--- a/app/app/stripe/return.tsx
+++ b/app/app/stripe/return.tsx
@@ -1,0 +1,63 @@
+import React, { useEffect } from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { useRouter } from 'expo-router';
+import { Icon } from '../../src/components/Icon';
+import { Button } from '../../src/components/Button';
+import { useTheme, spacing, typography } from '../../src/constants/theme';
+
+export default function StripeReturnScreen() {
+  const router = useRouter();
+  const { colors } = useTheme();
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      router.replace('/(tabs)/female/earnings');
+    }, 3000);
+    return () => clearTimeout(timer);
+  }, []);
+
+  return (
+    <View style={[styles.container, { backgroundColor: colors.background }]}>
+      <View style={[styles.iconCircle, { backgroundColor: colors.success + '20' }]}>
+        <Icon name="check" size={48} color={colors.success} />
+      </View>
+      <Text style={[styles.title, { color: colors.text }]}>Setup Complete!</Text>
+      <Text style={[styles.subtitle, { color: colors.textSecondary }]}>
+        Your Stripe account has been connected. You can now receive payments.
+      </Text>
+      <Button
+        title="Go to Earnings"
+        onPress={() => router.replace('/(tabs)/female/earnings')}
+        style={{ marginTop: spacing.lg }}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: spacing.xl,
+  },
+  iconCircle: {
+    width: 96,
+    height: 96,
+    borderRadius: 48,
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginBottom: spacing.lg,
+  },
+  title: {
+    fontFamily: typography.fonts.heading,
+    fontSize: typography.sizes.xl,
+    marginBottom: spacing.sm,
+  },
+  subtitle: {
+    fontFamily: typography.fonts.body,
+    fontSize: typography.sizes.md,
+    textAlign: 'center',
+    lineHeight: 24,
+  },
+});

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -19,6 +19,8 @@
         "@react-navigation/bottom-tabs": "^7.4.0",
         "@react-navigation/native": "^7.1.8",
         "@react-navigation/native-stack": "^7.3.16",
+        "@stripe/react-stripe-js": "^5.6.0",
+        "@stripe/stripe-js": "^8.8.0",
         "expo": "52",
         "expo-constants": "~17.0.8",
         "expo-font": "~13.0.4",
@@ -11425,6 +11427,29 @@
       "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@stripe/react-stripe-js": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@stripe/react-stripe-js/-/react-stripe-js-5.6.0.tgz",
+      "integrity": "sha512-tucu/vTGc+5NXbo2pUiaVjA4ENdRBET8qGS00BM4BAU8J4Pi3eY6BHollsP2+VSuzzlvXwMg0it3ZLhbCj2fPg==",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "^15.7.2"
+      },
+      "peerDependencies": {
+        "@stripe/stripe-js": ">=8.0.0 <9.0.0",
+        "react": ">=16.8.0 <20.0.0",
+        "react-dom": ">=16.8.0 <20.0.0"
+      }
+    },
+    "node_modules/@stripe/stripe-js": {
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/@stripe/stripe-js/-/stripe-js-8.8.0.tgz",
+      "integrity": "sha512-NNYuyW8qmLjyHnpyFgs/23wUrjB8k0xN9YIZFOMLewCa/pIkIji9e9aY/EgdNryEDDRptc6TcPIHRvG1R0ClFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.16"
+      }
     },
     "node_modules/@testing-library/jest-native": {
       "version": "5.4.3",

--- a/app/package.json
+++ b/app/package.json
@@ -30,6 +30,8 @@
     "@react-navigation/bottom-tabs": "^7.4.0",
     "@react-navigation/native": "^7.1.8",
     "@react-navigation/native-stack": "^7.3.16",
+    "@stripe/react-stripe-js": "^5.6.0",
+    "@stripe/stripe-js": "^8.8.0",
     "expo": "52",
     "expo-constants": "~17.0.8",
     "expo-font": "~13.0.4",

--- a/app/src/components/StripePaymentForm.tsx
+++ b/app/src/components/StripePaymentForm.tsx
@@ -1,0 +1,169 @@
+import React, { useState } from 'react';
+import { View, Text, StyleSheet, ActivityIndicator, Platform } from 'react-native';
+import { useTheme, spacing, typography, borderRadius } from '../constants/theme';
+
+interface StripePaymentFormProps {
+  clientSecret: string;
+  amount: number;
+  onSuccess: () => void;
+  onError?: (error: string) => void;
+}
+
+// Native fallback
+function NativeFallback() {
+  const { colors } = useTheme();
+  return (
+    <View style={styles.fallback}>
+      <Text style={[styles.fallbackText, { color: colors.textSecondary }]}>
+        Open DateRabbit in your browser to complete payment.
+      </Text>
+    </View>
+  );
+}
+
+// Web-only payment form
+function WebPaymentForm({ clientSecret, amount, onSuccess, onError }: StripePaymentFormProps) {
+  const { colors } = useTheme();
+  const [isProcessing, setIsProcessing] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  // Dynamic imports for web only
+  const {
+    useStripe,
+    useElements,
+    PaymentElement,
+  } = require('@stripe/react-stripe-js');
+  const { loadStripe } = require('@stripe/stripe-js');
+  const { Elements } = require('@stripe/react-stripe-js');
+  const Constants = require('expo-constants').default;
+
+  const publishableKey =
+    Constants.expoConfig?.extra?.stripePublishableKey ||
+    'pk_test_51T5TlyPIXSgCWIzOHEKqYS4Pqjt8VNkMlPx2aZ6MIqJQf1UWTEJvEdcSfrLj9z3qRzG49fQrF0FxEGqaNLNpSIX00Hb8bFncl';
+
+  const stripePromise = loadStripe(publishableKey);
+
+  return (
+    <Elements stripe={stripePromise} options={{ clientSecret }}>
+      <InnerForm
+        amount={amount}
+        onSuccess={onSuccess}
+        onError={onError}
+      />
+    </Elements>
+  );
+}
+
+function InnerForm({ amount, onSuccess, onError }: Omit<StripePaymentFormProps, 'clientSecret'>) {
+  const { colors } = useTheme();
+  const [isProcessing, setIsProcessing] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const { useStripe, useElements, PaymentElement } = require('@stripe/react-stripe-js');
+  const stripe = useStripe();
+  const elements = useElements();
+
+  const handleSubmit = async () => {
+    if (!stripe || !elements) return;
+
+    setIsProcessing(true);
+    setErrorMessage(null);
+
+    const { error } = await stripe.confirmPayment({
+      elements,
+      confirmParams: {
+        return_url: 'https://daterabbit.smartlaunchhub.com/stripe/return',
+      },
+      redirect: 'if_required',
+    });
+
+    if (error) {
+      setErrorMessage(error.message || 'Payment failed');
+      onError?.(error.message || 'Payment failed');
+      setIsProcessing(false);
+    } else {
+      onSuccess();
+    }
+  };
+
+  return (
+    <View style={styles.formContainer}>
+      <PaymentElement />
+
+      {errorMessage && (
+        <View style={[styles.errorBox, { backgroundColor: colors.error + '15', borderColor: colors.error }]}>
+          <Text style={[styles.errorText, { color: colors.error }]}>{errorMessage}</Text>
+        </View>
+      )}
+
+      <View
+        // @ts-ignore - web-only onClick
+        onClick={!isProcessing ? handleSubmit : undefined}
+        style={[
+          styles.payButton,
+          {
+            backgroundColor: isProcessing ? colors.textMuted : colors.primary,
+            borderColor: colors.text,
+          },
+        ]}
+      >
+        {isProcessing ? (
+          <ActivityIndicator color="#fff" size="small" />
+        ) : (
+          <Text style={styles.payButtonText}>Pay ${amount.toFixed(2)}</Text>
+        )}
+      </View>
+    </View>
+  );
+}
+
+export function StripePaymentForm(props: StripePaymentFormProps) {
+  if (Platform.OS !== 'web') {
+    return <NativeFallback />;
+  }
+  return <WebPaymentForm {...props} />;
+}
+
+const styles = StyleSheet.create({
+  formContainer: {
+    gap: spacing.md,
+  },
+  errorBox: {
+    padding: spacing.md,
+    borderRadius: borderRadius.md,
+    borderWidth: 2,
+  },
+  errorText: {
+    fontFamily: typography.fonts.body,
+    fontSize: typography.sizes.sm,
+  },
+  payButton: {
+    paddingVertical: spacing.md,
+    borderRadius: borderRadius.md,
+    borderWidth: 3,
+    alignItems: 'center',
+    justifyContent: 'center',
+    minHeight: 52,
+    shadowColor: '#000',
+    shadowOffset: { width: 4, height: 4 },
+    shadowOpacity: 1,
+    shadowRadius: 0,
+    cursor: 'pointer',
+  } as any,
+  payButtonText: {
+    fontFamily: typography.fonts.heading,
+    fontSize: typography.sizes.lg,
+    color: '#fff',
+    textTransform: 'uppercase',
+    letterSpacing: 1,
+  },
+  fallback: {
+    padding: spacing.xl,
+    alignItems: 'center',
+  },
+  fallbackText: {
+    fontFamily: typography.fonts.body,
+    fontSize: typography.sizes.md,
+    textAlign: 'center',
+  },
+});

--- a/app/src/components/StripeProvider.tsx
+++ b/app/src/components/StripeProvider.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { Platform } from 'react-native';
+
+interface StripeProviderProps {
+  children: React.ReactNode;
+}
+
+// Web-only Stripe wrapper. On native platforms, just render children.
+export function StripeProvider({ children }: StripeProviderProps) {
+  if (Platform.OS !== 'web') {
+    return <>{children}</>;
+  }
+
+  // Lazy import to avoid bundling on native
+  const WebStripeProvider = require('./StripeProviderWeb').default;
+  return <WebStripeProvider>{children}</WebStripeProvider>;
+}

--- a/app/src/components/StripeProviderWeb.tsx
+++ b/app/src/components/StripeProviderWeb.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { loadStripe } from '@stripe/stripe-js';
+import { Elements } from '@stripe/react-stripe-js';
+import Constants from 'expo-constants';
+
+const publishableKey =
+  Constants.expoConfig?.extra?.stripePublishableKey ||
+  'pk_test_51T5TlyPIXSgCWIzOHEKqYS4Pqjt8VNkMlPx2aZ6MIqJQf1UWTEJvEdcSfrLj9z3qRzG49fQrF0FxEGqaNLNpSIX00Hb8bFncl';
+
+const stripePromise = loadStripe(publishableKey);
+
+interface Props {
+  children: React.ReactNode;
+}
+
+export default function StripeProviderWeb({ children }: Props) {
+  return (
+    <Elements stripe={stripePromise}>
+      {children}
+    </Elements>
+  );
+}


### PR DESCRIPTION
## Summary
- Installed `@stripe/stripe-js` + `@stripe/react-stripe-js` for web payment processing
- Added `StripeProvider` wrapper (web-only Elements provider, native passthrough)
- Created `StripePaymentForm` component using Stripe PaymentElement with Neo-Brutalism styling
- New payment screen (`/payment/[bookingId]`) for seekers with booking summary + price breakdown + Stripe checkout
- Stripe Connect callback routes: `/stripe/return` (success) and `/stripe/refresh` (session expired, retry)
- Rewrote earnings screen with **Connect gating**: setup banner when not connected, verification warning when pending, full earnings UI when ready
- Added "Pay Now" button to confirmed unpaid bookings and "Paid" badge for paid bookings in seeker bookings tab
- Registered all new routes in root layout

## Files changed
**New (6):** StripeProvider, StripeProviderWeb, StripePaymentForm, payment/[bookingId], stripe/return, stripe/refresh
**Modified (4):** app.json (stripePublishableKey), _layout.tsx (StripeProvider + routes), earnings.tsx (Connect gating), bookings.tsx (Pay Now + Paid badge)

## Test plan
- [ ] Web build passes (`npx expo export --platform web`)
- [ ] Open as companion → earnings → see "Set Up Payments" banner → redirect to Stripe Connect
- [ ] After Stripe Connect → return to earnings → see full earnings UI
- [ ] Open as seeker → bookings → confirmed booking → see "Pay $X" button
- [ ] Tap "Pay Now" → payment screen with booking summary → Stripe form renders
- [ ] Test card `4242 4242 4242 4242` → payment success → booking shows "Paid" badge
- [ ] Native: payment screen shows "Open in browser" fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)