### PR TITLE
fix: remove db backup cron from CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -214,31 +214,6 @@ jobs:
           echo "=== Nginx config files ==="
           ls -la /etc/nginx/sites-enabled/ 2>/dev/null | grep -i date || echo "No daterabbit in sites-enabled"
 
-      - name: Setup database backup cron
-        run: |
-          # Create backup directory
-          sudo mkdir -p /var/backups/daterabbit
-          sudo chown postgres:postgres /var/backups/daterabbit
-          # Create backup script
-          cat > /tmp/daterabbit-backup.sh << 'BEOF'
-          #!/bin/bash
-          BACKUP_DIR="/var/backups/daterabbit"
-          DATE=$(date +%Y%m%d_%H%M%S)
-          sudo -u postgres pg_dump daterabbit | gzip > "$BACKUP_DIR/daterabbit_${DATE}.gz"
-          # Keep only last 7 days of backups
-          find "$BACKUP_DIR" -name "daterabbit_*.gz" -mtime +7 -delete
-          echo "Backup completed: daterabbit_${DATE}.gz"
-          BEOF
-          sudo mv /tmp/daterabbit-backup.sh /usr/local/bin/daterabbit-backup.sh
-          sudo chmod +x /usr/local/bin/daterabbit-backup.sh
-          # Add cron job if not exists
-          if ! sudo crontab -l 2>/dev/null | grep -q daterabbit-backup; then
-            (sudo crontab -l 2>/dev/null; echo "0 3 * * * /usr/local/bin/daterabbit-backup.sh >> /var/log/daterabbit-backup.log 2>&1") | sudo crontab -
-            echo "Cron job added: daily backup at 3 AM"
-          else
-            echo "Backup cron already exists"
-          fi
-
       - name: Run seed script
         if: github.event.inputs.seed == 'yes'
         run: |


### PR DESCRIPTION
## Summary
- Removes the database backup cron step from CI that was failing due to github-runner lacking sudo permissions for mkdir/crontab
- Database backups should be configured manually on the server by an admin

## Context
PR #62 introduced a backup cron step that uses `sudo mkdir` and `sudo crontab` which the github-runner user doesn't have permission for. This caused all subsequent deploys (#62, #63, #64) to fail.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>