### PR TITLE
fix: Neo-Brutalism brand compliance - borderRadius 8px and offset shadows

### DIFF
--- a/app/app/(tabs)/male/bookings.tsx
+++ b/app/app/(tabs)/male/bookings.tsx
@@ -292,7 +292,7 @@ const styles = StyleSheet.create({
     flex: 1,
     paddingVertical: spacing.sm,
     alignItems: 'center',
-    borderRadius: borderRadius.lg,
+    borderRadius: borderRadius.sm,
     minHeight: 44,
     justifyContent: 'center',
   },
@@ -341,7 +341,7 @@ const styles = StyleSheet.create({
   statusBadge: {
     paddingHorizontal: spacing.sm,
     paddingVertical: 2,
-    borderRadius: borderRadius.full,
+    borderRadius: borderRadius.sm,
     marginTop: spacing.xs,
   },
   statusText: {

--- a/app/app/(tabs)/male/profile.tsx
+++ b/app/app/(tabs)/male/profile.tsx
@@ -8,7 +8,7 @@ import { Card } from '../../../src/components/Card';
 import { UserImage } from '../../../src/components/UserImage';
 import { Button } from '../../../src/components/Button';
 import { Icon } from '../../../src/components/Icon';
-import { useTheme, spacing, typography, borderRadius } from '../../../src/constants/theme';
+import { useTheme, spacing, typography, borderRadius, shadows } from '../../../src/constants/theme';
 
 export default function MaleProfileScreen() {
   const insets = useSafeAreaInsets();
@@ -75,6 +75,7 @@ export default function MaleProfileScreen() {
           onPress={() => router.push('/settings/edit-profile')}
           variant="outline"
           fullWidth
+          style={shadows.md}
           testID="profile-edit-btn"
         />
       </Card>


### PR DESCRIPTION
## Summary

- **bookings.tsx**: Tab chips (Upcoming/Pending/Past) `borderRadius` changed from `lg` (12px) to `sm` (8px) per spec
- **bookings.tsx**: Status badge `borderRadius` changed from `full` (9999px pill) to `sm` (8px)
- **profile.tsx**: Edit Profile button gains Neo-Brutalism offset shadow (`shadows.md`: 4x4 solid black)

## Notes

- `browse.tsx` filter chips already used `borderRadius.sm` (8px) - no change needed
- `otp.tsx` digit boxes already used `borderRadius.md` (8px) - no change needed
- Only `borderRadius` values and shadow addition changed; no colors, fonts, or other styles modified

## Test plan

- [ ] Open Bookings screen - tab chips should have squared-off corners (8px radius, not pill-shaped)
- [ ] Check booking status badges - should be rectangular, not pill-shaped
- [ ] Open Profile screen - Edit Profile button should have a 4px offset black shadow