### PR TITLE
fix: Browse page filter styling - Neo-Brutalism design

### DIFF
--- a/app/app/(tabs)/male/browse.tsx
+++ b/app/app/(tabs)/male/browse.tsx
@@ -158,7 +158,7 @@ export default function BrowseScreen() {
       </View>
 
       <View style={styles.searchContainer}>
-        <View style={[styles.searchBox, { backgroundColor: colors.surface, borderColor: colors.border }]}>
+        <View style={[styles.searchBox, { backgroundColor: colors.surface }]}>
           <Icon name="search" size={18} color={colors.textSecondary} />
           <TextInput
             style={[styles.searchInput, { color: colors.text }]}
@@ -170,7 +170,7 @@ export default function BrowseScreen() {
           />
         </View>
         <TouchableOpacity
-          style={[styles.filterButton, { backgroundColor: colors.surface, borderColor: colors.border }]}
+          style={[styles.filterButton, { backgroundColor: colors.surface }]}
           onPress={() => setFilterModalVisible(true)}
           testID="browse-filter-btn"
         >
@@ -195,7 +195,7 @@ export default function BrowseScreen() {
             style={[
               styles.filterChip,
               { backgroundColor: colors.surface },
-              activeFilter === filter && { backgroundColor: colors.primary },
+              activeFilter === filter && [styles.filterChipActive, { backgroundColor: colors.primary }],
             ]}
             onPress={() => setActiveFilter(filter)}
           >
@@ -341,7 +341,9 @@ const styles = StyleSheet.create({
     alignSelf: 'flex-start',
     paddingHorizontal: spacing.sm,
     paddingVertical: spacing.xs,
-    borderRadius: borderRadius.full,
+    borderRadius: borderRadius.sm,
+    borderWidth: 2,
+    borderColor: '#000000',
     marginBottom: spacing.md,
     gap: spacing.xs,
   },
@@ -360,29 +362,45 @@ const styles = StyleSheet.create({
     flex: 1,
     flexDirection: 'row',
     alignItems: 'center',
-    borderRadius: borderRadius.xl,
+    borderRadius: borderRadius.sm,
     paddingHorizontal: spacing.md,
     paddingVertical: spacing.sm,
-    borderWidth: 1,
+    borderWidth: 2,
+    borderColor: '#000000',
     gap: spacing.sm,
+    // Neo-Brutalism offset shadow
+    shadowColor: '#000000',
+    shadowOffset: { width: 3, height: 3 },
+    shadowOpacity: 1,
+    shadowRadius: 0,
+    elevation: 3,
   },
   filterButton: {
-    width: 44,
-    height: 44,
-    borderRadius: borderRadius.lg,
+    width: 46,
+    height: 46,
+    borderRadius: borderRadius.sm,
     alignItems: 'center',
     justifyContent: 'center',
-    borderWidth: 1,
+    borderWidth: 2,
+    borderColor: '#000000',
+    // Neo-Brutalism offset shadow
+    shadowColor: '#000000',
+    shadowOffset: { width: 3, height: 3 },
+    shadowOpacity: 1,
+    shadowRadius: 0,
+    elevation: 3,
   },
   filterBadge: {
     position: 'absolute',
-    top: -4,
-    right: -4,
-    width: 18,
-    height: 18,
-    borderRadius: 9,
+    top: -6,
+    right: -6,
+    width: 20,
+    height: 20,
+    borderRadius: 10,
     alignItems: 'center',
     justifyContent: 'center',
+    borderWidth: 2,
+    borderColor: '#000000',
   },
   filterBadgeText: {
     fontFamily: typography.fonts.heading,
@@ -396,19 +414,33 @@ const styles = StyleSheet.create({
     padding: 0,
   },
   filtersScroll: {
-    maxHeight: 50,
+    maxHeight: 56,
   },
   filtersContent: {
     paddingHorizontal: spacing.lg,
     gap: spacing.sm,
+    alignItems: 'center',
   },
   filterChip: {
-    paddingHorizontal: spacing.lg,
-    paddingVertical: spacing.sm,
-    borderRadius: borderRadius.full,
+    paddingHorizontal: spacing.md,
+    paddingVertical: 8,
+    borderRadius: borderRadius.sm,
+    borderWidth: 2,
+    borderColor: '#000000',
+    // Inactive chip: subtle shadow
+    shadowColor: '#000000',
+    shadowOffset: { width: 2, height: 2 },
+    shadowOpacity: 1,
+    shadowRadius: 0,
+    elevation: 2,
+  },
+  filterChipActive: {
+    // Active chip: stronger offset shadow
+    shadowOffset: { width: 3, height: 3 },
+    elevation: 3,
   },
   filterText: {
-    fontFamily: typography.fonts.bodyMedium,
+    fontFamily: typography.fonts.bodySemiBold,
     fontSize: typography.sizes.sm,
   },
   scrollView: {
@@ -456,7 +488,14 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     paddingHorizontal: spacing.md,
     paddingVertical: spacing.sm,
-    borderRadius: borderRadius.lg,
+    borderRadius: borderRadius.sm,
+    borderWidth: 2,
+    borderColor: '#000000',
+    shadowColor: '#000000',
+    shadowOffset: { width: 2, height: 2 },
+    shadowOpacity: 1,
+    shadowRadius: 0,
+    elevation: 2,
   },
   rateValue: {
     fontFamily: typography.fonts.heading,


### PR DESCRIPTION
## Summary

- Filter chips now have thick 2px black borders + solid offset shadows (Neo-Brutalism style)
- Search box changed from overly rounded (16px radius) to chunky 8px radius with bold 2px border + 3px offset shadow
- Filter button (sliders icon) gets same treatment: 2px border, 8px radius, 3px offset shadow
- Active filter chip gets stronger shadow (3px vs 2px) to indicate selected state
- Filter chip text upgraded to `bodySemiBold` for better readability
- Rate box and distance badge now have borders + shadows for visual consistency
- Filter badge gets a 2px black border for Neo-Brutalism crispness
- Fixed `filtersContent` to vertically center chips, bumped maxHeight from 50 to 56

## Visual changes

Before:
- Chips were borderless pill shapes with no shadows - looked flat and generic
- Search box had thin 1px border, too-rounded corners (16px), no shadow
- Filter button had 1px border, inconsistent with design system

After:
- Everything matches Neo-Brutalism: thick borders, angular corners, solid offset shadows
- Clear visual hierarchy between inactive (subtle) and active (bold) filter chips

## Test plan

- [ ] Open Browse screen on mobile (375px)
- [ ] Verify filter chips look bold with thick black borders and offset shadows
- [ ] Tap a filter chip - active state should show primary color fill + stronger shadow
- [ ] Search box should have clean chunky look with 2px border
- [ ] Filter button (sliders) should match search box style
- [ ] Verify on tablet/desktop widths too

Generated with [Claude Code](https://claude.com/claude-code)