### PR TITLE
fix: BUG-044 real profile stats + BUG-045 Notifications onPress

### DIFF
--- a/app/app/(tabs)/male/profile.tsx
+++ b/app/app/(tabs)/male/profile.tsx
@@ -1,8 +1,9 @@
-import React from 'react';
+import React, { useEffect, useMemo } from 'react';
 import { View, Text, StyleSheet, ScrollView, TouchableOpacity } from 'react-native';
 import { router } from 'expo-router';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useAuthStore } from '../../../src/store/authStore';
+import { useBookingsStore } from '../../../src/store/bookingsStore';
 import { Card } from '../../../src/components/Card';
 import { UserImage } from '../../../src/components/UserImage';
 import { Button } from '../../../src/components/Button';
@@ -13,15 +14,23 @@ export default function MaleProfileScreen() {
   const insets = useSafeAreaInsets();
   const { colors } = useTheme();
   const { user, logout } = useAuthStore();
+  const { bookings, fetchMyBookings } = useBookingsStore();
+
+  useEffect(() => {
+    fetchMyBookings('past');
+  }, []);
+
+  // Compute stats from past bookings fetched from the API
+  const stats = useMemo(() => {
+    const pastBookings = bookings.filter((b) => b.status === 'completed');
+    const totalDates = pastBookings.length;
+    const totalSpent = pastBookings.reduce((sum, b) => sum + (b.total ?? 0), 0);
+    return { totalDates, totalSpent };
+  }, [bookings]);
 
   const handleLogout = () => {
     logout();
     router.replace('/(auth)/welcome');
-  };
-
-  const stats = {
-    totalDates: 8,
-    totalSpent: 1850,
   };
 
   return (
@@ -79,7 +88,7 @@ export default function MaleProfileScreen() {
           <View style={[styles.divider, { backgroundColor: colors.border }]} />
           <MenuItem icon="receipt" label="Transaction History" colors={colors} />
           <View style={[styles.divider, { backgroundColor: colors.border }]} />
-          <MenuItem icon="bell" label="Notifications" colors={colors} />
+          <MenuItem icon="bell" label="Notifications" onPress={() => router.push('/settings/notifications')} colors={colors} />
         </Card>
       </View>
 


### PR DESCRIPTION
## Summary

- **BUG-044**: Removed hardcoded `stats = { totalDates: 8, totalSpent: 1850 }`. The screen now calls `fetchMyBookings('past')` on mount via `useEffect` and computes real values with `useMemo`: `totalDates` = count of bookings with `status === 'completed'`, `totalSpent` = sum of their `total` field.
- **BUG-045**: Added `onPress={() => router.push('/settings/notifications')}` to the Notifications menu item, wiring it up to the existing `/settings/notifications` screen.

## Test plan

- [ ] Open the male profile screen — Dates and Total Spent should reflect actual completed bookings from the API (0 if none exist) instead of hardcoded 8 / $1850
- [ ] Tap Notifications in the Account section — should navigate to the notifications settings screen
- [ ] Sign out / sign in with a fresh account — stats should show 0 dates and $0 spent
- [ ] Complete a booking as a seeker — stats should update after returning to profile