### PR TITLE
fix: New filter chip and pagination offset in companions API (BUG-048, BUG-049)

### DIFF
--- a/app/app/(tabs)/male/browse.tsx
+++ b/app/app/(tabs)/male/browse.tsx
@@ -73,7 +73,7 @@ export default function BrowseScreen() {
   // Fetch companions when location or filters change
   const fetchCompanions = useCallback(async () => {
     try {
-      const sortByMap: Record<string, 'recommended' | 'price_low' | 'price_high' | 'rating' | 'distance'> = {
+      const sortByMap: Record<string, 'recommended' | 'price_low' | 'price_high' | 'rating' | 'distance' | 'new'> = {
         'recommended': 'recommended',
         'price_low': 'price_low',
         'price_high': 'price_high',
@@ -81,13 +81,16 @@ export default function BrowseScreen() {
         'distance': 'distance',
       };
 
-      let sortBy = sortByMap[appliedFilters.sortBy] || 'recommended';
+      let sortBy: 'recommended' | 'price_low' | 'price_high' | 'rating' | 'distance' | 'new' =
+        sortByMap[appliedFilters.sortBy] || 'recommended';
 
       // Quick filter overrides
       if (activeFilter === 'Nearby' && userLocation) {
         sortBy = 'distance';
       } else if (activeFilter === 'Top Rated') {
         sortBy = 'rating';
+      } else if (activeFilter === 'New') {
+        sortBy = 'new';
       }
 
       const response = await companionsApi.search({

--- a/app/src/services/api.ts
+++ b/app/src/services/api.ts
@@ -162,7 +162,7 @@ export interface SearchCompanionsParams {
   minRating?: number;
   ageMin?: number;
   ageMax?: number;
-  sortBy?: 'recommended' | 'price_low' | 'price_high' | 'rating' | 'distance';
+  sortBy?: 'recommended' | 'price_low' | 'price_high' | 'rating' | 'distance' | 'new';
   latitude?: number;
   longitude?: number;
   search?: string;

--- a/backend/daterabbit-api/src/companions/companions.controller.ts
+++ b/backend/daterabbit-api/src/companions/companions.controller.ts
@@ -17,7 +17,17 @@ export class CompanionsController {
     @Query('search') search?: string,
     @Query('limit') limit?: string,
     @Query('offset') offset?: string,
+    @Query('page') page?: string,
   ) {
+    const parsedLimit = limit ? parseInt(limit) : 20;
+    // Support both page-based and offset-based pagination.
+    // page takes precedence over offset when both are provided.
+    const parsedOffset = page
+      ? (parseInt(page) - 1) * parsedLimit
+      : offset
+        ? parseInt(offset)
+        : 0;
+
     const { companions, total } = await this.usersService.getCompanions({
       priceMin: priceMin ? parseFloat(priceMin) : undefined,
       priceMax: priceMax ? parseFloat(priceMax) : undefined,
@@ -27,9 +37,11 @@ export class CompanionsController {
       ageMax: ageMax ? parseInt(ageMax) : undefined,
       sortBy,
       search,
-      limit: limit ? parseInt(limit) : 20,
-      offset: offset ? parseInt(offset) : 0,
+      limit: parsedLimit,
+      offset: parsedOffset,
     });
+
+    const currentPage = page ? parseInt(page) : Math.floor(parsedOffset / parsedLimit) + 1;
 
     return {
       companions: companions.map((c) => ({
@@ -45,6 +57,8 @@ export class CompanionsController {
         isVerified: c.isVerified || false,
       })),
       total,
+      page: currentPage,
+      totalPages: Math.ceil(total / parsedLimit),
     };
   }
 

--- a/backend/daterabbit-api/src/users/users.service.ts
+++ b/backend/daterabbit-api/src/users/users.service.ts
@@ -104,6 +104,10 @@ export class UsersService {
       case 'rating':
         query.orderBy('user.rating', 'DESC');
         break;
+      case 'new':
+        // Show newest companions first (recently joined)
+        query.orderBy('user.createdAt', 'DESC');
+        break;
       default:
         query.orderBy('user.createdAt', 'DESC');
     }


### PR DESCRIPTION
## Summary

- **BUG-048**: The "New" quick filter chip in Browse had no backend effect. Added `sortBy=new` handling to the companions API — when active, the backend orders results by `createdAt DESC` (newest companions first).
- **BUG-049**: The `page` query parameter was not converting to a proper SQL offset. The controller now computes `skip = (page - 1) * limit` correctly. Response also now includes `page` and `totalPages` fields.

## Changes

**Backend (`backend/daterabbit-api/src/`)**

- `companions/companions.controller.ts`: Added `@Query('page')` param; compute `parsedOffset = (page - 1) * limit` when `page` is provided. Returns `page` and `totalPages` in response.
- `users/users.service.ts`: Added `case 'new':` to the sort switch — orders by `user.createdAt DESC`.

**Frontend (`app/`)**

- `app/(tabs)/male/browse.tsx`: Added `else if (activeFilter === 'New') { sortBy = 'new'; }` to the quick filter override block.
- `src/services/api.ts`: Extended `SearchCompanionsParams.sortBy` union type to include `'new'`.

## Test plan

- [ ] Tap "All" chip -> companions load (default sort)
- [ ] Tap "New" chip -> API receives `sortBy=new` -> newest companions appear first
- [ ] Tap "Top Rated" chip -> API receives `sortBy=rating`
- [ ] Tap "Nearby" chip (with location) -> API receives `sortBy=distance`
- [ ] Pagination: page=2 returns second page of results (offset = limit, not 0)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>