### PR TITLE
fix: BUG-038 bookings filter param was ignored, returns all bookings

### DIFF
--- a/backend/daterabbit-api/src/bookings/bookings.controller.ts
+++ b/backend/daterabbit-api/src/bookings/bookings.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Post, Put, Body, Param, UseGuards, Request, HttpException, HttpStatus } from '@nestjs/common';
+import { Controller, Get, Post, Put, Body, Param, Query, UseGuards, Request, HttpException, HttpStatus } from '@nestjs/common';
 import { BookingsService } from './bookings.service';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { BookingStatus, ActivityType } from './entities/booking.entity';
@@ -66,15 +66,26 @@ export class BookingsController {
   }
 
   @Get()
-  async getMyBookings(@Request() req) {
-    // Get bookings as seeker
-    const seekerBookings = await this.bookingsService.findByUser(req.user.id, 'seeker');
-    // Get bookings as companion
-    const companionBookings = await this.bookingsService.findByUser(req.user.id, 'companion');
+  async getMyBookings(
+    @Request() req,
+    @Query('filter') filter: 'all' | 'upcoming' | 'pending' | 'past' = 'all',
+    @Query('page') page = '1',
+  ) {
+    const validFilters = ['all', 'upcoming', 'pending', 'past'];
+    const safeFilter = validFilters.includes(filter) ? filter : 'all';
+    const pageNum = Math.max(1, parseInt(page, 10) || 1);
+
+    const { bookings, total } = await this.bookingsService.findByUserFiltered(
+      req.user.id,
+      safeFilter,
+      pageNum,
+    );
 
     return {
-      asSeeker: seekerBookings.map((b) => this.formatBooking(b)),
-      asCompanion: companionBookings.map((b) => this.formatBooking(b)),
+      bookings: bookings.map((b) => this.formatBooking(b)),
+      total,
+      page: pageNum,
+      filter: safeFilter,
     };
   }
 

--- a/backend/daterabbit-api/src/bookings/bookings.service.ts
+++ b/backend/daterabbit-api/src/bookings/bookings.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, HttpException, HttpStatus } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { Repository, MoreThanOrEqual, LessThan } from 'typeorm';
 import { Booking, BookingStatus, ActivityType } from './entities/booking.entity';
 import { UsersService } from '../users/users.service';
 
@@ -50,6 +50,75 @@ export class BookingsService {
       relations: ['seeker', 'companion'],
       order: { dateTime: 'DESC' },
     });
+  }
+
+  async findByUserFiltered(
+    userId: string,
+    filter: 'all' | 'upcoming' | 'pending' | 'past',
+    page = 1,
+    limit = 20,
+  ): Promise<{ bookings: Booking[]; total: number }> {
+    const now = new Date();
+    const skip = (page - 1) * limit;
+
+    // Build where conditions for both seeker and companion roles
+    let seekerWhere: object;
+    let companionWhere: object;
+
+    switch (filter) {
+      case 'upcoming':
+        // Confirmed/paid bookings with a future date
+        seekerWhere = [
+          { seekerId: userId, status: BookingStatus.CONFIRMED, dateTime: MoreThanOrEqual(now) },
+          { seekerId: userId, status: BookingStatus.PAID, dateTime: MoreThanOrEqual(now) },
+        ];
+        companionWhere = [
+          { companionId: userId, status: BookingStatus.CONFIRMED, dateTime: MoreThanOrEqual(now) },
+          { companionId: userId, status: BookingStatus.PAID, dateTime: MoreThanOrEqual(now) },
+        ];
+        break;
+
+      case 'pending':
+        seekerWhere = [{ seekerId: userId, status: BookingStatus.PENDING }];
+        companionWhere = [{ companionId: userId, status: BookingStatus.PENDING }];
+        break;
+
+      case 'past':
+        // Completed/cancelled bookings OR any booking with a past date
+        seekerWhere = [
+          { seekerId: userId, status: BookingStatus.COMPLETED },
+          { seekerId: userId, status: BookingStatus.CANCELLED },
+          { seekerId: userId, dateTime: LessThan(now), status: BookingStatus.CONFIRMED },
+          { seekerId: userId, dateTime: LessThan(now), status: BookingStatus.PAID },
+        ];
+        companionWhere = [
+          { companionId: userId, status: BookingStatus.COMPLETED },
+          { companionId: userId, status: BookingStatus.CANCELLED },
+          { companionId: userId, dateTime: LessThan(now), status: BookingStatus.CONFIRMED },
+          { companionId: userId, dateTime: LessThan(now), status: BookingStatus.PAID },
+        ];
+        break;
+
+      default: // 'all'
+        seekerWhere = [{ seekerId: userId }];
+        companionWhere = [{ companionId: userId }];
+        break;
+    }
+
+    const allWhere = [
+      ...(Array.isArray(seekerWhere) ? seekerWhere : [seekerWhere]),
+      ...(Array.isArray(companionWhere) ? companionWhere : [companionWhere]),
+    ];
+
+    const [bookings, total] = await this.bookingsRepository.findAndCount({
+      where: allWhere,
+      relations: ['seeker', 'companion'],
+      order: { dateTime: filter === 'past' ? 'DESC' : 'ASC' },
+      skip,
+      take: limit,
+    });
+
+    return { bookings, total };
   }
 
   async updateStatus(id: string, status: BookingStatus, reason?: string): Promise<Booking | null> {


### PR DESCRIPTION
## Summary

- `GET /api/bookings?filter=upcoming` (and other filter values) was silently ignoring the `filter` query param, returning ALL bookings regardless of the value passed
- Added `findByUserFiltered()` to `BookingsService` with correct per-filter SQL conditions using TypeORM `MoreThanOrEqual` / `LessThan` operators
- Updated the `GET /bookings` controller handler to read and validate `filter` + `page` query params, then delegate to the new service method

## Filter logic

| filter | conditions |
|--------|-----------|
| `upcoming` | `status IN ('confirmed','paid') AND dateTime >= now` |
| `pending` | `status = 'pending'` |
| `past` | `status IN ('completed','cancelled') OR (dateTime < now AND status IN ('confirmed','paid'))` |
| `all` (default) | no filter |

## Response shape

Changed from `{ asSeeker, asCompanion }` to `{ bookings, total, page, filter }`. The existing frontend `api.ts` already handles both shapes via the `'bookings' in response` check.

## Test plan

- [ ] Login as test@daterabbit.com (OTP: 000000)
- [ ] Call `GET /api/bookings?filter=upcoming` — should return only confirmed/paid future bookings
- [ ] Call `GET /api/bookings?filter=pending` — should return only pending bookings
- [ ] Call `GET /api/bookings?filter=past` — should return only completed/cancelled or past-dated bookings
- [ ] Call `GET /api/bookings?filter=all` or no filter — should return all bookings
- [ ] Bookings tab in app shows correct subset per tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)