### PR TITLE
fix: replace all emoji characters with Lucide icons

### DIFF
--- a/app/app/onboarding.tsx
+++ b/app/app/onboarding.tsx
@@ -7,35 +7,42 @@ import {
   Platform,
 } from 'react-native';
 import { router } from 'expo-router';
+import { Heart, Shield, DollarSign, Sparkles, type LucideIcon } from 'lucide-react-native';
 import { useAuthStore } from '../src/store/authStore';
 import { Button } from '../src/components/Button';
 import { colors, spacing, typography } from '../src/constants/theme';
-import type { OnboardingSlide } from '../src/types';
 
-const slides: OnboardingSlide[] = [
+interface SlideItem {
+  id: string;
+  title: string;
+  description: string;
+  IconComponent: LucideIcon;
+}
+
+const slides: SlideItem[] = [
   {
     id: '1',
     title: 'Find Your Perfect Date',
     description: 'Connect with verified, interesting people for memorable experiences',
-    icon: '💝',
+    IconComponent: Heart,
   },
   {
     id: '2',
     title: 'Safe & Secure',
     description: 'All users are verified. Your safety is our top priority',
-    icon: '🛡️',
+    IconComponent: Shield,
   },
   {
     id: '3',
     title: 'Earn While Dating',
     description: 'Set your own rates and schedule. You\'re in control',
-    icon: '💰',
+    IconComponent: DollarSign,
   },
   {
     id: '4',
     title: 'Premium Experiences',
     description: 'Book amazing dates at top restaurants, events, and more',
-    icon: '✨',
+    IconComponent: Sparkles,
   },
 ];
 
@@ -64,6 +71,7 @@ export default function OnboardingScreen() {
   };
 
   const currentSlide = slides[currentIndex];
+  const SlideIcon = currentSlide.IconComponent;
 
   return (
     <View style={styles.container}>
@@ -78,7 +86,9 @@ export default function OnboardingScreen() {
       </View>
 
       <View style={styles.slideContainer}>
-        <Text style={styles.icon}>{currentSlide.icon}</Text>
+        <View style={styles.iconContainer}>
+          <SlideIcon size={56} color={colors.primary} strokeWidth={1.5} />
+        </View>
         <Text style={styles.title}>{currentSlide.title}</Text>
         <Text style={styles.description}>{currentSlide.description}</Text>
       </View>
@@ -127,14 +137,16 @@ const styles = StyleSheet.create({
     paddingHorizontal: spacing.xl,
     paddingTop: 80,
   },
-  icon: {
-    fontSize: 80,
+  iconContainer: {
+    width: 120,
+    height: 120,
+    borderRadius: 60,
+    backgroundColor: colors.surface,
+    alignItems: 'center',
+    justifyContent: 'center',
     marginBottom: spacing.xl,
-    ...Platform.select({
-      web: {
-        lineHeight: 100,
-      },
-    }),
+    borderWidth: 2,
+    borderColor: colors.border,
   },
   title: {
     fontSize: typography.sizes.xxl,

--- a/app/src/components/Avatar.tsx
+++ b/app/src/components/Avatar.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { View, Image, Text, StyleSheet } from 'react-native';
+import { Check } from 'lucide-react-native';
 import { colors, borderRadius, borderWidth } from '../constants/theme';
 
 interface AvatarProps {
@@ -28,7 +29,7 @@ export function Avatar({ uri, name, size = 48, verified = false }: AvatarProps) 
       )}
       {verified && (
         <View style={[styles.badge, { right: 0, bottom: 0 }]}>
-          <Text style={styles.badgeText}>✓</Text>
+          <Check size={10} color={colors.white} strokeWidth={3} />
         </View>
       )}
     </View>
@@ -66,9 +67,5 @@ const styles = StyleSheet.create({
     borderWidth: 2,
     borderColor: colors.white,
   },
-  badgeText: {
-    color: colors.white,
-    fontSize: 10,
-    fontWeight: 'bold',
-  },
 });
+

--- a/app/src/components/FilterModal.tsx
+++ b/app/src/components/FilterModal.tsx
@@ -8,6 +8,7 @@ import {
   ScrollView,
 } from 'react-native';
 import Slider from '@react-native-community/slider';
+import { X, Star } from 'lucide-react-native';
 import { Button } from './Button';
 import { colors, spacing, typography, borderRadius } from '../constants/theme';
 
@@ -88,7 +89,7 @@ export function FilterModal({
       <View style={styles.container}>
         <View style={styles.header}>
           <TouchableOpacity onPress={onClose} style={styles.closeButton} testID="filter-close-btn">
-            <Text style={styles.closeIcon}>✕</Text>
+            <X size={20} color={colors.text} strokeWidth={2} />
           </TouchableOpacity>
           <Text style={styles.title} testID="filter-modal-title">Filters</Text>
           <TouchableOpacity onPress={handleReset} testID="filter-reset-btn">
@@ -163,7 +164,10 @@ export function FilterModal({
           <View style={styles.section}>
             <View style={styles.sectionHeader}>
               <Text style={styles.sectionTitle}>Minimum Rating</Text>
-              <Text style={styles.valueLabel}>⭐ {filters.minRating.toFixed(1)}+</Text>
+              <View style={styles.ratingLabel}>
+                <Star size={14} color={colors.primary} fill={colors.primary} strokeWidth={1} />
+                <Text style={styles.valueLabel}> {filters.minRating.toFixed(1)}+</Text>
+              </View>
             </View>
             <Slider
               style={styles.slider}
@@ -310,9 +314,9 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
   },
-  closeIcon: {
-    fontSize: 20,
-    color: colors.text,
+  ratingLabel: {
+    flexDirection: 'row',
+    alignItems: 'center',
   },
   title: {
     fontSize: typography.sizes.lg,

--- a/app/src/components/PhotoUpload.tsx
+++ b/app/src/components/PhotoUpload.tsx
@@ -9,6 +9,7 @@ import {
   Platform,
   Alert,
 } from 'react-native';
+import { Camera, X, Plus } from 'lucide-react-native';
 import { colors, spacing, typography, borderRadius, borderWidth } from '../constants/theme';
 import { showConfirm } from '../utils/alert';
 
@@ -74,14 +75,14 @@ export function PhotoUpload({
         {photos.map((uri, index) => (
           <View key={uri} style={styles.photoWrapper}>
             <View style={styles.photoPlaceholder}>
-              <Text style={styles.photoPlaceholderText}>📷</Text>
+              <Camera size={32} color={colors.textSecondary} strokeWidth={1.5} />
               <Text style={styles.photoIndex}>{index + 1}</Text>
             </View>
             <TouchableOpacity
               style={styles.removeButton}
               onPress={() => handleRemove(uri)}
             >
-              <Text style={styles.removeButtonText}>✕</Text>
+              <X size={12} color={colors.white} strokeWidth={2.5} />
             </TouchableOpacity>
             {index === 0 && (
               <View style={styles.mainBadge}>
@@ -101,7 +102,7 @@ export function PhotoUpload({
               <ActivityIndicator color={colors.primary} />
             ) : (
               <>
-                <Text style={styles.addIcon}>+</Text>
+                <Plus size={32} color={colors.primary} strokeWidth={1.5} />
                 <Text style={styles.addText}>Add Photo</Text>
               </>
             )}
@@ -156,9 +157,6 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     alignItems: 'center',
   },
-  photoPlaceholderText: {
-    fontSize: 32,
-  },
   photoIndex: {
     position: 'absolute',
     bottom: spacing.sm,
@@ -179,11 +177,6 @@ const styles = StyleSheet.create({
     backgroundColor: colors.error,
     justifyContent: 'center',
     alignItems: 'center',
-  },
-  removeButtonText: {
-    color: colors.white,
-    fontSize: 12,
-    fontWeight: '600',
   },
   mainBadge: {
     position: 'absolute',
@@ -209,11 +202,6 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     alignItems: 'center',
     backgroundColor: colors.surface,
-  },
-  addIcon: {
-    fontSize: 32,
-    color: colors.primary,
-    marginBottom: spacing.xs,
   },
   addText: {
     fontSize: typography.sizes.xs,


### PR DESCRIPTION
## Summary

- Replaced 9 emoji instances across 4 files with proper Lucide icons from `lucide-react-native`
- Zero emojis remain in any UI-facing code

## Changes

**`app/app/onboarding.tsx`**
- Replaced 4 slide icons: `💝` Heart, `🛡️` Shield, `💰` DollarSign, `✨` Sparkles
- Switched from `string` icon field to typed `LucideIcon` component pattern
- Cleaned up the `OnboardingSlide` type dependency (local `SlideItem` interface)

**`app/src/components/FilterModal.tsx`**
- Replaced `✕` close button text with `X` icon
- Replaced `⭐` rating label text with inline `Star` icon (filled)

**`app/src/components/Avatar.tsx`**
- Replaced `✓` checkmark text in verified badge with `Check` icon

**`app/src/components/PhotoUpload.tsx`**
- Replaced `📷` camera placeholder text with `Camera` icon
- Replaced `✕` remove button text with `X` icon
- Replaced `+` add button text with `Plus` icon
- Removed now-unused text styles: `photoPlaceholderText`, `removeButtonText`, `addIcon`

## Test plan

- [ ] Launch app and verify onboarding slides render icons (Heart/Shield/DollarSign/Sparkles) correctly
- [ ] Open filter modal and verify close button shows X icon, rating shows star icon
- [ ] Check avatar component with `verified=true` shows checkmark icon in badge
- [ ] Check photo upload component shows camera icon in slots, X icon on remove, Plus on add button

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>