### PR TITLE
fix: cancelled future bookings shown in correct tab

### DIFF
--- a/backend/daterabbit-api/src/bookings/bookings.service.ts
+++ b/backend/daterabbit-api/src/bookings/bookings.service.ts
@@ -67,14 +67,16 @@ export class BookingsService {
 
     switch (filter) {
       case 'upcoming':
-        // Confirmed/paid bookings with a future date
+        // Confirmed/paid bookings with a future date + cancelled bookings with future dates
         seekerWhere = [
           { seekerId: userId, status: BookingStatus.CONFIRMED, dateTime: MoreThanOrEqual(now) },
           { seekerId: userId, status: BookingStatus.PAID, dateTime: MoreThanOrEqual(now) },
+          { seekerId: userId, status: BookingStatus.CANCELLED, dateTime: MoreThanOrEqual(now) },
         ];
         companionWhere = [
           { companionId: userId, status: BookingStatus.CONFIRMED, dateTime: MoreThanOrEqual(now) },
           { companionId: userId, status: BookingStatus.PAID, dateTime: MoreThanOrEqual(now) },
+          { companionId: userId, status: BookingStatus.CANCELLED, dateTime: MoreThanOrEqual(now) },
         ];
         break;
 
@@ -84,16 +86,16 @@ export class BookingsService {
         break;
 
       case 'past':
-        // Completed/cancelled bookings OR any booking with a past date
+        // Completed/cancelled bookings with past dates OR confirmed/paid bookings with past dates
         seekerWhere = [
           { seekerId: userId, status: BookingStatus.COMPLETED },
-          { seekerId: userId, status: BookingStatus.CANCELLED },
+          { seekerId: userId, status: BookingStatus.CANCELLED, dateTime: LessThan(now) },
           { seekerId: userId, dateTime: LessThan(now), status: BookingStatus.CONFIRMED },
           { seekerId: userId, dateTime: LessThan(now), status: BookingStatus.PAID },
         ];
         companionWhere = [
           { companionId: userId, status: BookingStatus.COMPLETED },
-          { companionId: userId, status: BookingStatus.CANCELLED },
+          { companionId: userId, status: BookingStatus.CANCELLED, dateTime: LessThan(now) },
           { companionId: userId, dateTime: LessThan(now), status: BookingStatus.CONFIRMED },
           { companionId: userId, dateTime: LessThan(now), status: BookingStatus.PAID },
         ];


### PR DESCRIPTION
## Summary
- Cancelled bookings with future dates now appear in the **Upcoming** tab instead of the Past tab
- The **Past** tab now only shows cancelled bookings whose `dateTime` is in the past
- Applies to both seeker and companion perspectives

## Root Cause
The `past` filter matched ALL cancelled bookings regardless of date. A booking for May 2026 that was cancelled would incorrectly appear in the Past tab.

## Fix
- `past` case: added `dateTime: LessThan(now)` constraint to cancelled bookings
- `upcoming` case: added `{ status: CANCELLED, dateTime: MoreThanOrEqual(now) }` so future-dated cancelled bookings surface in Upcoming with their cancelled status visible

## Test plan
- [ ] Cancel a booking with a future date — verify it appears in Upcoming, not Past
- [ ] Cancel a booking with a past date — verify it appears in Past, not Upcoming
- [ ] Completed bookings still appear in Past
- [ ] Confirmed/paid future bookings still appear in Upcoming