### PR TITLE
fix: allow unauthenticated access to /terms and /privacy routes

### DIFF
--- a/app/app/_layout.tsx
+++ b/app/app/_layout.tsx
@@ -55,15 +55,31 @@ export default function RootLayout() {
         {!hasSeenOnboarding ? (
           <Stack.Screen name="onboarding" />
         ) : !isAuthenticated ? (
-          <Stack.Screen name="(auth)" />
+          <>
+            <Stack.Screen name="(auth)" />
+            <Stack.Screen name="terms" />
+            <Stack.Screen name="privacy" />
+          </>
         ) : needsVerification ? (
           isSeeker ? (
-            <Stack.Screen name="(seeker-verify)" />
+            <>
+              <Stack.Screen name="(seeker-verify)" />
+              <Stack.Screen name="terms" />
+              <Stack.Screen name="privacy" />
+            </>
           ) : (
-            <Stack.Screen name="(comp-onboard)" />
+            <>
+              <Stack.Screen name="(comp-onboard)" />
+              <Stack.Screen name="terms" />
+              <Stack.Screen name="privacy" />
+            </>
           )
         ) : (
-          <Stack.Screen name="(tabs)" />
+          <>
+            <Stack.Screen name="(tabs)" />
+            <Stack.Screen name="terms" />
+            <Stack.Screen name="privacy" />
+          </>
         )}
         <Stack.Screen name="index" />
         <Stack.Screen name="(seeker-verify)" />
@@ -80,8 +96,6 @@ export default function RootLayout() {
         <Stack.Screen name="settings/notifications" />
         <Stack.Screen name="settings/verification" />
         <Stack.Screen name="settings/delete-account" />
-        <Stack.Screen name="terms" />
-        <Stack.Screen name="privacy" />
       </Stack>
     </StripeProvider>
   );


### PR DESCRIPTION
## Summary

- BUG-024: Terms and Privacy pages were redirecting unauthenticated users to the login screen
- Root cause: Expo Router's conditional `Stack.Screen` rendering acts as a navigation guard — only screens explicitly rendered in the active conditional branch are accessible. `/terms` and `/privacy` were declared outside the conditional block, so they were blocked when the auth-guard conditions were active
- Fix: Added `<Stack.Screen name="terms" />` and `<Stack.Screen name="privacy" />` to every branch of the conditional guard in `app/app/_layout.tsx`, wrapping them in React Fragments alongside the existing screens

## Changes

- `app/app/_layout.tsx`: Added terms and privacy screens to all four conditional branches (unauthenticated, seeker-verify, comp-onboard, authenticated/tabs) using React Fragments

## Test plan

- [ ] Open app without logging in — navigate to `/terms` via the footer links on the Welcome screen
- [ ] Verify Terms of Service page loads without redirecting to login
- [ ] Navigate to `/privacy` via the footer links on the Welcome screen
- [ ] Verify Privacy Policy page loads without redirecting to login
- [ ] Verify authenticated users can still access both pages normally
- [ ] Verify back navigation returns to the welcome/previous screen correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)