### PR TITLE
fix: BUG-010 protected routes redirect without feedback

### DIFF
--- a/app/app/(tabs)/_layout.tsx
+++ b/app/app/(tabs)/_layout.tsx
@@ -32,7 +32,7 @@ export default function TabsLayout() {
   }
 
   if (!isAuthenticated || !user) {
-    return <Redirect href="/(auth)/welcome" />;
+    return <Redirect href="/(auth)/welcome?redirect=1" />;
   }
 
   const isCompanion = user.role === 'companion';


### PR DESCRIPTION
## Summary
- In `app/app/(tabs)/_layout.tsx`: changed the unauthenticated redirect from `/(auth)/welcome` to `/(auth)/welcome?redirect=1`
- The welcome screen (`app/app/(auth)/welcome.tsx`) already had the banner logic: it reads the `redirect` query param and shows "Please sign in to access that page" when `redirect === '1'`
- This closes the gap where the protection gate in `(tabs)/_layout.tsx` was redirecting without the query param, so the banner was never shown

## Test plan
- [ ] Open the app while logged out
- [ ] Navigate directly to a protected tab route (e.g. `/male/bookings`)
- [ ] Verify you are redirected to the welcome screen
- [ ] Verify the banner "Please sign in to access that page" is visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)