### PR TITLE
fix: remove sudo from mkdir in admin panel deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Deploy admin panel
         run: |
-          sudo mkdir -p /var/www/daterabbit-admin
+          mkdir -p /var/www/daterabbit-admin
           sudo chown -R github-runner:www-data /var/www/daterabbit-admin
           rsync -rlD --delete \
             --exclude 'node_modules' \
@@ -243,7 +243,7 @@ jobs:
 
       - name: Deploy admin panel
         run: |
-          sudo mkdir -p /var/www/daterabbit-admin
+          mkdir -p /var/www/daterabbit-admin
           sudo chown -R github-runner:www-data /var/www/daterabbit-admin
           rsync -rlD --delete \
             --exclude 'node_modules' \


### PR DESCRIPTION
## Summary
- Removes `sudo` from `mkdir -p /var/www/daterabbit-admin` in both staging and production deploy jobs
- The `github-runner` user has passwordless sudo only for `pm2`, `chown`, `chmod`, and `systemctl reload nginx` — `mkdir` is not in the allowed list
- Since `github-runner` is in the `www-data` group and `/var/www` dirs are accessible to that group, `mkdir` works without sudo

## Test plan
- [ ] Push to development branch triggers staging deploy
- [ ] Admin panel deploy step completes without the sudo password error
- [ ] PM2 process `daterabbit-admin` starts/restarts successfully