### PR TITLE
feat: Admin backend module with /api/admin/* endpoints

### DIFF
--- a/backend/daterabbit-api/src/admin/admin.controller.ts
+++ b/backend/daterabbit-api/src/admin/admin.controller.ts
@@ -1,0 +1,83 @@
+import {
+  Controller,
+  Get,
+  Patch,
+  Put,
+  Param,
+  Body,
+  Query,
+  UseGuards,
+  ParseIntPipe,
+  DefaultValuePipe,
+} from '@nestjs/common';
+import { AdminGuard } from './admin.guard';
+import { AdminService } from './admin.service';
+
+@Controller('admin')
+@UseGuards(AdminGuard)
+export class AdminController {
+  constructor(private readonly adminService: AdminService) {}
+
+  @Get('stats')
+  getStats() {
+    return this.adminService.getStats();
+  }
+
+  @Get('users')
+  getUsers(
+    @Query('search') search = '',
+    @Query('page', new DefaultValuePipe(1), ParseIntPipe) page: number,
+    @Query('limit', new DefaultValuePipe(20), ParseIntPipe) limit: number,
+  ) {
+    return this.adminService.getUsers(search, page, Math.min(limit, 100));
+  }
+
+  @Get('users/:id')
+  getUserById(@Param('id') id: string) {
+    return this.adminService.getUserById(id);
+  }
+
+  @Patch('users/:id')
+  updateUser(
+    @Param('id') id: string,
+    @Body() body: { isActive?: boolean; isAdmin?: boolean },
+  ) {
+    return this.adminService.updateUser(id, body);
+  }
+
+  @Get('bookings')
+  getBookings(
+    @Query('status') status?: string,
+    @Query('page', new DefaultValuePipe(1), ParseIntPipe) page = 1,
+    @Query('limit', new DefaultValuePipe(20), ParseIntPipe) limit = 20,
+  ) {
+    return this.adminService.getBookings(status, page, Math.min(limit, 100));
+  }
+
+  @Get('bookings/:id')
+  getBookingById(@Param('id') id: string) {
+    return this.adminService.getBookingById(id);
+  }
+
+  @Get('verifications')
+  getVerifications(
+    @Query('status') status?: string,
+    @Query('page', new DefaultValuePipe(1), ParseIntPipe) page = 1,
+    @Query('limit', new DefaultValuePipe(20), ParseIntPipe) limit = 20,
+  ) {
+    return this.adminService.getVerifications(status, page, Math.min(limit, 100));
+  }
+
+  @Put('verifications/:id/approve')
+  approveVerification(@Param('id') id: string) {
+    return this.adminService.approveVerification(id);
+  }
+
+  @Put('verifications/:id/reject')
+  rejectVerification(
+    @Param('id') id: string,
+    @Body() body: { reason?: string },
+  ) {
+    return this.adminService.rejectVerification(id, body.reason);
+  }
+}

--- a/backend/daterabbit-api/src/admin/admin.guard.ts
+++ b/backend/daterabbit-api/src/admin/admin.guard.ts
@@ -1,0 +1,51 @@
+import {
+  Injectable,
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import { ConfigService } from '@nestjs/config';
+import { UsersService } from '../users/users.service';
+
+@Injectable()
+export class AdminGuard implements CanActivate {
+  constructor(
+    private jwtService: JwtService,
+    private configService: ConfigService,
+    private usersService: UsersService,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest();
+    const authHeader = request.headers?.authorization;
+
+    if (!authHeader?.startsWith('Bearer ')) {
+      throw new UnauthorizedException('Authentication required');
+    }
+
+    const token = authHeader.slice(7);
+    let payload: { id: string; email: string };
+
+    try {
+      payload = this.jwtService.verify(token, {
+        secret: this.configService.get('JWT_SECRET'),
+      });
+    } catch {
+      throw new UnauthorizedException('Invalid token');
+    }
+
+    const user = await this.usersService.findById(payload.id);
+    if (!user) {
+      throw new UnauthorizedException('User not found');
+    }
+
+    if (!user.isAdmin) {
+      throw new ForbiddenException('Admin access required');
+    }
+
+    request.user = user;
+    return true;
+  }
+}

--- a/backend/daterabbit-api/src/admin/admin.module.ts
+++ b/backend/daterabbit-api/src/admin/admin.module.ts
@@ -1,0 +1,29 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { JwtModule } from '@nestjs/jwt';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { AdminController } from './admin.controller';
+import { AdminService } from './admin.service';
+import { AdminGuard } from './admin.guard';
+import { User } from '../users/entities/user.entity';
+import { Booking } from '../bookings/entities/booking.entity';
+import { Verification } from '../verification/entities/verification.entity';
+import { UsersModule } from '../users/users.module';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([User, Booking, Verification]),
+    JwtModule.registerAsync({
+      imports: [ConfigModule],
+      inject: [ConfigService],
+      useFactory: (configService: ConfigService) => ({
+        secret: configService.get('JWT_SECRET'),
+        signOptions: { expiresIn: configService.get('JWT_EXPIRATION', '7d') },
+      }),
+    }),
+    UsersModule,
+  ],
+  controllers: [AdminController],
+  providers: [AdminService, AdminGuard],
+})
+export class AdminModule {}

--- a/backend/daterabbit-api/src/admin/admin.service.ts
+++ b/backend/daterabbit-api/src/admin/admin.service.ts
@@ -1,0 +1,182 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, ILike } from 'typeorm';
+import { User } from '../users/entities/user.entity';
+import { Booking, BookingStatus } from '../bookings/entities/booking.entity';
+import { Verification, VerificationStatus } from '../verification/entities/verification.entity';
+
+@Injectable()
+export class AdminService {
+  constructor(
+    @InjectRepository(User)
+    private usersRepo: Repository<User>,
+    @InjectRepository(Booking)
+    private bookingsRepo: Repository<Booking>,
+    @InjectRepository(Verification)
+    private verificationsRepo: Repository<Verification>,
+  ) {}
+
+  async getStats() {
+    const [totalUsers, totalBookings, revenueResult] = await Promise.all([
+      this.usersRepo.count(),
+      this.bookingsRepo.count(),
+      this.bookingsRepo
+        .createQueryBuilder('b')
+        .select('COALESCE(SUM(b.totalPrice), 0)', 'total')
+        .where('b.status IN (:...statuses)', {
+          statuses: [BookingStatus.PAID, BookingStatus.COMPLETED],
+        })
+        .getRawOne<{ total: string }>(),
+    ]);
+
+    return {
+      totalUsers,
+      totalBookings,
+      revenue: parseFloat(revenueResult?.total ?? '0'),
+    };
+  }
+
+  async getUsers(search: string, page: number, limit: number) {
+    const skip = (page - 1) * limit;
+
+    const where = search
+      ? [{ email: ILike(`%${search}%`) }, { name: ILike(`%${search}%`) }]
+      : {};
+
+    const [items, total] = await this.usersRepo.findAndCount({
+      where,
+      select: {
+        id: true,
+        email: true,
+        name: true,
+        role: true,
+        isVerified: true,
+        verificationStatus: true,
+        isActive: true,
+        isAdmin: true,
+        createdAt: true,
+      },
+      order: { createdAt: 'DESC' },
+      skip,
+      take: limit,
+    });
+
+    return { items, total, page, limit };
+  }
+
+  async getUserById(id: string) {
+    const user = await this.usersRepo.findOne({
+      where: { id },
+      select: {
+        id: true,
+        email: true,
+        name: true,
+        role: true,
+        age: true,
+        location: true,
+        bio: true,
+        hourlyRate: true,
+        rating: true,
+        reviewCount: true,
+        isVerified: true,
+        verificationStatus: true,
+        isActive: true,
+        isAdmin: true,
+        stripeOnboardingComplete: true,
+        createdAt: true,
+        updatedAt: true,
+      },
+    });
+
+    if (!user) {
+      throw new NotFoundException('User not found');
+    }
+
+    return user;
+  }
+
+  async updateUser(id: string, data: { isActive?: boolean; isAdmin?: boolean }) {
+    const user = await this.usersRepo.findOne({ where: { id } });
+    if (!user) {
+      throw new NotFoundException('User not found');
+    }
+
+    await this.usersRepo.update(id, data);
+    return this.getUserById(id);
+  }
+
+  async getBookings(status: string | undefined, page: number, limit: number) {
+    const skip = (page - 1) * limit;
+    const where = status ? { status: status as BookingStatus } : {};
+
+    const [items, total] = await this.bookingsRepo.findAndCount({
+      where,
+      relations: ['seeker', 'companion'],
+      order: { createdAt: 'DESC' },
+      skip,
+      take: limit,
+    });
+
+    return { items, total, page, limit };
+  }
+
+  async getBookingById(id: string) {
+    const booking = await this.bookingsRepo.findOne({
+      where: { id },
+      relations: ['seeker', 'companion'],
+    });
+
+    if (!booking) {
+      throw new NotFoundException('Booking not found');
+    }
+
+    return booking;
+  }
+
+  async getVerifications(status: string | undefined, page: number, limit: number) {
+    const skip = (page - 1) * limit;
+    const where = status ? { status: status as VerificationStatus } : {};
+
+    const [items, total] = await this.verificationsRepo.findAndCount({
+      where,
+      order: { createdAt: 'DESC' },
+      skip,
+      take: limit,
+    });
+
+    return { items, total, page, limit };
+  }
+
+  async approveVerification(id: string) {
+    const verification = await this.verificationsRepo.findOne({ where: { id } });
+    if (!verification) {
+      throw new NotFoundException('Verification not found');
+    }
+
+    await this.verificationsRepo.update(id, { status: VerificationStatus.APPROVED });
+    await this.usersRepo.update(verification.userId, {
+      isVerified: true,
+      verificationStatus: 'approved' as any,
+    });
+
+    return { success: true };
+  }
+
+  async rejectVerification(id: string, reason?: string) {
+    const verification = await this.verificationsRepo.findOne({ where: { id } });
+    if (!verification) {
+      throw new NotFoundException('Verification not found');
+    }
+
+    await this.verificationsRepo.update(id, {
+      status: VerificationStatus.REJECTED,
+      rejectionReason: reason || 'Rejected by admin',
+    });
+    await this.usersRepo.update(verification.userId, {
+      isVerified: false,
+      verificationStatus: 'rejected' as any,
+    });
+
+    return { success: true };
+  }
+}

--- a/backend/daterabbit-api/src/app.module.ts
+++ b/backend/daterabbit-api/src/app.module.ts
@@ -11,6 +11,7 @@ import { MessagesModule } from './messages/messages.module';
 import { VerificationModule } from './verification/verification.module';
 import { ReviewsModule } from './reviews/reviews.module';
 import { PaymentsModule } from './payments/payments.module';
+import { AdminModule } from './admin/admin.module';
 
 @Module({
   imports: [
@@ -54,6 +55,7 @@ import { PaymentsModule } from './payments/payments.module';
     VerificationModule,
     ReviewsModule,
     PaymentsModule,
+    AdminModule,
   ],
   providers: [
     {

--- a/backend/daterabbit-api/src/auth/auth.controller.ts
+++ b/backend/daterabbit-api/src/auth/auth.controller.ts
@@ -7,6 +7,13 @@ import { UserRole } from '../users/entities/user.entity';
 export class AuthController {
   constructor(private authService: AuthService) {}
 
+  // Alias for admin panel compatibility
+  @Post('send-otp')
+  @Throttle({ default: { limit: 20, ttl: 3600000 } })
+  async sendOtp(@Body() body: { email: string }) {
+    return this.startAuth(body);
+  }
+
   @Post('start')
   @Throttle({ default: { limit: 20, ttl: 3600000 } }) // 20 emails per hour
   async startAuth(@Body() body: { email: string }) {
@@ -25,6 +32,13 @@ export class AuthController {
 
     const result = await this.authService.startAuth(email);
     return result;
+  }
+
+  // Alias for admin panel compatibility
+  @Post('verify-otp')
+  @Throttle({ default: { limit: 10, ttl: 600000 } })
+  async verifyOtpAlias(@Body() body: { email: string; code: string }) {
+    return this.verifyOtp(body);
   }
 
   @Post('verify')

--- a/backend/daterabbit-api/src/users/entities/user.entity.ts
+++ b/backend/daterabbit-api/src/users/entities/user.entity.ts
@@ -68,6 +68,9 @@ export class User {
   @Column({ default: true })
   isActive: boolean;
 
+  @Column({ default: false })
+  isAdmin: boolean;
+
   @Column({ nullable: true })
   stripeAccountId: string;
 


### PR DESCRIPTION
## Summary

- Add full `AdminModule` in `backend/daterabbit-api/src/admin/` (controller, service, guard)
- Add `isAdmin` boolean column to `User` entity for admin access control
- Add auth endpoint aliases for admin panel compatibility

## Endpoints

**Auth aliases (fix mismatch with admin panel):**
- `POST /auth/send-otp` -> alias for `/auth/start`
- `POST /auth/verify-otp` -> alias for `/auth/verify`

**Admin endpoints (all require `isAdmin=true` JWT):**
- `GET /api/admin/stats` — total users, bookings, revenue
- `GET /api/admin/users?search=&page=&limit=` — paginated user list
- `GET /api/admin/users/:id` — user details
- `PATCH /api/admin/users/:id` — update user (isActive, isAdmin)
- `GET /api/admin/bookings?status=&page=&limit=` — paginated bookings
- `GET /api/admin/bookings/:id` — booking details with seeker/companion
- `GET /api/admin/verifications?status=pending` — verification requests
- `PUT /api/admin/verifications/:id/approve` — approve + set isVerified=true
- `PUT /api/admin/verifications/:id/reject` — reject with optional reason

## Test plan

- [ ] Deploy to staging and verify `daterabbit.smartlaunchhub.com/api/admin/stats` returns 403 without token
- [ ] Set `isAdmin=true` for a test user in DB, get JWT, verify admin endpoints work
- [ ] Verify auth aliases `/auth/send-otp` and `/auth/verify-otp` work correctly
- [ ] Admin panel login flow works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)