### PR TITLE
fix: correct photos type in UpdateUserDto

### DIFF
--- a/backend/daterabbit-api/src/users/dto/update-user.dto.ts
+++ b/backend/daterabbit-api/src/users/dto/update-user.dto.ts
@@ -1,14 +1,32 @@
 import {
   IsArray,
+  IsBoolean,
   IsInt,
   IsNumber,
   IsOptional,
   IsString,
+  IsUUID,
   Max,
   MaxLength,
   Min,
+  ValidateNested,
 } from 'class-validator';
 import { Type } from 'class-transformer';
+
+export class PhotoDto {
+  @IsUUID()
+  id: string;
+
+  @IsString()
+  url: string;
+
+  @IsInt()
+  @Min(0)
+  order: number;
+
+  @IsBoolean()
+  isPrimary: boolean;
+}
 
 export class UpdateUserDto {
   @IsOptional()
@@ -35,8 +53,9 @@ export class UpdateUserDto {
 
   @IsOptional()
   @IsArray()
-  @IsString({ each: true })
-  photos?: string[];
+  @ValidateNested({ each: true })
+  @Type(() => PhotoDto)
+  photos?: PhotoDto[];
 
   @IsOptional()
   @IsNumber({ maxDecimalPlaces: 2 })


### PR DESCRIPTION
## Summary

- Fixes TypeScript compile error introduced in #34 (BUG-014 fix)
- `photos` field in `UpdateUserDto` was typed as `string[]` but the `User` entity expects `{ id, url, order, isPrimary }[]`
- Added `PhotoDto` nested class with proper validation and updated `photos` field to use it

## Test plan

- [ ] Backend builds without TypeScript errors
- [ ] `PUT /users/me` with `{ hourlyRate: -50 }` still returns 400
- [ ] `PUT /users/me` with `{ hourlyRate: 100 }` returns 200

Generated with [Claude Code](https://claude.com/claude-code)