### PR TITLE
fix: guard booking.companion access to prevent crash (BUG-BOOKINGS-001)

### DIFF
--- a/app/app/(tabs)/male/bookings.tsx
+++ b/app/app/(tabs)/male/bookings.tsx
@@ -39,9 +39,10 @@ export default function BookingsScreen() {
   }, [activeTab]);
 
   const handleCancelBooking = useCallback((booking: Booking) => {
+    const companionName = booking.companion?.name || 'this companion';
     showConfirm(
       'Cancel Booking',
-      `Are you sure you want to cancel your date with ${booking.companion.name}?`,
+      `Are you sure you want to cancel your date with ${companionName}?`,
       async () => {
         const result = await cancelBooking(booking.id, 'Cancelled by user');
         if (result.success) {
@@ -154,7 +155,11 @@ interface BookingCardProps {
 }
 
 function BookingCard({ booking, type, colors, onCancel, formatDate }: BookingCardProps) {
-  const companion = booking.companion || { name: 'Unknown', photo: null, rating: 0 };
+  // Guard against undefined companion OR empty object {} produced by normalization
+  const rawCompanion = booking.companion;
+  const companion = (rawCompanion && rawCompanion.name)
+    ? rawCompanion
+    : { name: 'Unknown', photo: null, rating: 0 };
   
   const getStatusStyle = (status: string) => {
     switch (status) {

--- a/app/src/services/api.ts
+++ b/app/src/services/api.ts
@@ -288,8 +288,24 @@ export const bookingsApi = {
       body: data,
     }),
 
-  getById: (id: string) =>
-    apiRequest<Booking>(`/bookings/${id}`),
+  getById: async (id: string) => {
+    const b = await apiRequest<any>(`/bookings/${id}`);
+    // Apply same normalization as getMyBookings to ensure companion is always safe to access
+    return {
+      ...b,
+      date: b.date ?? b.dateTime,
+      total: typeof b.total === 'number' ? b.total : parseFloat(b.totalPrice ?? b.total ?? '0'),
+      subtotal: typeof b.subtotal === 'number' ? b.subtotal : parseFloat(b.subtotal ?? '0'),
+      platformFee: typeof b.platformFee === 'number' ? b.platformFee : parseFloat(b.platformFee ?? '0'),
+      hourlyRate: typeof b.hourlyRate === 'number' ? b.hourlyRate : parseFloat(b.hourlyRate ?? b.companion?.hourlyRate ?? '0'),
+      companionEarnings: typeof b.companionEarnings === 'number' ? b.companionEarnings : parseFloat(b.companionEarnings ?? '0'),
+      isPaid: b.isPaid ?? false,
+      companion: {
+        ...b.companion,
+        photo: b.companion?.photo ?? b.companion?.photos?.[0]?.url,
+      },
+    } as Booking;
+  },
 
   getMyBookings: async (filter: 'all' | 'pending' | 'upcoming' | 'past' = 'all', page = 1) => {
     const response = await apiRequest<


### PR DESCRIPTION
## Summary

- Fixed `handleCancelBooking()` in `bookings.tsx` — was directly accessing `booking.companion.name` without any guard, causing crash when companion is undefined. Now uses `booking.companion?.name || 'this companion'`.
- Fixed `bookingsApi.getById()` in `api.ts` — was returning raw API response without normalization, bypassing the companion safety logic applied by all other booking endpoints. Now applies identical normalization to `getMyBookings()`.
- Fixed `BookingCard` companion fallback — the previous `booking.companion || fallback` was dead code because normalization produces `{}` (never `undefined`). Now checks `rawCompanion.name` to correctly detect empty objects and apply the fallback.

## Test plan

- [ ] Open Bookings screen — confirm no crash on load
- [ ] Cancel a pending/upcoming booking — confirm dialog shows companion name (or "this companion" if name missing)
- [ ] Verify booking loaded via `getById` path (e.g. payment/chat routes) also renders without crash

Fixes: BUG-BOOKINGS-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)