### PR TITLE
fix: persist favorites across app reloads

### DIFF
--- a/app/src/store/favoritesStore.ts
+++ b/app/src/store/favoritesStore.ts
@@ -1,4 +1,6 @@
 import { create } from 'zustand';
+import { persist, createJSONStorage } from 'zustand/middleware';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 
 interface FavoritesState {
   favorites: string[];
@@ -7,23 +9,34 @@ interface FavoritesState {
   clearFavorites: () => void;
 }
 
-export const useFavoritesStore = create<FavoritesState>((set, get) => ({
-  favorites: [],
+export const useFavoritesStore = create<FavoritesState>()(
+  persist(
+    (set, get) => ({
+      favorites: [],
 
-  toggleFavorite: (profileId: string) => {
-    const { favorites } = get();
-    if (favorites.includes(profileId)) {
-      set({ favorites: favorites.filter((id) => id !== profileId) });
-    } else {
-      set({ favorites: [...favorites, profileId] });
+      toggleFavorite: (profileId: string) => {
+        const { favorites } = get();
+        if (favorites.includes(profileId)) {
+          set({ favorites: favorites.filter((id) => id !== profileId) });
+        } else {
+          set({ favorites: [...favorites, profileId] });
+        }
+      },
+
+      isFavorite: (profileId: string) => {
+        return get().favorites.includes(profileId);
+      },
+
+      clearFavorites: () => {
+        set({ favorites: [] });
+      },
+    }),
+    {
+      name: 'favorites-storage',
+      storage: createJSONStorage(() => AsyncStorage),
+      partialize: (state) => ({
+        favorites: state.favorites,
+      }),
     }
-  },
-
-  isFavorite: (profileId: string) => {
-    return get().favorites.includes(profileId);
-  },
-
-  clearFavorites: () => {
-    set({ favorites: [] });
-  },
-}));
+  )
+);


### PR DESCRIPTION
## Summary

- `favoritesStore` used plain Zustand with no persistence — favorites were lost on every page reload
- Added `persist` middleware with `AsyncStorage` backend, matching the pattern already used in `authStore`
- Only the `favorites` array is persisted via `partialize` (no transient state leaks into storage)
- Storage key: `favorites-storage`

## Changes

- `/app/src/store/favoritesStore.ts` — wrapped store with `persist(…, { name, storage, partialize })`

## Test plan

- [ ] Add a profile to favorites
- [ ] Close/reload the app
- [ ] Verify the favorite is still shown on the Favorites screen
- [ ] Toggle off a favorite, reload — verify it stays removed
- [ ] Verify `clearFavorites()` still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)