### PR TITLE
fix: OTP page loses email state on web (BUG-028)

### DIFF
--- a/app/app/(auth)/login.tsx
+++ b/app/app/(auth)/login.tsx
@@ -24,7 +24,7 @@ export default function LoginScreen() {
 
   useEffect(() => {
     if (authStep === 'otp') {
-      router.push('/(auth)/otp');
+      router.push({ pathname: '/(auth)/otp', params: { email: email.trim().toLowerCase() } });
     }
   }, [authStep]);
 

--- a/app/app/(auth)/otp.tsx
+++ b/app/app/(auth)/otp.tsx
@@ -8,7 +8,7 @@ import {
   KeyboardAvoidingView,
   Platform,
 } from 'react-native';
-import { router } from 'expo-router';
+import { router, useLocalSearchParams } from 'expo-router';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useAuthStore } from '../../src/store/authStore';
 import { Button } from '../../src/components/Button';
@@ -21,7 +21,19 @@ const CODE_LENGTH = 6;
 export default function OTPScreen() {
   const insets = useSafeAreaInsets();
   const { colors } = useTheme();
-  const { pendingEmail, verifyCode, resendCode, isLoading, error, clearError, authStep } = useAuthStore();
+  const params = useLocalSearchParams<{ email?: string }>();
+  const { pendingEmail, verifyCode, resendCode, isLoading, error, clearError, authStep, setPendingEmail } = useAuthStore();
+
+  // Use email from route params (reliable on web) or fall back to store value
+  const email = params.email || pendingEmail;
+
+  // Sync route param email back into the store if store lost it
+  useEffect(() => {
+    if (params.email && !pendingEmail && setPendingEmail) {
+      setPendingEmail(params.email);
+    }
+  }, [params.email]);
+
   const [code, setCode] = useState('');
   const [resendCooldown, setResendCooldown] = useState(0);
   const inputRef = useRef<TextInput>(null);
@@ -113,7 +125,7 @@ export default function OTPScreen() {
         <Text style={[styles.title, { color: colors.text }]}>Enter Code</Text>
         <Text style={[styles.subtitle, { color: colors.textSecondary }]}>
           We sent a 6-digit code to{'\n'}
-          <Text style={[styles.email, { color: colors.primary }]}>{pendingEmail}</Text>
+          <Text style={[styles.email, { color: colors.primary }]}>{email}</Text>
         </Text>
 
         <TouchableOpacity

--- a/app/src/store/authStore.ts
+++ b/app/src/store/authStore.ts
@@ -57,6 +57,7 @@ interface AuthState {
   setOnboardingSeen: () => void;
   refreshUser: () => Promise<void>;
   initialize: () => Promise<void>;
+  setPendingEmail: (email: string) => void;
 }
 
 // Convert API user to local User type
@@ -305,6 +306,8 @@ export const useAuthStore = create<AuthState>()(
       clearError: () => set({ error: null }),
 
       setOnboardingSeen: () => set({ hasSeenOnboarding: true }),
+
+      setPendingEmail: (email) => set({ pendingEmail: email }),
     }),
     {
       name: 'auth-storage',


### PR DESCRIPTION
## Summary

- On web, Zustand's `pendingEmail` is lost on navigation because the `persist` middleware's `partialize` intentionally excludes it from storage
- Login page now passes `email` as a route param when navigating to OTP: `router.push({ pathname: '/(auth)/otp', params: { email } })`
- OTP page reads email via `useLocalSearchParams` as the primary source, falls back to store's `pendingEmail`
- Added `setPendingEmail` action to authStore to sync the route param back into the store (ensures `resendCode` and `verifyCode` also work correctly)

## Root cause

`authStore.ts` `partialize` only persists `hasSeenOnboarding`, `user`, `isAuthenticated`, `hasCompletedOnboarding` - `pendingEmail` and `authStep` are excluded. On web navigation, in-memory Zustand state can be lost, making `pendingEmail` null when OTP page mounts.

## Test plan

- [ ] Enter email on login page, tap Continue
- [ ] OTP page should show the email address in subtitle
- [ ] Enter `000000` and tap Verify - should succeed (no "No email address provided" error)
- [ ] Test on web (most affected platform) and native

🤖 Generated with [Claude Code](https://claude.com/claude-code)