### PR TITLE
fix: show actual last message preview in conversations list (BUG-034)

### DIFF
--- a/app/app/(tabs)/male/messages.tsx
+++ b/app/app/(tabs)/male/messages.tsx
@@ -91,7 +91,7 @@ export default function MessagesScreen() {
                     ]}
                     numberOfLines={1}
                   >
-                    {'No messages yet'}
+                    {chat.lastMessage || 'No messages yet'}
                   </Text>
                   {(chat.unreadCount || 0) > 0 && (
                     <View style={[styles.unreadBadge, { backgroundColor: colors.primary }]}>

--- a/app/src/services/api.ts
+++ b/app/src/services/api.ts
@@ -376,6 +376,7 @@ export interface Chat {
     name: string;
     photos?: any[];
   };
+  lastMessage?: string | null;
   lastMessageAt?: string;
   unreadCount?: number;
 }

--- a/app/src/store/messagesStore.ts
+++ b/app/src/store/messagesStore.ts
@@ -75,6 +75,7 @@ export const useMessagesStore = create<MessagesState>((set, get) => ({
           chat.otherUser.id === otherUserId
             ? {
                 ...chat,
+                lastMessage: content,
                 lastMessageAt: newMessage.createdAt,
               }
             : chat

--- a/app/src/types/index.ts
+++ b/app/src/types/index.ts
@@ -113,6 +113,7 @@ export interface Chat {
     name: string;
     photos?: any[];
   };
+  lastMessage?: string | null;
   lastMessageAt?: string;
   unreadCount?: number;
 }

--- a/backend/daterabbit-api/src/messages/entities/message.entity.ts
+++ b/backend/daterabbit-api/src/messages/entities/message.entity.ts
@@ -59,6 +59,10 @@ export class Conversation {
   @Column({ nullable: true })
   lastMessageId: string;
 
+  @ManyToOne(() => Message, { nullable: true, eager: false })
+  @JoinColumn({ name: 'lastMessageId' })
+  lastMessage: Message;
+
   @Column({ nullable: true })
   lastMessageAt: Date;
 

--- a/backend/daterabbit-api/src/messages/messages.controller.ts
+++ b/backend/daterabbit-api/src/messages/messages.controller.ts
@@ -22,6 +22,7 @@ export class MessagesController {
         photos: c.user1.photos,
       },
       lastMessageAt: c.lastMessageAt,
+      lastMessage: c.lastMessage?.content || null,
     }));
   }
 

--- a/backend/daterabbit-api/src/messages/messages.service.ts
+++ b/backend/daterabbit-api/src/messages/messages.service.ts
@@ -59,7 +59,7 @@ export class MessagesService {
         { user1Id: userId },
         { user2Id: userId },
       ],
-      relations: ['user1', 'user2'],
+      relations: ['user1', 'user2', 'lastMessage'],
       order: { lastMessageAt: 'DESC' },
     });
   }


### PR DESCRIPTION
## Summary

- BUG-034: The messages screen was hardcoding 'No messages yet' for all conversation items, ignoring the actual last message content
- Added `lastMessage` relation to `Conversation` entity pointing to the last `Message`
- Backend now returns `lastMessage` (message content string) in the `/messages/conversations` API response
- Frontend `Chat` type updated to include `lastMessage?: string | null`
- `messagesStore` optimistically updates `lastMessage` when a new message is sent
- `messages.tsx` now renders `chat.lastMessage || 'No messages yet'` instead of hardcoded text

## Test plan

- [ ] Log in as a user who has conversations with messages
- [ ] Open the Messages tab — each conversation should show the last message text as a preview
- [ ] Conversations with no messages should still show 'No messages yet'
- [ ] Send a new message in a chat — when navigating back to the list, the preview should update immediately

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>