### PR TITLE
fix: pass companion user ID to chat instead of booking ID (BUG-032)

### DIFF
--- a/app/app/(tabs)/male/bookings.tsx
+++ b/app/app/(tabs)/male/bookings.tsx
@@ -215,7 +215,10 @@ function BookingCard({ booking, type, colors, onCancel, formatDate }: BookingCar
           )}
           <Button
             title="Message"
-            onPress={() => router.push(`/chat/${booking.id}`)}
+            onPress={() => router.push({
+              pathname: `/chat/${booking.companion?.id || booking.companion_id}`,
+              params: { name: booking.companion?.name }
+            })}
             variant="outline"
             size="sm"
             style={{ flex: 1 }}


### PR DESCRIPTION
## Summary

- In `bookings.tsx`, the Message button was passing `booking.id` (booking UUID) to the chat route
- The chat screen (`app/app/chat/[id].tsx`) uses the `id` param as `otherUserId` to fetch and send messages via the API
- Passing a booking UUID caused the API to fetch messages for a non-existent user
- Fix: pass `booking.companion?.id || booking.companion_id` as the chat route ID, and pass `booking.companion?.name` as the `name` param so the chat header displays the correct companion name

## Test plan

- [ ] Open the Bookings tab as a seeker with an upcoming/confirmed booking
- [ ] Tap the "Message" button on a booking
- [ ] Verify the chat screen opens with the companion's name in the header
- [ ] Verify messages load correctly (not empty due to wrong user ID)
- [ ] Verify sending a message works correctly

Fixes BUG-032