### PR TITLE
fix: resolve critical navigation bugs on web (BUG-031, BUG-033)

### DIFF
--- a/app/app/(tabs)/_layout.tsx
+++ b/app/app/(tabs)/_layout.tsx
@@ -1,5 +1,5 @@
 import { Tabs, Redirect } from 'expo-router';
-import { View, ActivityIndicator, StyleSheet, Platform } from 'react-native';
+import { View, ActivityIndicator, StyleSheet } from 'react-native';
 import { useAuthStore } from '../../src/store/authStore';
 import { colors } from '../../src/constants/theme';
 import { useEffect, useState } from 'react';
@@ -44,33 +44,48 @@ export default function TabsLayout() {
       }}
       tabBar={(props) => <CustomTabBar role={isCompanion ? 'companion' : 'seeker'} />}
     >
-      {isCompanion ? (
-        <>
-          <Tabs.Screen name="female/index" />
-          <Tabs.Screen name="female/requests" />
-          <Tabs.Screen name="female/calendar" />
-          <Tabs.Screen name="female/earnings" />
-          <Tabs.Screen name="female/profile" />
-          <Tabs.Screen name="male/index" options={{ href: null }} />
-          <Tabs.Screen name="male/browse" options={{ href: null }} />
-          <Tabs.Screen name="male/bookings" options={{ href: null }} />
-          <Tabs.Screen name="male/messages" options={{ href: null }} />
-          <Tabs.Screen name="male/profile" options={{ href: null }} />
-        </>
-      ) : (
-        <>
-          <Tabs.Screen name="male/index" />
-          <Tabs.Screen name="male/browse" />
-          <Tabs.Screen name="male/bookings" />
-          <Tabs.Screen name="male/messages" />
-          <Tabs.Screen name="male/profile" />
-          <Tabs.Screen name="female/index" options={{ href: null }} />
-          <Tabs.Screen name="female/requests" options={{ href: null }} />
-          <Tabs.Screen name="female/calendar" options={{ href: null }} />
-          <Tabs.Screen name="female/earnings" options={{ href: null }} />
-          <Tabs.Screen name="female/profile" options={{ href: null }} />
-        </>
-      )}
+      {/* Female / companion screens — hidden for seekers */}
+      <Tabs.Screen
+        name="female/index"
+        options={isCompanion ? undefined : { href: null }}
+      />
+      <Tabs.Screen
+        name="female/requests"
+        options={isCompanion ? undefined : { href: null }}
+      />
+      <Tabs.Screen
+        name="female/calendar"
+        options={isCompanion ? undefined : { href: null }}
+      />
+      <Tabs.Screen
+        name="female/earnings"
+        options={isCompanion ? undefined : { href: null }}
+      />
+      <Tabs.Screen
+        name="female/profile"
+        options={isCompanion ? undefined : { href: null }}
+      />
+      {/* Male / seeker screens — hidden for companions */}
+      <Tabs.Screen
+        name="male/index"
+        options={isCompanion ? { href: null } : undefined}
+      />
+      <Tabs.Screen
+        name="male/browse"
+        options={isCompanion ? { href: null } : undefined}
+      />
+      <Tabs.Screen
+        name="male/bookings"
+        options={isCompanion ? { href: null } : undefined}
+      />
+      <Tabs.Screen
+        name="male/messages"
+        options={isCompanion ? { href: null } : undefined}
+      />
+      <Tabs.Screen
+        name="male/profile"
+        options={isCompanion ? { href: null } : undefined}
+      />
     </Tabs>
   );
 }

