### PR TITLE
fix: deploy admin panel to /var/www/daterabbit/admin-panel

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,24 +55,25 @@ jobs:
           rsync -rlD --delete \
             --exclude 'api' \
             --exclude 'uploads' \
+            --exclude 'admin-panel' \
             app/dist/ /var/www/daterabbit/
 
       - name: Deploy admin panel
         run: |
-          mkdir -p /var/www/daterabbit-admin
-          sudo chown -R github-runner:www-data /var/www/daterabbit-admin
+          # Deploy admin into subdirectory of existing /var/www/daterabbit (runner already owns it)
+          mkdir -p /var/www/daterabbit/admin-panel
           rsync -rlD --delete \
             --exclude 'node_modules' \
             --exclude '.env.local' \
             --exclude '.git' \
-            admin/ /var/www/daterabbit-admin/
-          cd /var/www/daterabbit-admin
+            admin/ /var/www/daterabbit/admin-panel/
+          cd /var/www/daterabbit/admin-panel
           npm ci --production
-          if [ ! -f /var/www/daterabbit-admin/.env.local ]; then
-            echo "NEXT_PUBLIC_API_URL=https://daterabbit.smartlaunchhub.com/api" > /var/www/daterabbit-admin/.env.local
+          if [ ! -f /var/www/daterabbit/admin-panel/.env.local ]; then
+            echo "NEXT_PUBLIC_API_URL=https://daterabbit.smartlaunchhub.com/api" > /var/www/daterabbit/admin-panel/.env.local
           fi
           sudo pm2 restart daterabbit-admin || sudo pm2 start npm --name daterabbit-admin -- start -- -p 3005
-          sudo chown -R www-data:www-data /var/www/daterabbit-admin/
+          sudo chown -R www-data:www-data /var/www/daterabbit/
 
       - name: Create backend .env if missing
         run: |
@@ -239,24 +240,25 @@ jobs:
           rsync -rlD --delete \
             --exclude 'api' \
             --exclude 'uploads' \
+            --exclude 'admin-panel' \
             app/dist/ /var/www/daterabbit/
 
       - name: Deploy admin panel
         run: |
-          mkdir -p /var/www/daterabbit-admin
-          sudo chown -R github-runner:www-data /var/www/daterabbit-admin
+          # Deploy admin into subdirectory of existing /var/www/daterabbit (runner already owns it)
+          mkdir -p /var/www/daterabbit/admin-panel
           rsync -rlD --delete \
             --exclude 'node_modules' \
             --exclude '.env.local' \
             --exclude '.git' \
-            admin/ /var/www/daterabbit-admin/
-          cd /var/www/daterabbit-admin
+            admin/ /var/www/daterabbit/admin-panel/
+          cd /var/www/daterabbit/admin-panel
           npm ci --production
-          if [ ! -f /var/www/daterabbit-admin/.env.local ]; then
-            echo "NEXT_PUBLIC_API_URL=https://daterabbit.smartlaunchhub.com/api" > /var/www/daterabbit-admin/.env.local
+          if [ ! -f /var/www/daterabbit/admin-panel/.env.local ]; then
+            echo "NEXT_PUBLIC_API_URL=https://daterabbit.smartlaunchhub.com/api" > /var/www/daterabbit/admin-panel/.env.local
           fi
           sudo pm2 restart daterabbit-admin || sudo pm2 start npm --name daterabbit-admin -- start -- -p 3005
-          sudo chown -R www-data:www-data /var/www/daterabbit-admin/
+          sudo chown -R www-data:www-data /var/www/daterabbit/
 
       - name: Create backend .env if missing
         run: |


### PR DESCRIPTION
## Summary
- The previous fix removed `sudo` from `mkdir -p /var/www/daterabbit-admin` but github-runner still cannot create new directories in `/var/www/` (it's owned by root, not www-data group-writable)
- Changed admin panel deploy target from `/var/www/daterabbit-admin` (new top-level dir requiring sudo) to `/var/www/daterabbit/admin-panel` (subdirectory of the existing dir the runner already has write access to)
- Added `--exclude 'admin-panel'` to the frontend rsync deploy to prevent `--delete` from wiping the admin panel directory
- Both staging and production jobs are updated consistently

## Test plan
- [ ] Push to development triggers staging deploy
- [ ] Deploy admin panel step creates /var/www/daterabbit/admin-panel without errors
- [ ] PM2 process daterabbit-admin starts on port 3005
- [ ] Admin panel accessible at /admin on the staging URL