### PR TITLE
fix: replace Alert.alert no-ops on web with cross-platform helpers (BUG-025)

### DIFF
--- a/app/src/components/PhotoUpload.tsx
+++ b/app/src/components/PhotoUpload.tsx
@@ -6,9 +6,11 @@ import {
   TouchableOpacity,
   ScrollView,
   ActivityIndicator,
+  Platform,
   Alert,
 } from 'react-native';
 import { colors, spacing, typography, borderRadius, borderWidth } from '../constants/theme';
+import { showConfirm } from '../utils/alert';
 
 interface PhotoUploadProps {
   photos: string[];
@@ -28,25 +30,29 @@ export function PhotoUpload({
   onRemove,
 }: PhotoUploadProps) {
   const showAddOptions = () => {
-    Alert.alert(
-      'Add Photo',
-      'Choose an option',
-      [
-        { text: 'Take Photo', onPress: onTakePhoto },
-        { text: 'Choose from Library', onPress: onPickFromLibrary },
-        { text: 'Cancel', style: 'cancel' },
-      ]
-    );
+    if (Platform.OS === 'web') {
+      // Camera not available on web — go straight to library
+      onPickFromLibrary();
+    } else {
+      Alert.alert(
+        'Add Photo',
+        'Choose an option',
+        [
+          { text: 'Take Photo', onPress: onTakePhoto },
+          { text: 'Choose from Library', onPress: onPickFromLibrary },
+          { text: 'Cancel', style: 'cancel' },
+        ]
+      );
+    }
   };
 
   const handleRemove = (uri: string) => {
-    Alert.alert(
+    showConfirm(
       'Remove Photo',
       'Are you sure you want to remove this photo?',
-      [
-        { text: 'Cancel', style: 'cancel' },
-        { text: 'Remove', style: 'destructive', onPress: () => onRemove(uri) },
-      ]
+      () => onRemove(uri),
+      'Remove',
+      'Cancel'
     );
   };
 

--- a/app/src/components/verification/IDUpload.tsx
+++ b/app/src/components/verification/IDUpload.tsx
@@ -5,12 +5,12 @@ import {
   StyleSheet,
   TouchableOpacity,
   Image,
-  Alert,
   Platform,
 } from 'react-native';
 import * as ImagePicker from 'expo-image-picker';
 import { Icon } from '../Icon';
 import { colors, spacing, borderRadius, typography, touchTargets, shadows } from '../../constants/theme';
+import { showAlert } from '../../utils/alert';
 
 interface IDUploadProps {
   imageUri?: string;
@@ -24,20 +24,18 @@ export function IDUpload({ imageUri, onImageSelected, error }: IDUploadProps) {
       if (type === 'camera') {
         const { status } = await ImagePicker.requestCameraPermissionsAsync();
         if (status !== 'granted') {
-          Alert.alert(
+          showAlert(
             'Camera Permission Required',
-            'Please allow camera access in settings to take a photo of your ID.',
-            [{ text: 'OK' }]
+            'Please allow camera access in settings to take a photo of your ID.'
           );
           return false;
         }
       } else {
         const { status } = await ImagePicker.requestMediaLibraryPermissionsAsync();
         if (status !== 'granted') {
-          Alert.alert(
+          showAlert(
             'Gallery Permission Required',
-            'Please allow photo library access to select your ID.',
-            [{ text: 'OK' }]
+            'Please allow photo library access to select your ID.'
           );
           return false;
         }

--- a/app/src/components/verification/SelfieCapture.tsx
+++ b/app/src/components/verification/SelfieCapture.tsx
@@ -5,12 +5,12 @@ import {
   StyleSheet,
   TouchableOpacity,
   Image,
-  Alert,
   Platform,
 } from 'react-native';
 import * as ImagePicker from 'expo-image-picker';
 import { Icon } from '../Icon';
 import { colors, spacing, borderRadius, typography, touchTargets, shadows } from '../../constants/theme';
+import { showAlert } from '../../utils/alert';
 
 interface SelfieCaptureProps {
   imageUri?: string;
@@ -23,10 +23,9 @@ export function SelfieCapture({ imageUri, onImageCaptured, error }: SelfieCaptur
     if (Platform.OS !== 'web') {
       const { status } = await ImagePicker.requestCameraPermissionsAsync();
       if (status !== 'granted') {
-        Alert.alert(
+        showAlert(
           'Camera Permission Required',
-          'Please allow camera access in settings to take a selfie.',
-          [{ text: 'OK' }]
+          'Please allow camera access in settings to take a selfie.'
         );
         return;
       }

--- a/app/src/components/verification/VideoRecorder.tsx
+++ b/app/src/components/verification/VideoRecorder.tsx
@@ -4,12 +4,12 @@ import {
   Text,
   StyleSheet,
   TouchableOpacity,
-  Alert,
   Platform,
 } from 'react-native';
 import * as ImagePicker from 'expo-image-picker';
 import { Icon } from '../Icon';
 import { colors, spacing, borderRadius, typography, touchTargets, shadows } from '../../constants/theme';
+import { showAlert } from '../../utils/alert';
 
 interface VideoRecorderProps {
   videoUri?: string;
@@ -48,10 +48,9 @@ export function VideoRecorder({
     if (Platform.OS !== 'web') {
       const { status } = await ImagePicker.requestCameraPermissionsAsync();
       if (status !== 'granted') {
-        Alert.alert(
+        showAlert(
           'Camera Permission Required',
-          'Please allow camera access in settings to record a video.',
-          [{ text: 'OK' }]
+          'Please allow camera access in settings to record a video.'
         );
         return;
       }

--- a/app/src/hooks/useImagePicker.ts
+++ b/app/src/hooks/useImagePicker.ts
@@ -1,6 +1,7 @@
 import { useState, useCallback } from 'react';
 import * as ImagePicker from 'expo-image-picker';
-import { Alert, Platform } from 'react-native';
+import { Platform } from 'react-native';
+import { showAlert } from '../utils/alert';
 
 interface UseImagePickerOptions {
   allowsMultipleSelection?: boolean;
@@ -36,20 +37,18 @@ export function useImagePicker(options: UseImagePickerOptions = {}): UseImagePic
     if (type === 'library') {
       const { status } = await ImagePicker.requestMediaLibraryPermissionsAsync();
       if (status !== 'granted') {
-        Alert.alert(
+        showAlert(
           'Permission Required',
-          'Please allow access to your photo library to upload photos.',
-          [{ text: 'OK' }]
+          'Please allow access to your photo library to upload photos.'
         );
         return false;
       }
     } else {
       const { status } = await ImagePicker.requestCameraPermissionsAsync();
       if (status !== 'granted') {
-        Alert.alert(
+        showAlert(
           'Permission Required',
-          'Please allow camera access to take photos.',
-          [{ text: 'OK' }]
+          'Please allow camera access to take photos.'
         );
         return false;
       }
@@ -78,7 +77,7 @@ export function useImagePicker(options: UseImagePickerOptions = {}): UseImagePic
         const imagesToAdd = newImages.slice(0, availableSlots);
 
         if (newImages.length > availableSlots) {
-          Alert.alert(
+          showAlert(
             'Limit Reached',
             `You can only add ${maxImages} photos. Some photos were not added.`
           );
@@ -89,7 +88,7 @@ export function useImagePicker(options: UseImagePickerOptions = {}): UseImagePic
       }
     } catch (error) {
       console.error('Error picking images:', error);
-      Alert.alert('Error', 'Failed to pick images. Please try again.');
+      showAlert('Error', 'Failed to pick images. Please try again.');
     } finally {
       setLoading(false);
     }
@@ -98,7 +97,7 @@ export function useImagePicker(options: UseImagePickerOptions = {}): UseImagePic
 
   const takePhoto = useCallback(async (): Promise<string | null> => {
     if (images.length >= maxImages) {
-      Alert.alert('Limit Reached', `You can only add ${maxImages} photos.`);
+      showAlert('Limit Reached', `You can only add ${maxImages} photos.`);
       return null;
     }
 
@@ -120,7 +119,7 @@ export function useImagePicker(options: UseImagePickerOptions = {}): UseImagePic
       }
     } catch (error) {
       console.error('Error taking photo:', error);
-      Alert.alert('Error', 'Failed to take photo. Please try again.');
+      showAlert('Error', 'Failed to take photo. Please try again.');
     } finally {
       setLoading(false);
     }


### PR DESCRIPTION
## Summary

- Replace 12 `Alert.alert()` calls across 5 files with cross-platform `showAlert()`/`showConfirm()` helpers from `utils/alert.ts`
- `Alert.alert` is a no-op on web, so these alerts were silently doing nothing for web users
- `PhotoUpload.showAddOptions` now uses `Platform.OS === 'web'` guard — on web it calls `onPickFromLibrary()` directly (camera unavailable on web); on native it keeps the existing 3-button action sheet
- `PhotoUpload.handleRemove` converted to `showConfirm()` pattern
- All permission denied alerts and error alerts converted to `showAlert()`

## Files changed

- `app/src/components/verification/SelfieCapture.tsx` — 1 call
- `app/src/components/verification/VideoRecorder.tsx` — 1 call
- `app/src/components/verification/IDUpload.tsx` — 2 calls
- `app/src/components/PhotoUpload.tsx` — 2 calls (1 showConfirm, 1 web-guard)
- `app/src/hooks/useImagePicker.ts` — 6 calls

## Test plan

- [ ] On native: permission denied alerts still show as native dialogs
- [ ] On web: permission denied alerts show as `window.alert()`
- [ ] On web: remove photo confirmation shows `window.confirm()`
- [ ] On web: "Add Photo" button calls library picker directly (no crash)
- [ ] On native: "Add Photo" still shows 3-button action sheet

🤖 Generated with [Claude Code](https://claude.com/claude-code)