--- a/app/app/(tabs)/female/requests.tsx
+++ b/app/app/(tabs)/female/requests.tsx
@@ -195,10 +195,7 @@ function RequestCard({ request, type, colors, onAccept, onDecline, formatDate }:
         <View style={styles.actions}>
           <Button
             title="Message"
-            onPress={() => router.push({
-              pathname: '/chat/[id]',
-              params: { id: request.seeker.id, name: request.seeker.name },
-            })}
+            onPress={() => router.push(`/chat/${request.seeker.id}`)}
             variant="outline"
             size="sm"
             style={{ flex: 1 }}

--- a/app/app/(tabs)/male/browse.tsx
+++ b/app/app/(tabs)/male/browse.tsx
@@ -278,7 +278,7 @@ export default function BrowseScreen() {
               <View style={styles.actions}>
                 <Button
                   title="View Profile"
-                  onPress={() => router.push({ pathname: '/profile/[id]', params: { id: companion.id } })}
+                  onPress={() => router.push(`/profile/${companion.id}`)}
                   variant="outline"
                   size="md"
                   style={styles.actionButton}
@@ -286,7 +286,7 @@ export default function BrowseScreen() {
                 />
                 <Button
                   title="Book Date"
-                  onPress={() => router.push({ pathname: '/booking/[id]', params: { id: companion.id } })}
+                  onPress={() => router.push(`/booking/${companion.id}`)}
                   size="md"
                   style={styles.actionButton}
                   testID={`browse-book-date-${companion.id}`}

--- a/app/app/(tabs)/male/messages.tsx
+++ b/app/app/(tabs)/male/messages.tsx
@@ -32,10 +32,7 @@ export default function MessagesScreen() {
   };
 
   const handleOpenChat = (chat: Chat) => {
-    router.push({
-      pathname: '/chat/[id]',
-      params: { id: chat.otherUser.id, name: chat.otherUser.name },
-    });
+    router.push(`/chat/${chat.otherUser.id}`);
   };
 
   if (isLoading && chats.length === 0) {

--- a/app/app/_layout.tsx
+++ b/app/app/_layout.tsx
@@ -52,20 +52,10 @@ export default function RootLayout() {
           }
         }}
       >
-        {!hasSeenOnboarding ? (
-          <Stack.Screen name="onboarding" />
-        ) : !isAuthenticated ? (
-          <Stack.Screen name="(auth)" />
-        ) : needsVerification ? (
-          isSeeker ? (
-            <Stack.Screen name="(seeker-verify)" />
-          ) : (
-            <Stack.Screen name="(comp-onboard)" />
-          )
-        ) : (
-          <Stack.Screen name="(tabs)" />
-        )}
         <Stack.Screen name="index" />
+        <Stack.Screen name="onboarding" />
+        <Stack.Screen name="(auth)" />
+        <Stack.Screen name="(tabs)" />
         <Stack.Screen name="(seeker-verify)" />
         <Stack.Screen name="(comp-onboard)" />
         <Stack.Screen name="booking/[id]" />

--- a/app/app/chat/[id].tsx
+++ b/app/app/chat/[id].tsx
@@ -113,7 +113,7 @@ export default function ChatScreen() {
 
         <TouchableOpacity
           style={styles.headerProfile}
-          onPress={() => router.push({ pathname: '/profile/[id]', params: { id: id || '' } })}
+          onPress={() => router.push(`/profile/${id || ''}`)}
         >
           <UserImage name={name || 'User'} size={40} />
           <View style={styles.headerInfo}>
@@ -124,7 +124,7 @@ export default function ChatScreen() {
 
         <TouchableOpacity
           style={[styles.bookButton, { backgroundColor: colors.primary }]}
-          onPress={() => router.push({ pathname: '/booking/[id]', params: { id: id || '' } })}
+          onPress={() => router.push(`/booking/${id || ''}`)}
           testID="chat-book-btn"
         >
           <Text style={[styles.bookButtonText, { color: colors.white }]}>Book</Text>

--- a/app/app/favorites/index.tsx
+++ b/app/app/favorites/index.tsx
@@ -128,14 +128,14 @@ export default function FavoritesScreen() {
                 <View style={styles.actions}>
                   <Button
                     title="View Profile"
-                    onPress={() => router.push({ pathname: '/profile/[id]', params: { id: companion.id } })}
+                    onPress={() => router.push(`/profile/${companion.id}`)}
                     variant="outline"
                     size="sm"
                     style={{ flex: 1 }}
                   />
                   <Button
                     title="Book Date"
-                    onPress={() => router.push({ pathname: '/booking/[id]', params: { id: companion.id } })}
+                    onPress={() => router.push(`/booking/${companion.id}`)}
                     size="sm"
                     style={{ flex: 1 }}
                   />

--- a/app/app/profile/[id].tsx
+++ b/app/app/profile/[id].tsx
@@ -190,17 +190,11 @@ export default function ProfileViewScreen() {
   };
 
   const handleBookDate = () => {
-    router.push({
-      pathname: '/booking/[id]',
-      params: { id: profile.id },
-    });
+    router.push(`/booking/${profile.id}`);
   };
 
   const handleMessage = () => {
-    router.push({
-      pathname: '/chat/[id]',
-      params: { id: profile.id, name: profile.name },
-    });
+    router.push(`/chat/${profile.id}`);
   };
 
   const nextPhoto = () => {
@@ -390,7 +384,7 @@ export default function ProfileViewScreen() {
           <Card style={styles.section}>
             <View style={styles.sectionHeader}>
               <Text style={[styles.sectionTitle, { color: colors.text }]}>Reviews</Text>
-              <TouchableOpacity onPress={() => router.push({ pathname: '/reviews/[id]', params: { id: profile.id } })}>
+              <TouchableOpacity onPress={() => router.push(`/reviews/${profile.id}`)}>
                 <Text style={[styles.seeAll, { color: colors.primary }]}>See All</Text>
               </TouchableOpacity>
             </View>


### PR DESCRIPTION
## Summary

- **BUG-031 (CRITICAL):** Chat screen (and other non-tab routes like `/profile/[id]`, `/booking/[id]`) were unreachable on web — `router.push()` from tab screens redirected to `/male` home instead.
- **BUG-033 (MEDIUM):** Browse "View Profile" navigated to seeker's own profile instead of the companion's profile.

## Root Causes & Fixes

### Fix 1: Static Tabs.Screen declarations (`(tabs)/_layout.tsx`)

The conditional rendering of `<Tabs.Screen>` inside ternary/fragment blocks caused the Expo Router warning `"Layout children must be of type Screen"`. On web this breaks `router.push()` to routes registered in the root Stack but outside the tab group.

**Before:** Two `<>...</>` fragments inside a ternary, each containing a different set of 10 `Tabs.Screen` components.

**After:** All 10 `Tabs.Screen` components declared statically. Visibility controlled via `options={isCompanion ? { href: null } : undefined}` — same end result, no conditional rendering of Screen components.

### Fix 2: Static Stack.Screen declarations (`app/_layout.tsx`)

The root layout had a conditional block that rendered only one `Stack.Screen` based on auth state (onboarding / auth / tabs). This prevented Expo Router from knowing all available routes on web.

**After:** All route groups (`onboarding`, `(auth)`, `(tabs)`, `(seeker-verify)`, `(comp-onboard)`) declared statically. Auth flow handled by `Redirect` components in each layout (already in place).

### Fix 3: String path syntax for cross-layout navigation

Expo Router on web mishandles object syntax `{ pathname: '/profile/[id]', params: { id } }` when navigating from a tab screen to a route in the root Stack. Replaced with string template syntax `/profile/${id}` in all affected files.

**Files updated:**
- `app/app/(tabs)/male/browse.tsx` — View Profile, Book Date buttons
- `app/app/(tabs)/male/messages.tsx` — open chat handler
- `app/app/(tabs)/female/requests.tsx` — Message button
- `app/app/chat/[id].tsx` — profile header tap, Book button
- `app/app/profile/[id].tsx` — handleBookDate, handleMessage, See All reviews
- `app/app/favorites/index.tsx` — View Profile, Book Date buttons

## Test plan

- [ ] Log in as seeker on web, go to Browse tab, tap "View Profile" — should open companion profile (not own profile)
- [ ] From Browse, tap "Book Date" — should open booking screen
- [ ] Go to Bookings tab, tap "Message" on an upcoming booking — should open chat screen
- [ ] From Messages tab, tap a conversation — should open chat screen
- [ ] From any chat, tap companion header — should open companion profile
- [ ] Log in as companion, verify female tabs are shown and male tabs are hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)