### PR TITLE
fix: handle undefined companion name in chat screen (BUG-029)

### DIFF
--- a/app/app/chat/[id].tsx
+++ b/app/app/chat/[id].tsx
@@ -34,6 +34,9 @@ export default function ChatScreen() {
   const chatMessages = getMessages(otherUserId);
   const chat = chats.find(c => c.otherUser.id === otherUserId);
 
+  // Resolve companion name: prefer URL param, fall back to chat data, then a safe default
+  const companionName = name || chat?.otherUser?.name || 'this person';
+
   useEffect(() => {
     // Fetch messages — backend auto-marks as read on GET
     fetchMessages(otherUserId);
@@ -99,6 +102,26 @@ export default function ChatScreen() {
     return groups;
   }, {} as Record<string, typeof chatMessages>);
 
+  // Show error state when no valid conversation ID is provided
+  if (!otherUserId) {
+    return (
+      <View style={[styles.container, { backgroundColor: colors.background }]}>
+        <View style={[styles.header, { paddingTop: insets.top + spacing.sm, backgroundColor: colors.white, borderBottomColor: colors.border }]}>
+          <TouchableOpacity onPress={() => router.back()} style={styles.backButton} testID="chat-back-btn">
+            <Icon name="arrow-left" size={24} color={colors.text} />
+          </TouchableOpacity>
+        </View>
+        <View style={styles.emptyContainer}>
+          <EmptyState
+            icon="alert-circle"
+            title="Conversation not found"
+            description="This conversation does not exist or may have been removed."
+          />
+        </View>
+      </View>
+    );
+  }
+
   return (
     <KeyboardAvoidingView
       style={[styles.container, { backgroundColor: colors.background }]}
@@ -115,9 +138,9 @@ export default function ChatScreen() {
           style={styles.headerProfile}
           onPress={() => router.push({ pathname: '/profile/[id]', params: { id: id || '' } })}
         >
-          <UserImage name={name || 'User'} size={40} />
+          <UserImage name={companionName} size={40} />
           <View style={styles.headerInfo}>
-            <Text style={[styles.headerName, { color: colors.text }]}>{name || 'User'}</Text>
+            <Text style={[styles.headerName, { color: colors.text }]}>{companionName}</Text>
             <Text style={[styles.headerStatus, { color: colors.textSecondary }]}>Tap to view profile</Text>
           </View>
         </TouchableOpacity>
@@ -143,7 +166,7 @@ export default function ChatScreen() {
             <EmptyState
               icon="message-circle"
               title="Start the conversation"
-              description={`Say hello to ${name}! Be respectful and have a great conversation.`}
+              description={`Say hello to ${companionName}! Be respectful and have a great conversation.`}
             />
           </View>
         ) : (
@@ -171,7 +194,7 @@ export default function ChatScreen() {
                     ]}
                   >
                     {!isMine && showAvatar && (
-                      <UserImage name={name || 'User'} size={32} />
+                      <UserImage name={companionName} size={32} />
                     )}
                     {!isMine && !showAvatar && (
                       <View style={{ width: 32 }} />


### PR DESCRIPTION
## Summary

- Add `companionName` variable resolved with a three-level fallback: URL param `name` -> chat store `otherUser.name` -> safe default `'this person'`
- Show a proper "Conversation not found" error state (with back button) when `id` param is missing/empty
- Replace all raw `name` references in the render tree with the safe `companionName`

## Test plan

- [ ] Navigate to `/chat/[id]` with a valid ID but no `name` param — header and empty-state should show the name from the chat store, or "this person" if not found
- [ ] Navigate to `/chat/` with no `id` — should display "Conversation not found" error state with a back button, not crash
- [ ] Normal chat flow (valid ID + name param) still works as before

Fixes BUG-029 (LOW): Chat shows 'undefined' for non-existent companion