### PR TITLE
feat: DELETE /api/users/me — account deactivation (UC-048)

### DIFF
--- a/backend/daterabbit-api/src/auth/strategies/jwt.strategy.ts
+++ b/backend/daterabbit-api/src/auth/strategies/jwt.strategy.ts
@@ -1,11 +1,15 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
 import { ExtractJwt, Strategy } from 'passport-jwt';
 import { ConfigService } from '@nestjs/config';
+import { UsersService } from '../../users/users.service';
 
 @Injectable()
 export class JwtStrategy extends PassportStrategy(Strategy) {
-  constructor(configService: ConfigService) {
+  constructor(
+    configService: ConfigService,
+    private usersService: UsersService,
+  ) {
     super({
       jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
       ignoreExpiration: false,
@@ -14,6 +18,12 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
   }
 
   async validate(payload: { id: string; email: string }) {
+    // Use withDeleted lookup so deactivated accounts are not silently treated as "not found"
+    const user = await this.usersService.findByIdWithDeleted(payload.id);
+    // Reject tokens for deleted/deactivated accounts
+    if (!user || !user.isActive || user.deletedAt) {
+      throw new UnauthorizedException('Account is deactivated');
+    }
     return { id: payload.id, email: payload.email };
   }
 }

--- a/backend/daterabbit-api/src/users/entities/user.entity.ts
+++ b/backend/daterabbit-api/src/users/entities/user.entity.ts
@@ -4,7 +4,7 @@ import {
   Column,
   CreateDateColumn,
   UpdateDateColumn,
-  OneToMany,
+  DeleteDateColumn,
 } from 'typeorm';
 
 export enum UserRole {
@@ -85,4 +85,8 @@ export class User {
 
   @UpdateDateColumn()
   updatedAt: Date;
+
+  // Soft delete timestamp - set when account is deactivated
+  @DeleteDateColumn({ nullable: true })
+  deletedAt: Date;
 }

--- a/backend/daterabbit-api/src/users/users.controller.ts
+++ b/backend/daterabbit-api/src/users/users.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Put, Body, UseGuards, Request, Param, BadRequestException } from '@nestjs/common';
+import { Controller, Get, Put, Delete, Body, UseGuards, Request, Param, BadRequestException } from '@nestjs/common';
 import { UsersService } from './users.service';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { UpdateUserDto } from './dto/update-user.dto';
@@ -50,6 +50,13 @@ export class UsersController {
     }
     const { otpCode, otpExpiresAt, ...safeUser } = updated;
     return safeUser;
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Delete('me')
+  async deleteAccount(@Request() req) {
+    await this.usersService.deactivateAccount(req.user.id);
+    return { success: true, message: 'Account deactivated' };
   }
 
   @Get(':id')

--- a/backend/daterabbit-api/src/users/users.service.ts
+++ b/backend/daterabbit-api/src/users/users.service.ts
@@ -18,6 +18,11 @@ export class UsersService {
     return this.usersRepository.findOne({ where: { id } });
   }
 
+  // Find user including soft-deleted ones (used by JWT strategy to detect deactivated accounts)
+  async findByIdWithDeleted(id: string): Promise<User | null> {
+    return this.usersRepository.findOne({ where: { id }, withDeleted: true });
+  }
+
   async create(data: Partial<User>): Promise<User> {
     const user = this.usersRepository.create(data);
     return this.usersRepository.save(user);
@@ -40,6 +45,14 @@ export class UsersService {
       otpCode: undefined,
       otpExpiresAt: undefined,
     } as any);
+  }
+
+  async deactivateAccount(userId: string): Promise<void> {
+    // Soft delete: set isActive=false and deletedAt timestamp via TypeORM softDelete
+    await this.usersRepository.update(userId, {
+      isActive: false,
+    });
+    await this.usersRepository.softDelete(userId);
   }
 
   async getCompanions(filters: {


### PR DESCRIPTION
## Summary

- Implements `DELETE /api/users/me` endpoint for soft account deactivation (UC-048)
- No data is physically deleted — TypeORM soft delete sets `deletedAt` timestamp
- JWT tokens become immediately invalid after deactivation (strategy checks `isActive` and `deletedAt` on every request)
- Frontend `delete-account.tsx` already calls `usersApi.deleteAccount()` which maps to this endpoint

## Changes

**`user.entity.ts`**
- Replaced unused `OneToMany` import with `DeleteDateColumn`
- Added `@DeleteDateColumn() deletedAt: Date` for TypeORM soft delete support

**`users.service.ts`**
- Added `findByIdWithDeleted()` — queries including soft-deleted records (used by JWT strategy)
- Added `deactivateAccount()` — sets `isActive: false` then calls `softDelete()`

**`users.controller.ts`**
- Added `DELETE /users/me` endpoint protected by `JwtAuthGuard`
- Returns `{ success: true, message: "Account deactivated" }`

**`jwt.strategy.ts`**
- Now injects `UsersService` and calls `findByIdWithDeleted()` on every token validation
- Throws `UnauthorizedException` if user is not found, `isActive=false`, or `deletedAt` is set

## Test plan

- [ ] Call `DELETE /api/users/me` with valid JWT → expect `{ success: true, message: "Account deactivated" }`
- [ ] Call `GET /api/users/me` with same JWT after deletion → expect `401 Unauthorized`
- [ ] Verify DB: `isActive=false`, `deleted_at` timestamp set, record still exists (soft delete)
- [ ] Companions list endpoint should not return deactivated companions (existing `isActive=true` filter)
- [ ] Deactivated account email should still be unique in DB (re-registration edge case)

🤖 Generated with [Claude Code](https://claude.com/claude-code)