### PR TITLE
fix: server-side validation for hourlyRate (BUG-014)

### DIFF
--- a/backend/daterabbit-api/src/users/dto/update-user.dto.ts
+++ b/backend/daterabbit-api/src/users/dto/update-user.dto.ts
@@ -1,0 +1,47 @@
+import {
+  IsArray,
+  IsInt,
+  IsNumber,
+  IsOptional,
+  IsString,
+  Max,
+  MaxLength,
+  Min,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class UpdateUserDto {
+  @IsOptional()
+  @IsString()
+  @MaxLength(100)
+  name?: string;
+
+  @IsOptional()
+  @IsInt()
+  @Min(18)
+  @Max(100)
+  @Type(() => Number)
+  age?: number;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(200)
+  location?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(2000)
+  bio?: string;
+
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  photos?: string[];
+
+  @IsOptional()
+  @IsNumber({ maxDecimalPlaces: 2 })
+  @Min(1, { message: 'hourlyRate must be greater than 0' })
+  @Max(9999, { message: 'hourlyRate must be less than 10000' })
+  @Type(() => Number)
+  hourlyRate?: number;
+}

--- a/backend/daterabbit-api/src/users/users.controller.ts
+++ b/backend/daterabbit-api/src/users/users.controller.ts
@@ -1,6 +1,7 @@
 import { Controller, Get, Put, Body, UseGuards, Request, Param } from '@nestjs/common';
 import { UsersService } from './users.service';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { UpdateUserDto } from './dto/update-user.dto';
 
 @Controller('users')
 export class UsersController {
@@ -20,7 +21,7 @@ export class UsersController {
 
   @UseGuards(JwtAuthGuard)
   @Put('me')
-  async updateProfile(@Request() req, @Body() body: any) {
+  async updateProfile(@Request() req, @Body() body: UpdateUserDto) {
     const { name, age, location, bio, photos, hourlyRate } = body;
     const updated = await this.usersService.update(req.user.id, {
       name,


### PR DESCRIPTION
## Summary

- Added `UpdateUserDto` with `class-validator` decorators for the `PUT /users/me` endpoint
- `hourlyRate` is now validated server-side: must be between 1 and 9999 (inclusive), with at most 2 decimal places
- Sending `{ hourlyRate: -50 }` or `{ hourlyRate: 0 }` now returns HTTP 400 Bad Request instead of persisting the invalid value
- Also adds sensible bounds for `name`, `age`, `location`, `bio`, and `photos` fields
- The global `ValidationPipe` (already configured in `main.ts` with `whitelist: true, transform: true`) handles rejection automatically

## Test plan

- [ ] `PUT /users/me` with `{ hourlyRate: -50 }` returns 400
- [ ] `PUT /users/me` with `{ hourlyRate: 0 }` returns 400
- [ ] `PUT /users/me` with `{ hourlyRate: 50000 }` returns 400
- [ ] `PUT /users/me` with `{ hourlyRate: 100 }` returns 200 and persists correctly
- [ ] `PUT /users/me` without `hourlyRate` field still returns 200 (field is optional)

Fixes BUG-014.

Generated with [Claude Code](https://claude.com/claude-code)