### PR TITLE
fix: resolve URL route collision bugs (BUG-046, BUG-047)

### DIFF
--- a/backend/daterabbit-api/src/messages/messages.controller.ts
+++ b/backend/daterabbit-api/src/messages/messages.controller.ts
@@ -32,6 +32,13 @@ export class MessagesController {
     return { count };
   }
 
+  // Explicit route declared before @Get(':userId') wildcard to prevent route collision
+  @Get('unread')
+  async getUnreadMessages(@Request() req) {
+    const count = await this.messagesService.getUnreadCount(req.user.id);
+    return { unread: count };
+  }
+
   @Get(':userId')
   async getMessages(
     @Param('userId') otherUserId: string,

--- a/backend/daterabbit-api/src/users/users.controller.ts
+++ b/backend/daterabbit-api/src/users/users.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Put, Delete, Body, UseGuards, Request, Param, BadRequestException } from '@nestjs/common';
+import { Controller, Get, Put, Delete, Body, UseGuards, Request, Param, BadRequestException, ParseUUIDPipe } from '@nestjs/common';
 import { UsersService } from './users.service';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { UpdateUserDto } from './dto/update-user.dto';
@@ -60,7 +60,7 @@ export class UsersController {
   }
 
   @Get(':id')
-  async getUserById(@Param('id') id: string) {
+  async getUserById(@Param('id', ParseUUIDPipe) id: string) {
     const user = await this.usersService.findById(id);
     if (!user) {
       return { error: 'User not found' };


### PR DESCRIPTION
## Summary

- **BUG-046**: `GET /api/messages/unread` was returning 500 because the string `unread` was being matched by the `@Get(':userId')` wildcard route and passed to the service as a user ID. Fixed by adding an explicit `@Get('unread')` route **before** the parameterized route in `MessagesController`.

- **BUG-047**: `GET /api/users/settings` was returning 500 because the string `settings` was being matched by `@Get(':id')` and passed to `findById()`. Fixed by adding `ParseUUIDPipe` to the `:id` parameter — non-UUID values like `settings` now correctly return **400 Bad Request** instead of crashing the service.

## Files changed

- `backend/daterabbit-api/src/messages/messages.controller.ts`
- `backend/daterabbit-api/src/users/users.controller.ts`

## Test plan

- [ ] `GET /api/messages/unread` returns `{ unread: <count> }` (not 500)
- [ ] `GET /api/messages/<valid-uuid>` still works correctly
- [ ] `GET /api/users/settings` returns 400 Bad Request (not 500)
- [ ] `GET /api/users/<valid-uuid>` still returns the user's public profile