### PR TITLE
fix: sync verificationStatus on user when verification is approved

### DIFF
--- a/backend/daterabbit-api/src/verification/verification.service.ts
+++ b/backend/daterabbit-api/src/verification/verification.service.ts
@@ -17,7 +17,7 @@ import { UploadsService } from '../uploads/uploads.service';
 import { SubmitSsnDto } from './dto/submit-ssn.dto';
 import { SubmitReferencesDto } from './dto/submit-references.dto';
 import { SubmitConsentDto } from './dto/submit-consent.dto';
-import { UserRole } from '../users/entities/user.entity';
+import { UserRole, UserVerificationStatus } from '../users/entities/user.entity';
 
 @Injectable()
 export class VerificationService {
@@ -218,7 +218,10 @@ export class VerificationService {
 
     verification.status = VerificationStatus.APPROVED;
     await this.verificationRepository.save(verification);
-    await this.usersService.update(userId, { isVerified: true });
+    await this.usersService.update(userId, {
+      isVerified: true,
+      verificationStatus: UserVerificationStatus.APPROVED,
+    });
   }
 
   private async getOrFail(userId: string): Promise<Verification> {


### PR DESCRIPTION
## Summary

- Fixed backend bug where `approveVerification()` updated `isVerified: true` on the User but did NOT update `verificationStatus` column
- Added `UserVerificationStatus` import to `verification.service.ts`
- Included `verificationStatus: UserVerificationStatus.APPROVED` in the `usersService.update()` call

## Root Cause

`_layout.tsx` in the React Native app checks `user?.verificationStatus !== 'approved'` to gate access to the main app tabs. Since the backend was not updating this column, verified users were permanently redirected to the verification flow.

## Test plan

- [ ] Create new test account, complete seeker verification flow in DEV mode
- [ ] Verify that after auto-approval (3s delay), `GET /api/users/me` returns `verificationStatus: 'approved'`
- [ ] Verify the app no longer redirects to seeker-verify after verification completes