### PR TITLE
fix: allow authenticated non-tab routes in NavigationGuard (BUG-042)

### DIFF
--- a/.ai/bugs.json
+++ b/.ai/bugs.json
@@ -360,13 +360,15 @@
       "id": "BUG-042",
       "type": "bug",
       "severity": "low",
-      "status": "open",
+      "status": "pending_review",
       "title": "Reviews page unreachable on web via direct navigation",
       "description": "The /reviews/[id] route renders briefly then redirects to /male. Stack screen navigation from tabs broken. Reviews UI exists but is inaccessible.",
       "platform": "web",
       "created": "2026-03-03",
+      "fixed": "2026-03-04T23:30:00Z",
+      "fix": "Added NON_TAB_AUTH_ROUTES constant in _layout.tsx NavigationGuard listing all authenticated non-tab routes (booking, chat, profile, reviews, payment, stripe, favorites, settings). Guard now skips redirect when currentSegment is in this list.",
       "found_by": "uc-test",
-      "screens": ["app/app/reviews/[id].tsx"]
+      "screens": ["app/app/reviews/[id].tsx", "app/app/_layout.tsx"]
     },
     {
       "id": "BUG-043",

--- a/app/app/_layout.tsx
+++ b/app/app/_layout.tsx
@@ -16,6 +16,18 @@ import { StripeProvider } from '../src/components/StripeProvider';
 // Public routes accessible without authentication
 const PUBLIC_ROUTES = ['terms', 'privacy', 'onboarding', '(auth)'];
 
+// Authenticated non-tab routes — accessible to fully verified users outside (tabs)
+const NON_TAB_AUTH_ROUTES = [
+  'booking',
+  'chat',
+  'profile',
+  'reviews',
+  'payment',
+  'stripe',
+  'favorites',
+  'settings',
+];
+
 function NavigationGuard() {
   const { isAuthenticated, hasSeenOnboarding, user } = useAuthStore();
   const router = useRouter();
@@ -81,7 +93,8 @@ function NavigationGuard() {
 
     // Fully authenticated and verified
     const inTabsGroup = currentSegment === '(tabs)';
-    if (!inTabsGroup) {
+    const inNonTabAuthRoute = NON_TAB_AUTH_ROUTES.includes(currentSegment);
+    if (!inTabsGroup && !inNonTabAuthRoute) {
       const isCompanion = user?.role === 'companion';
       router.replace(isCompanion ? '/(tabs)/female' : '/(tabs)/male');
     }


### PR DESCRIPTION
## Summary

- Root cause: `NavigationGuard` in `app/app/_layout.tsx` redirected all fully-authenticated verified users to `/(tabs)/male` or `/(tabs)/female` if `segments[0]` was not `(tabs)`. This made `/reviews/[id]` (and all other non-tab auth routes) unreachable on web via direct navigation — they would flash briefly then redirect.

- Fix: Added a `NON_TAB_AUTH_ROUTES` constant listing all top-level route segments that authenticated users may access outside of `(tabs)`: `booking`, `chat`, `profile`, `reviews`, `payment`, `stripe`, `favorites`, `settings`. The guard now skips the redirect when `currentSegment` matches any of these.

- Updated `BUG-042` in `.ai/bugs.json` to `pending_review`.

## Test plan

- [ ] Log in as a seeker on web
- [ ] Navigate to a companion profile and tap "See All Reviews" — should go to `/reviews/[companionId]` and stay there (not redirect)
- [ ] Navigate directly to `/reviews/some-id` in browser URL bar while logged in — should render the reviews screen, not redirect to `/male`
- [ ] Verify existing non-tab routes still work: `/chat/[id]`, `/profile/[id]`, `/booking/[id]`, `/favorites`, `/settings/edit-profile`
- [ ] Verify unauthenticated users navigating to `/reviews/[id]` are still redirected to auth

🤖 Generated with [Claude Code](https://claude.com/claude-code)