### PR TITLE
fix: add role badge, bio, and prominent location to seeker profile (BUG-030)

### DIFF
--- a/app/app/(tabs)/male/profile.tsx
+++ b/app/app/(tabs)/male/profile.tsx
@@ -48,8 +48,18 @@ export default function MaleProfileScreen() {
             showVerified={user?.isVerified}
           />
           <View style={styles.profileInfo}>
+            <View style={styles.badgeRow}>
+              <View style={[styles.roleBadge, { backgroundColor: colors.badge.purple.bg, borderColor: colors.badge.purple.border }]}>
+                <Text style={[styles.roleBadgeText, { color: colors.badge.purple.text }]}>SEEKER</Text>
+              </View>
+            </View>
             <Text style={[styles.profileName, { color: colors.text }]}>{user?.name}, {user?.age}</Text>
-            <Text style={[styles.profileLocation, { color: colors.textSecondary }]}>{user?.location}</Text>
+            {user?.location ? (
+              <View style={styles.locationRow}>
+                <Icon name="map-pin" size={13} color={colors.primary} />
+                <Text style={[styles.profileLocation, { color: colors.text }]}> {user.location}</Text>
+              </View>
+            ) : null}
             <View style={styles.ratingRow}>
               <Icon name="star" size={14} color={colors.accent} />
               <Text style={[styles.ratingValue, { color: colors.text }]}> {user?.rating}</Text>
@@ -57,6 +67,12 @@ export default function MaleProfileScreen() {
             </View>
           </View>
         </View>
+
+        {user?.bio ? (
+          <View style={[styles.bioBox, { backgroundColor: colors.surface, borderColor: colors.border }]}>
+            <Text style={[styles.bioText, { color: colors.text }]}>{user.bio}</Text>
+          </View>
+        ) : null}
 
         <View style={[styles.statsRow, { backgroundColor: colors.surface }]}>
           <View style={styles.statItem}>
@@ -176,14 +192,44 @@ const styles = StyleSheet.create({
     marginLeft: spacing.md,
     justifyContent: 'center',
   },
+  badgeRow: {
+    flexDirection: 'row',
+    marginBottom: spacing.xs,
+  },
+  roleBadge: {
+    paddingHorizontal: spacing.sm,
+    paddingVertical: 3,
+    borderRadius: borderRadius.sm,
+    borderWidth: 2,
+  },
+  roleBadgeText: {
+    fontFamily: typography.fonts.heading,
+    fontSize: typography.sizes.xs,
+    letterSpacing: 1,
+  },
   profileName: {
     fontFamily: typography.fonts.bodySemiBold,
     fontSize: typography.sizes.lg,
   },
+  locationRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginTop: 3,
+  },
   profileLocation: {
+    fontFamily: typography.fonts.bodySemiBold,
+    fontSize: typography.sizes.sm,
+  },
+  bioBox: {
+    borderWidth: 2,
+    borderRadius: borderRadius.sm,
+    padding: spacing.md,
+    marginBottom: spacing.md,
+  },
+  bioText: {
     fontFamily: typography.fonts.body,
     fontSize: typography.sizes.sm,
-    marginTop: 2,
+    lineHeight: 20,
   },
   ratingRow: {
     flexDirection: 'row',


### PR DESCRIPTION
## Summary
- Adds a **SEEKER** role badge (Neo-Brutalism purple badge with 2px bold border) above the name in the profile card header
- Adds a **bio section** (bordered box, shown only when `user.bio` is present) between the profile header and stats row
- Makes **location more prominent**: now uses `map-pin` icon + bold `bodySemiBold` font with `colors.text` instead of secondary color

## Changes
- File: `app/app/(tabs)/male/profile.tsx`
- Added styles: `badgeRow`, `roleBadge`, `roleBadgeText`, `locationRow`, `bioBox`, `bioText`
- Updated `profileLocation` style: font changed to `bodySemiBold`, color changed to `colors.text`
- All existing menu items and stats preserved unchanged

## Test plan
- [ ] Open seeker profile tab — SEEKER badge visible above name
- [ ] If user has bio — bio box rendered below the avatar row
- [ ] If user has no bio — bio box not rendered (conditional render)
- [ ] Location shows map-pin icon with bold text
- [ ] All existing menu sections (Account, Preferences, Support) unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)