### PR TITLE
fix: add unread count badge to Messages tab icon

### DIFF
--- a/app/app/(tabs)/_layout.tsx
+++ b/app/app/(tabs)/_layout.tsx
@@ -4,10 +4,14 @@ import { useAuthStore } from '../../src/store/authStore';
 import { colors } from '../../src/constants/theme';
 import { useEffect, useState } from 'react';
 import { CustomTabBar } from '../../src/components/CustomTabBar';
+import { useMessagesStore } from '../../src/store/messagesStore';
+
+const UNREAD_REFRESH_INTERVAL_MS = 30_000; // 30 seconds
 
 export default function TabsLayout() {
   const { user, isAuthenticated } = useAuthStore();
   const [isHydrated, setIsHydrated] = useState(false);
+  const refreshUnreadCount = useMessagesStore((s) => s.refreshUnreadCount);
 
   useEffect(() => {
     const unsubFinishHydration = useAuthStore.persist.onFinishHydration(() => {
@@ -22,6 +26,17 @@ export default function TabsLayout() {
       unsubFinishHydration();
     };
   }, []);
+
+  useEffect(() => {
+    if (!isAuthenticated) return;
+
+    // Fetch immediately on mount
+    refreshUnreadCount();
+
+    // Then refresh periodically
+    const interval = setInterval(refreshUnreadCount, UNREAD_REFRESH_INTERVAL_MS);
+    return () => clearInterval(interval);
+  }, [isAuthenticated, refreshUnreadCount]);
 
   if (!isHydrated) {
     return (

--- a/app/src/components/CustomTabBar.tsx
+++ b/app/src/components/CustomTabBar.tsx
@@ -4,6 +4,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { LinearGradient } from 'expo-linear-gradient';
 import { colors, spacing, typography, borderRadius, shadows } from '../constants/theme';
 import { Home, Search, Calendar, MessageCircle, User, Grid, Mail, Wallet } from 'lucide-react-native';
+import { useMessagesStore } from '../store/messagesStore';
 
 interface TabItem {
   name: string;
@@ -37,6 +38,7 @@ export function CustomTabBar({ role }: CustomTabBarProps) {
   const pathname = usePathname();
   const router = useRouter();
   const tabs = role === 'companion' ? companionTabs : seekerTabs;
+  const unreadCount = useMessagesStore((s) => s.unreadCount);
 
   const isActive = (path: string) => {
     if (path === '/male' || path === '/female') {
@@ -55,6 +57,8 @@ export function CustomTabBar({ role }: CustomTabBarProps) {
       {tabs.map((tab) => {
         const Icon = tab.icon;
         const active = isActive(tab.path);
+
+        const showBadge = tab.name === 'messages' && unreadCount > 0;
 
         return (
           <TouchableOpacity
@@ -75,10 +79,24 @@ export function CustomTabBar({ role }: CustomTabBarProps) {
                 >
                   <Icon size={20} color={colors.white} strokeWidth={2.5} />
                 </LinearGradient>
+                {showBadge && (
+                  <View style={styles.badge}>
+                    <Text style={styles.badgeText}>
+                      {unreadCount > 99 ? '99+' : unreadCount}
+                    </Text>
+                  </View>
+                )}
               </View>
             ) : (
               <View style={styles.iconWrap}>
                 <Icon size={20} color={colors.textMuted} strokeWidth={1.8} />
+                {showBadge && (
+                  <View style={styles.badge}>
+                    <Text style={styles.badgeText}>
+                      {unreadCount > 99 ? '99+' : unreadCount}
+                    </Text>
+                  </View>
+                )}
               </View>
             )}
             <Text
@@ -139,5 +157,23 @@ const styles = StyleSheet.create({
   },
   labelInactive: {
     color: colors.textMuted,
+  },
+  badge: {
+    position: 'absolute',
+    top: -4,
+    right: -6,
+    minWidth: 16,
+    height: 16,
+    borderRadius: 8,
+    backgroundColor: '#FF3B30',
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 3,
+  },
+  badgeText: {
+    color: colors.white,
+    fontSize: 9,
+    fontFamily: typography.fonts.bodyBold,
+    lineHeight: 12,
   },
 });


### PR DESCRIPTION
## Summary
- Subscribe to `unreadCount` from `messagesStore` in `CustomTabBar`
- Render a small red badge circle with the count on the Messages tab icon (capped at 99+)
- Badge appears in both active and inactive tab states
- `_layout.tsx` now calls `refreshUnreadCount` on mount and every 30 seconds via `setInterval`

## Files changed
- `app/src/components/CustomTabBar.tsx` — badge rendering + styles
- `app/app/(tabs)/_layout.tsx` — periodic unread count refresh

## Test plan
- [ ] Log in as a seeker who has unread messages — badge with count appears on Messages tab
- [ ] Badge disappears after visiting Messages tab (messages marked read by backend)
- [ ] Badge shows 99+ when unread count exceeds 99
- [ ] Badge is visible on both active (gradient bg) and inactive tab states
- [ ] Badge refreshes every 30 seconds automatically