### PR TITLE
feat: PUT /bookings/:id/complete endpoint (UC-025)

### DIFF
--- a/backend/daterabbit-api/src/bookings/bookings.controller.ts
+++ b/backend/daterabbit-api/src/bookings/bookings.controller.ts
@@ -140,6 +140,12 @@ export class BookingsController {
     return this.formatBooking(updated);
   }
 
+  @Put(':id/complete')
+  async completeBooking(@Param('id') id: string, @Request() req) {
+    const updated = await this.bookingsService.complete(id, req.user.id);
+    return this.formatBooking(updated);
+  }
+
   private formatBooking(booking: any) {
     return {
       id: booking.id,

--- a/backend/daterabbit-api/src/bookings/bookings.service.ts
+++ b/backend/daterabbit-api/src/bookings/bookings.service.ts
@@ -82,4 +82,38 @@ export class BookingsService {
       order: { createdAt: 'DESC' },
     });
   }
+
+  async complete(id: string, userId: string): Promise<Booking> {
+    const booking = await this.findById(id);
+
+    if (!booking) {
+      throw new HttpException('Booking not found', HttpStatus.NOT_FOUND);
+    }
+
+    if (booking.seekerId !== userId && booking.companionId !== userId) {
+      throw new HttpException('Unauthorized', HttpStatus.FORBIDDEN);
+    }
+
+    if (
+      booking.status !== BookingStatus.CONFIRMED &&
+      booking.status !== BookingStatus.PAID
+    ) {
+      throw new HttpException(
+        `Cannot complete a ${booking.status} booking`,
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+
+    // Booking date must be today or in the past
+    const now = new Date();
+    const todayEnd = new Date(now.getFullYear(), now.getMonth(), now.getDate(), 23, 59, 59, 999);
+    if (new Date(booking.dateTime) > todayEnd) {
+      throw new HttpException(
+        'Cannot complete a future booking',
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+
+    return this.updateStatus(id, BookingStatus.COMPLETED);
+  }
 }


### PR DESCRIPTION
## Summary

- Adds `PUT /api/bookings/:id/complete` endpoint
- Business logic is in `BookingsService.complete()`, controller delegates and formats response

## Validation rules

- Only the seeker or companion of the booking can complete it (403 otherwise)
- Only bookings with status `CONFIRMED` or `PAID` can be completed (400 otherwise)
- Booking `dateTime` must be today or in the past — future bookings cannot be completed (400 otherwise)

## Test plan

- [ ] PUT `/bookings/:id/complete` as seeker with CONFIRMED booking dated in the past -> 200, status=completed
- [ ] PUT `/bookings/:id/complete` as companion with PAID booking dated in the past -> 200, status=completed
- [ ] PUT `/bookings/:id/complete` as unrelated user -> 403
- [ ] PUT `/bookings/:id/complete` with PENDING booking -> 400
- [ ] PUT `/bookings/:id/complete` with future booking date -> 400
- [ ] PUT `/bookings/:id/complete` with already COMPLETED booking -> 400