### PR TITLE
fix: companion safe defaults to prevent crash on undefined (BUG-BOOKINGS-001)

### DIFF
--- a/app/src/services/api.ts
+++ b/app/src/services/api.ts
@@ -290,19 +290,22 @@ export const bookingsApi = {
 
   getById: async (id: string) => {
     const b = await apiRequest<any>(`/bookings/${id}`);
-    // Apply same normalization as getMyBookings to ensure companion is always safe to access
+    // Normalize companion to always have safe defaults, even if API returns undefined or {}
+    const rawCompanion = b.companion ?? {};
     return {
       ...b,
       date: b.date ?? b.dateTime,
       total: typeof b.total === 'number' ? b.total : parseFloat(b.totalPrice ?? b.total ?? '0'),
       subtotal: typeof b.subtotal === 'number' ? b.subtotal : parseFloat(b.subtotal ?? '0'),
       platformFee: typeof b.platformFee === 'number' ? b.platformFee : parseFloat(b.platformFee ?? '0'),
-      hourlyRate: typeof b.hourlyRate === 'number' ? b.hourlyRate : parseFloat(b.hourlyRate ?? b.companion?.hourlyRate ?? '0'),
+      hourlyRate: typeof b.hourlyRate === 'number' ? b.hourlyRate : parseFloat(b.hourlyRate ?? rawCompanion.hourlyRate ?? '0'),
       companionEarnings: typeof b.companionEarnings === 'number' ? b.companionEarnings : parseFloat(b.companionEarnings ?? '0'),
       isPaid: b.isPaid ?? false,
       companion: {
-        ...b.companion,
-        photo: b.companion?.photo ?? b.companion?.photos?.[0]?.url,
+        id: rawCompanion.id ?? '',
+        name: rawCompanion.name ?? '',
+        rating: rawCompanion.rating ?? 0,
+        photo: rawCompanion.photo ?? rawCompanion.photos?.[0]?.url ?? null,
       },
     } as Booking;
   },
@@ -318,20 +321,26 @@ export const bookingsApi = {
       : [...(response.asSeeker || []), ...(response.asCompanion || [])];
 
     // Normalize field names (API may send dateTime/totalPrice instead of date/total)
-    const bookings = raw.map((b: any) => ({
-      ...b,
-      date: b.date ?? b.dateTime,
-      total: typeof b.total === 'number' ? b.total : parseFloat(b.totalPrice ?? b.total ?? '0'),
-      subtotal: typeof b.subtotal === 'number' ? b.subtotal : parseFloat(b.subtotal ?? '0'),
-      platformFee: typeof b.platformFee === 'number' ? b.platformFee : parseFloat(b.platformFee ?? '0'),
-      hourlyRate: typeof b.hourlyRate === 'number' ? b.hourlyRate : parseFloat(b.hourlyRate ?? b.companion?.hourlyRate ?? '0'),
-      companionEarnings: typeof b.companionEarnings === 'number' ? b.companionEarnings : parseFloat(b.companionEarnings ?? '0'),
-      isPaid: b.isPaid ?? false,
-      companion: {
-        ...b.companion,
-        photo: b.companion?.photo ?? b.companion?.photos?.[0]?.url,
-      },
-    }));
+    // companion is always normalized to a safe object with defaults so callers never crash
+    const bookings = raw.map((b: any) => {
+      const rawCompanion = b.companion ?? {};
+      return {
+        ...b,
+        date: b.date ?? b.dateTime,
+        total: typeof b.total === 'number' ? b.total : parseFloat(b.totalPrice ?? b.total ?? '0'),
+        subtotal: typeof b.subtotal === 'number' ? b.subtotal : parseFloat(b.subtotal ?? '0'),
+        platformFee: typeof b.platformFee === 'number' ? b.platformFee : parseFloat(b.platformFee ?? '0'),
+        hourlyRate: typeof b.hourlyRate === 'number' ? b.hourlyRate : parseFloat(b.hourlyRate ?? rawCompanion.hourlyRate ?? '0'),
+        companionEarnings: typeof b.companionEarnings === 'number' ? b.companionEarnings : parseFloat(b.companionEarnings ?? '0'),
+        isPaid: b.isPaid ?? false,
+        companion: {
+          id: rawCompanion.id ?? '',
+          name: rawCompanion.name ?? '',
+          rating: rawCompanion.rating ?? 0,
+          photo: rawCompanion.photo ?? rawCompanion.photos?.[0]?.url ?? null,
+        },
+      };
+    });
 
     return { bookings, total: 'bookings' in response ? (response as any).total : bookings.length };
   },


### PR DESCRIPTION
## Summary

- Fixed `bookingsApi.getById()` to extract `rawCompanion = b.companion ?? {}` before normalization, then explicitly set defaults (`id: ''`, `name: ''`, `rating: 0`, `photo: null`) so the companion object is always complete regardless of API response
- Fixed `bookingsApi.getMyBookings()` with the same pattern - changed from arrow function to block body to allow the `rawCompanion` variable, applied identical safe defaults
- Both normalization paths now guarantee `companion.name` is always a string (never undefined), preventing crashes at any call site

## Root cause

The previous fix spread `b.companion` directly (`{ ...b.companion, photo: ... }`). When `b.companion` is `undefined`, this produces `{}` - an object with no `name` field. The `|| fallback` check in BookingCard correctly detects this, but `handleCancelBooking` and any other direct `.name` access would crash. The real fix is to ensure the normalized output always has explicit string/number defaults.

## Test plan

- [ ] Bookings screen loads without crash when companion data is missing from API
- [ ] `handleCancelBooking` shows "this companion" fallback when companion name is empty
- [ ] BookingCard shows "Unknown" when companion name is empty string
- [ ] Normal bookings with full companion data still display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)