### PR TITLE
feat: block/report user endpoints

### DIFF
--- a/backend/daterabbit-api/src/auth/guards/optional-jwt-auth.guard.ts
+++ b/backend/daterabbit-api/src/auth/guards/optional-jwt-auth.guard.ts
@@ -1,0 +1,14 @@
+import { Injectable, ExecutionContext } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+
+@Injectable()
+export class OptionalJwtAuthGuard extends AuthGuard('jwt') {
+  canActivate(context: ExecutionContext) {
+    return super.canActivate(context);
+  }
+
+  handleRequest(err: any, user: any) {
+    // Don't throw on missing/invalid token, just return null
+    return user || null;
+  }
+}

--- a/backend/daterabbit-api/src/companions/companions.controller.ts
+++ b/backend/daterabbit-api/src/companions/companions.controller.ts
@@ -1,12 +1,15 @@
-import { Controller, Get, Query, Param, NotFoundException } from '@nestjs/common';
+import { Controller, Get, Query, Param, NotFoundException, UseGuards, Request } from '@nestjs/common';
 import { UsersService } from '../users/users.service';
+import { OptionalJwtAuthGuard } from '../auth/guards/optional-jwt-auth.guard';
 
 @Controller('companions')
 export class CompanionsController {
   constructor(private usersService: UsersService) {}
 
+  @UseGuards(OptionalJwtAuthGuard)
   @Get()
   async searchCompanions(
+    @Request() req,
     @Query('priceMin') priceMin?: string,
     @Query('priceMax') priceMax?: string,
     @Query('maxDistance') maxDistance?: string,
@@ -28,6 +31,12 @@ export class CompanionsController {
         ? parseInt(offset)
         : 0;
 
+    // Exclude blocked users if the requester is authenticated
+    let excludeUserIds: string[] | undefined;
+    if (req.user?.id) {
+      excludeUserIds = await this.usersService.getBlockedUserIds(req.user.id);
+    }
+
     const { companions, total } = await this.usersService.getCompanions({
       priceMin: priceMin ? parseFloat(priceMin) : undefined,
       priceMax: priceMax ? parseFloat(priceMax) : undefined,
@@ -39,6 +48,7 @@ export class CompanionsController {
       search,
       limit: parsedLimit,
       offset: parsedOffset,
+      excludeUserIds,
     });
 
     const currentPage = page ? parseInt(page) : Math.floor(parsedOffset / parsedLimit) + 1;

--- a/backend/daterabbit-api/src/messages/messages.controller.ts
+++ b/backend/daterabbit-api/src/messages/messages.controller.ts
@@ -1,29 +1,44 @@
 import { Controller, Get, Post, Body, Param, Query, UseGuards, Request, HttpException, HttpStatus } from '@nestjs/common';
 import { MessagesService } from './messages.service';
+import { UsersService } from '../users/users.service';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 
 @Controller('messages')
 @UseGuards(JwtAuthGuard)
 export class MessagesController {
-  constructor(private messagesService: MessagesService) {}
+  constructor(
+    private messagesService: MessagesService,
+    private usersService: UsersService,
+  ) {}
 
   @Get('conversations')
   async getConversations(@Request() req) {
-    const conversations = await this.messagesService.getConversations(req.user.id);
-    return conversations.map((c) => ({
-      id: c.id,
-      otherUser: c.user1Id === req.user.id ? {
-        id: c.user2.id,
-        name: c.user2.name,
-        photos: c.user2.photos,
-      } : {
-        id: c.user1.id,
-        name: c.user1.name,
-        photos: c.user1.photos,
-      },
-      lastMessageAt: c.lastMessageAt,
-      lastMessage: c.lastMessage?.content || null,
-    }));
+    const [conversations, blockedIds] = await Promise.all([
+      this.messagesService.getConversations(req.user.id),
+      this.usersService.getBlockedUserIds(req.user.id),
+    ]);
+
+    const blockedSet = new Set(blockedIds);
+
+    return conversations
+      .filter((c) => {
+        const otherId = c.user1Id === req.user.id ? c.user2Id : c.user1Id;
+        return !blockedSet.has(otherId);
+      })
+      .map((c) => ({
+        id: c.id,
+        otherUser: c.user1Id === req.user.id ? {
+          id: c.user2.id,
+          name: c.user2.name,
+          photos: c.user2.photos,
+        } : {
+          id: c.user1.id,
+          name: c.user1.name,
+          photos: c.user1.photos,
+        },
+        lastMessageAt: c.lastMessageAt,
+        lastMessage: c.lastMessage?.content || null,
+      }));
   }
 
   @Get('unread-count')
@@ -77,6 +92,15 @@ export class MessagesController {
     }
     if (body.content.length > 5000) {
       throw new HttpException('Message too long (max 5000 chars)', HttpStatus.BAD_REQUEST);
+    }
+
+    // Prevent messaging blocked users (in either direction)
+    const [blockedByMe, blockedByThem] = await Promise.all([
+      this.usersService.isBlocked(req.user.id, receiverId),
+      this.usersService.isBlocked(receiverId, req.user.id),
+    ]);
+    if (blockedByMe || blockedByThem) {
+      throw new HttpException('Cannot send message to this user', HttpStatus.FORBIDDEN);
     }
 
     const message = await this.messagesService.sendMessage(

--- a/backend/daterabbit-api/src/messages/messages.module.ts
+++ b/backend/daterabbit-api/src/messages/messages.module.ts
@@ -3,9 +3,13 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { Message, Conversation } from './entities/message.entity';
 import { MessagesService } from './messages.service';
 import { MessagesController } from './messages.controller';
+import { UsersModule } from '../users/users.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Message, Conversation])],
+  imports: [
+    TypeOrmModule.forFeature([Message, Conversation]),
+    UsersModule,
+  ],
   providers: [MessagesService],
   controllers: [MessagesController],
   exports: [MessagesService],

--- a/backend/daterabbit-api/src/users/entities/blocked-user.entity.ts
+++ b/backend/daterabbit-api/src/users/entities/blocked-user.entity.ts
@@ -1,0 +1,28 @@
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, CreateDateColumn, JoinColumn } from 'typeorm';
+import { User } from './user.entity';
+
+@Entity('blocked_users')
+export class BlockedUser {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  blockerId: string;
+
+  @ManyToOne(() => User)
+  @JoinColumn({ name: 'blockerId' })
+  blocker: User;
+
+  @Column()
+  blockedId: string;
+
+  @ManyToOne(() => User)
+  @JoinColumn({ name: 'blockedId' })
+  blocked: User;
+
+  @Column({ nullable: true })
+  reason: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}

--- a/backend/daterabbit-api/src/users/entities/user-report.entity.ts
+++ b/backend/daterabbit-api/src/users/entities/user-report.entity.ts
@@ -1,0 +1,34 @@
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, CreateDateColumn, JoinColumn } from 'typeorm';
+import { User } from './user.entity';
+
+@Entity('user_reports')
+export class UserReport {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  reporterId: string;
+
+  @ManyToOne(() => User)
+  @JoinColumn({ name: 'reporterId' })
+  reporter: User;
+
+  @Column()
+  reportedId: string;
+
+  @ManyToOne(() => User)
+  @JoinColumn({ name: 'reportedId' })
+  reported: User;
+
+  @Column()
+  reason: string;
+
+  @Column({ nullable: true })
+  description: string;
+
+  @Column({ default: 'pending' })
+  status: string; // pending, reviewed, dismissed
+
+  @CreateDateColumn()
+  createdAt: Date;
+}

--- a/backend/daterabbit-api/src/users/users.controller.ts
+++ b/backend/daterabbit-api/src/users/users.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Put, Delete, Body, UseGuards, Request, Param, BadRequestException, ParseUUIDPipe } from '@nestjs/common';
+import { Controller, Get, Post, Put, Delete, Body, UseGuards, Request, Param, BadRequestException, ParseUUIDPipe } from '@nestjs/common';
 import { UsersService } from './users.service';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { UpdateUserDto } from './dto/update-user.dto';
@@ -57,6 +57,52 @@ export class UsersController {
   async deleteAccount(@Request() req) {
     await this.usersService.deactivateAccount(req.user.id);
     return { success: true, message: 'Account deactivated' };
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Get('blocked')
+  async getBlockedUsers(@Request() req) {
+    const blocked = await this.usersService.getBlockedUsers(req.user.id);
+    return blocked.map((b) => ({
+      id: b.blocked.id,
+      name: b.blocked.name,
+      blockedAt: b.createdAt,
+    }));
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Post(':id/block')
+  async blockUser(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Request() req,
+    @Body() body: { reason?: string },
+  ) {
+    await this.usersService.blockUser(req.user.id, id, body?.reason);
+    return { success: true };
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Delete(':id/block')
+  async unblockUser(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Request() req,
+  ) {
+    await this.usersService.unblockUser(req.user.id, id);
+    return { success: true };
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Post(':id/report')
+  async reportUser(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Request() req,
+    @Body() body: { reason: string; description?: string },
+  ) {
+    if (!body?.reason) {
+      throw new BadRequestException('Reason is required');
+    }
+    await this.usersService.reportUser(req.user.id, id, body.reason, body.description);
+    return { success: true, message: 'Report submitted successfully' };
   }
 
   @Get(':id')

--- a/backend/daterabbit-api/src/users/users.module.ts
+++ b/backend/daterabbit-api/src/users/users.module.ts
@@ -1,11 +1,13 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { User } from './entities/user.entity';
+import { BlockedUser } from './entities/blocked-user.entity';
+import { UserReport } from './entities/user-report.entity';
 import { UsersService } from './users.service';
 import { UsersController } from './users.controller';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([User])],
+  imports: [TypeOrmModule.forFeature([User, BlockedUser, UserReport])],
   providers: [UsersService],
   controllers: [UsersController],
   exports: [UsersService],

--- a/backend/daterabbit-api/src/users/users.service.ts
+++ b/backend/daterabbit-api/src/users/users.service.ts
@@ -1,13 +1,19 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, BadRequestException, ConflictException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { Repository, In } from 'typeorm';
 import { User, UserRole } from './entities/user.entity';
+import { BlockedUser } from './entities/blocked-user.entity';
+import { UserReport } from './entities/user-report.entity';
 
 @Injectable()
 export class UsersService {
   constructor(
     @InjectRepository(User)
     private usersRepository: Repository<User>,
+    @InjectRepository(BlockedUser)
+    private blockedUsersRepository: Repository<BlockedUser>,
+    @InjectRepository(UserReport)
+    private userReportsRepository: Repository<UserReport>,
   ) {}
 
   async findByEmail(email: string): Promise<User | null> {
@@ -66,11 +72,16 @@ export class UsersService {
     search?: string;
     limit?: number;
     offset?: number;
+    excludeUserIds?: string[];
   }): Promise<{ companions: User[]; total: number }> {
     const query = this.usersRepository
       .createQueryBuilder('user')
       .where('user.role = :role', { role: UserRole.COMPANION })
       .andWhere('user.isActive = true');
+
+    if (filters.excludeUserIds && filters.excludeUserIds.length > 0) {
+      query.andWhere('user.id NOT IN (:...excludeIds)', { excludeIds: filters.excludeUserIds });
+    }
 
     if (filters.priceMin) {
       query.andWhere('user.hourlyRate >= :priceMin', { priceMin: filters.priceMin });
@@ -119,5 +130,70 @@ export class UsersService {
       .getMany();
 
     return { companions, total };
+  }
+
+  // --- Block / Unblock ---
+
+  async blockUser(blockerId: string, blockedId: string, reason?: string): Promise<void> {
+    if (blockerId === blockedId) {
+      throw new BadRequestException('You cannot block yourself');
+    }
+
+    const existing = await this.blockedUsersRepository.findOne({
+      where: { blockerId, blockedId },
+    });
+    if (existing) {
+      throw new ConflictException('User is already blocked');
+    }
+
+    const blocked = this.blockedUsersRepository.create({
+      blockerId,
+      blockedId,
+      reason,
+    });
+    await this.blockedUsersRepository.save(blocked);
+  }
+
+  async unblockUser(blockerId: string, blockedId: string): Promise<void> {
+    await this.blockedUsersRepository.delete({ blockerId, blockedId });
+  }
+
+  async getBlockedUsers(userId: string): Promise<BlockedUser[]> {
+    return this.blockedUsersRepository.find({
+      where: { blockerId: userId },
+      relations: ['blocked'],
+      order: { createdAt: 'DESC' },
+    });
+  }
+
+  async getBlockedUserIds(userId: string): Promise<string[]> {
+    const blocked = await this.blockedUsersRepository.find({
+      where: { blockerId: userId },
+      select: ['blockedId'],
+    });
+    return blocked.map((b) => b.blockedId);
+  }
+
+  async isBlocked(userId: string, targetId: string): Promise<boolean> {
+    const count = await this.blockedUsersRepository.count({
+      where: { blockerId: userId, blockedId: targetId },
+    });
+    return count > 0;
+  }
+
+  // --- Report ---
+
+  async reportUser(reporterId: string, reportedId: string, reason: string, description?: string): Promise<UserReport> {
+    if (reporterId === reportedId) {
+      throw new BadRequestException('You cannot report yourself');
+    }
+
+    const report = this.userReportsRepository.create({
+      reporterId,
+      reportedId,
+      reason,
+      description,
+    });
+    return this.userReportsRepository.save(report);
   }
 }


### PR DESCRIPTION
## Summary
- Add `POST /users/:id/block`, `DELETE /users/:id/block`, `GET /users/blocked`, `POST /users/:id/report` endpoints
- Create `BlockedUser` and `UserReport` entities with auto-created DB tables (TypeORM synchronize)
- Filter blocked users from companion browse results (via OptionalJwtAuthGuard)
- Filter blocked users from conversations list and prevent messaging in both directions

## Test plan
- [ ] Verify block/unblock/report endpoints return correct responses
- [ ] Verify blocked users are excluded from companion browse when authenticated
- [ ] Verify blocked users are hidden from conversations list
- [ ] Verify sending a message to a blocked user returns 403
- [ ] Verify self-block and self-report return 400
- [ ] Verify duplicate block returns 409

Generated with [Claude Code](https://claude.com/claude-code)