### PR TITLE
feat: Brevo transactional emails for OTP and booking confirmations

### DIFF
--- a/backend/daterabbit-api/src/auth/auth.module.ts
+++ b/backend/daterabbit-api/src/auth/auth.module.ts
@@ -6,11 +6,13 @@ import { AuthService } from './auth.service';
 import { AuthController } from './auth.controller';
 import { JwtStrategy } from './strategies/jwt.strategy';
 import { UsersModule } from '../users/users.module';
+import { EmailModule } from '../email/email.module';
 
 @Module({
   imports: [
     UsersModule,
     PassportModule,
+    EmailModule,
     JwtModule.registerAsync({
       imports: [ConfigModule],
       inject: [ConfigService],

--- a/backend/daterabbit-api/src/auth/auth.service.ts
+++ b/backend/daterabbit-api/src/auth/auth.service.ts
@@ -4,23 +4,19 @@ import { ConfigService } from '@nestjs/config';
 import * as crypto from 'crypto';
 import { UsersService } from '../users/users.service';
 import { User, UserRole } from '../users/entities/user.entity';
+import { EmailService } from '../email/email.service';
 
 @Injectable()
 export class AuthService {
-  private brevoApiKey: string;
-  private senderEmail: string;
-
   constructor(
     private usersService: UsersService,
     private jwtService: JwtService,
     private configService: ConfigService,
-  ) {
-    this.brevoApiKey = this.configService.get('BREVO_API_KEY') || '';
-    this.senderEmail = this.configService.get('BREVO_SENDER_EMAIL') || 'noreply@diagrams.love';
-  }
+    private emailService: EmailService,
+  ) {}
 
   generateOtp(): string {
-    // DEV режим: фиксированный код для быстрого тестирования
+    // DEV mode: fixed code for quick testing
     if (this.configService.get('DEV_AUTH') === 'true') {
       return '000000';
     }
@@ -44,44 +40,13 @@ export class AuthService {
 
     await this.usersService.setOtp(user.id, otp, expiresAt);
 
-    // DEV режим: пропускаем отправку email
+    // DEV mode: skip email sending
     if (this.configService.get('DEV_AUTH') === 'true') {
-      console.log(`🔧 DEV MODE: OTP для ${email} → 000000 (email не отправляется)`);
+      console.log(`DEV MODE: OTP for ${email} -> 000000 (email not sent)`);
       return { success: true, isNewUser };
     }
 
-    // Send email via Brevo API
-    try {
-      const response = await fetch('https://api.brevo.com/v3/smtp/email', {
-        method: 'POST',
-        headers: {
-          'accept': 'application/json',
-          'api-key': this.brevoApiKey,
-          'content-type': 'application/json',
-        },
-        body: JSON.stringify({
-          sender: { email: this.senderEmail, name: 'DateRabbit' },
-          to: [{ email }],
-          subject: 'Your DateRabbit Verification Code',
-          htmlContent: `
-            <div style="font-family: 'Space Grotesk', Arial, sans-serif; max-width: 400px; margin: 0 auto; padding: 24px; background: #F4F0EA; border: 3px solid #000; border-radius: 12px;">
-              <h2 style="color: #FF2A5F; font-weight: 700; text-transform: uppercase; margin-bottom: 16px;">DateRabbit</h2>
-              <p style="color: #000; font-size: 16px;">Your verification code is:</p>
-              <h1 style="font-size: 36px; letter-spacing: 8px; color: #000; font-weight: 700; background: #fff; border: 3px solid #000; border-radius: 8px; padding: 16px; text-align: center; margin: 16px 0;">${otp}</h1>
-              <p style="color: #666; font-size: 14px;">This code expires in 10 minutes.</p>
-            </div>
-          `,
-        }),
-      });
-      if (response.ok) {
-        console.log(`OTP sent to ${email}`);
-      } else {
-        console.error('Brevo API error:', await response.text());
-      }
-    } catch (error) {
-      console.error('Failed to send email:', error);
-      // Continue anyway for development
-    }
+    await this.emailService.sendOtp(email, otp);
 
     return { success: true, isNewUser };
   }

--- a/backend/daterabbit-api/src/bookings/bookings.controller.ts
+++ b/backend/daterabbit-api/src/bookings/bookings.controller.ts
@@ -128,7 +128,7 @@ export class BookingsController {
         HttpStatus.BAD_REQUEST,
       );
     }
-    const updated = await this.bookingsService.updateStatus(id, BookingStatus.CONFIRMED);
+    const updated = await this.bookingsService.confirm(id);
     return this.formatBooking(updated);
   }
 

--- a/backend/daterabbit-api/src/bookings/bookings.module.ts
+++ b/backend/daterabbit-api/src/bookings/bookings.module.ts
@@ -4,9 +4,10 @@ import { Booking } from './entities/booking.entity';
 import { BookingsService } from './bookings.service';
 import { BookingsController } from './bookings.controller';
 import { UsersModule } from '../users/users.module';
+import { EmailModule } from '../email/email.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Booking]), UsersModule],
+  imports: [TypeOrmModule.forFeature([Booking]), UsersModule, EmailModule],
   providers: [BookingsService],
   controllers: [BookingsController],
   exports: [BookingsService],

--- a/backend/daterabbit-api/src/bookings/bookings.service.ts
+++ b/backend/daterabbit-api/src/bookings/bookings.service.ts
@@ -3,6 +3,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository, MoreThanOrEqual, LessThan } from 'typeorm';
 import { Booking, BookingStatus, ActivityType } from './entities/booking.entity';
 import { UsersService } from '../users/users.service';
+import { EmailService } from '../email/email.service';
 
 @Injectable()
 export class BookingsService {
@@ -10,6 +11,7 @@ export class BookingsService {
     @InjectRepository(Booking)
     private bookingsRepository: Repository<Booking>,
     private usersService: UsersService,
+    private emailService: EmailService,
   ) {}
 
   async create(data: {
@@ -130,6 +132,48 @@ export class BookingsService {
     }
     await this.bookingsRepository.update(id, update);
     return this.findById(id);
+  }
+
+  async confirm(id: string): Promise<Booking | null> {
+    const booking = await this.updateStatus(id, BookingStatus.CONFIRMED);
+    if (!booking) return null;
+
+    // Send confirmation emails to both parties (fire-and-forget)
+    const emailData = {
+      dateTime: booking.dateTime,
+      duration: booking.duration,
+      activity: booking.activity,
+      location: booking.location,
+      totalPrice: booking.totalPrice,
+    };
+
+    if (booking.seeker?.email) {
+      this.emailService
+        .sendBookingConfirmedToSeeker({
+          seekerEmail: booking.seeker.email,
+          seekerName: booking.seeker.name || 'there',
+          companionName: booking.companion?.name || 'your companion',
+          ...emailData,
+        })
+        .catch(() => {
+          // Email errors must not break the booking confirmation
+        });
+    }
+
+    if (booking.companion?.email) {
+      this.emailService
+        .sendBookingConfirmedToCompanion({
+          companionEmail: booking.companion.email,
+          companionName: booking.companion.name || 'there',
+          seekerName: booking.seeker?.name || 'your guest',
+          ...emailData,
+        })
+        .catch(() => {
+          // Email errors must not break the booking confirmation
+        });
+    }
+
+    return booking;
   }
 
   async getUpcoming(userId: string): Promise<Booking[]> {

--- a/backend/daterabbit-api/src/email/email.module.ts
+++ b/backend/daterabbit-api/src/email/email.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { EmailService } from './email.service';
+
+@Module({
+  imports: [ConfigModule],
+  providers: [EmailService],
+  exports: [EmailService],
+})
+export class EmailModule {}

--- a/backend/daterabbit-api/src/email/email.service.ts
+++ b/backend/daterabbit-api/src/email/email.service.ts
@@ -1,0 +1,297 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+
+interface SendEmailOptions {
+  to: string;
+  subject: string;
+  htmlContent: string;
+}
+
+@Injectable()
+export class EmailService {
+  private readonly logger = new Logger(EmailService.name);
+  private readonly brevoApiKey: string;
+  private readonly senderEmail: string;
+  private readonly senderName = 'DateRabbit';
+
+  constructor(private configService: ConfigService) {
+    this.brevoApiKey = this.configService.get<string>('BREVO_API_KEY') || '';
+    this.senderEmail =
+      this.configService.get<string>('BREVO_SENDER_EMAIL') || 'noreply@daterabbit.com';
+  }
+
+  async sendEmail(options: SendEmailOptions): Promise<boolean> {
+    if (!this.brevoApiKey) {
+      this.logger.warn('BREVO_API_KEY not set — email not sent');
+      return false;
+    }
+
+    try {
+      const response = await fetch('https://api.brevo.com/v3/smtp/email', {
+        method: 'POST',
+        headers: {
+          accept: 'application/json',
+          'api-key': this.brevoApiKey,
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          sender: { email: this.senderEmail, name: this.senderName },
+          to: [{ email: options.to }],
+          subject: options.subject,
+          htmlContent: options.htmlContent,
+        }),
+      });
+
+      if (response.ok) {
+        this.logger.log(`Email sent to ${options.to}: ${options.subject}`);
+        return true;
+      } else {
+        const errorText = await response.text();
+        this.logger.error(`Brevo API error (${response.status}): ${errorText}`);
+        return false;
+      }
+    } catch (error) {
+      this.logger.error(`Failed to send email to ${options.to}: ${error}`);
+      return false;
+    }
+  }
+
+  async sendOtp(email: string, otp: string): Promise<boolean> {
+    return this.sendEmail({
+      to: email,
+      subject: 'Your DateRabbit Verification Code',
+      htmlContent: this.buildOtpTemplate(otp),
+    });
+  }
+
+  async sendBookingConfirmedToSeeker(data: {
+    seekerEmail: string;
+    seekerName: string;
+    companionName: string;
+    dateTime: Date;
+    duration: number;
+    activity: string;
+    location?: string;
+    totalPrice: number;
+  }): Promise<boolean> {
+    const dateStr = data.dateTime.toLocaleDateString('en-US', {
+      weekday: 'long',
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    });
+    const timeStr = data.dateTime.toLocaleTimeString('en-US', {
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+
+    return this.sendEmail({
+      to: data.seekerEmail,
+      subject: `Booking Confirmed — ${data.companionName} on ${dateStr}`,
+      htmlContent: this.buildBookingConfirmedSeekerTemplate({
+        ...data,
+        dateStr,
+        timeStr,
+      }),
+    });
+  }
+
+  async sendBookingConfirmedToCompanion(data: {
+    companionEmail: string;
+    companionName: string;
+    seekerName: string;
+    dateTime: Date;
+    duration: number;
+    activity: string;
+    location?: string;
+    totalPrice: number;
+  }): Promise<boolean> {
+    const dateStr = data.dateTime.toLocaleDateString('en-US', {
+      weekday: 'long',
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    });
+    const timeStr = data.dateTime.toLocaleTimeString('en-US', {
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+
+    return this.sendEmail({
+      to: data.companionEmail,
+      subject: `New Booking Confirmed — ${data.seekerName} on ${dateStr}`,
+      htmlContent: this.buildBookingConfirmedCompanionTemplate({
+        ...data,
+        dateStr,
+        timeStr,
+      }),
+    });
+  }
+
+  // ─── HTML Templates ─────────────────────────────────────────────────────────
+
+  private buildOtpTemplate(otp: string): string {
+    return `
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Your DateRabbit Code</title>
+</head>
+<body style="margin:0;padding:0;background:#F4F0EA;font-family:Arial,sans-serif;">
+  <table width="100%" cellpadding="0" cellspacing="0" style="background:#F4F0EA;padding:40px 20px;">
+    <tr>
+      <td align="center">
+        <table width="400" cellpadding="0" cellspacing="0" style="background:#F4F0EA;border:3px solid #000;border-radius:12px;padding:32px;">
+          <tr>
+            <td>
+              <p style="margin:0 0 4px 0;font-size:11px;font-weight:700;letter-spacing:3px;text-transform:uppercase;color:#FF2A5F;">DateRabbit</p>
+              <h1 style="margin:0 0 24px 0;font-size:24px;font-weight:700;color:#000;">Your verification code</h1>
+              <p style="margin:0 0 16px 0;font-size:15px;color:#333;">Enter this code in the app to sign in:</p>
+              <div style="background:#fff;border:3px solid #000;border-radius:8px;padding:20px;text-align:center;margin:0 0 24px 0;">
+                <span style="font-size:40px;font-weight:700;letter-spacing:10px;color:#000;">${otp}</span>
+              </div>
+              <p style="margin:0 0 8px 0;font-size:13px;color:#666;">This code expires in <strong>10 minutes</strong>.</p>
+              <p style="margin:0;font-size:13px;color:#666;">If you didn't request this, you can safely ignore this email.</p>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>
+    `.trim();
+  }
+
+  private buildBookingConfirmedSeekerTemplate(data: {
+    seekerName: string;
+    companionName: string;
+    dateStr: string;
+    timeStr: string;
+    duration: number;
+    activity: string;
+    location?: string;
+    totalPrice: number;
+  }): string {
+    const activityFormatted =
+      data.activity.charAt(0).toUpperCase() + data.activity.slice(1).toLowerCase();
+    const locationRow = data.location
+      ? `<tr><td style="padding:6px 0;font-size:14px;color:#555;">Location</td><td style="padding:6px 0;font-size:14px;color:#000;font-weight:600;">${data.location}</td></tr>`
+      : '';
+
+    return `
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Booking Confirmed</title>
+</head>
+<body style="margin:0;padding:0;background:#F4F0EA;font-family:Arial,sans-serif;">
+  <table width="100%" cellpadding="0" cellspacing="0" style="background:#F4F0EA;padding:40px 20px;">
+    <tr>
+      <td align="center">
+        <table width="480" cellpadding="0" cellspacing="0" style="background:#F4F0EA;border:3px solid #000;border-radius:12px;padding:32px;">
+          <tr>
+            <td>
+              <p style="margin:0 0 4px 0;font-size:11px;font-weight:700;letter-spacing:3px;text-transform:uppercase;color:#FF2A5F;">DateRabbit</p>
+              <h1 style="margin:0 0 8px 0;font-size:24px;font-weight:700;color:#000;">Booking Confirmed!</h1>
+              <p style="margin:0 0 24px 0;font-size:15px;color:#333;">Hi ${data.seekerName}, your date with <strong>${data.companionName}</strong> is confirmed.</p>
+
+              <div style="background:#fff;border:3px solid #000;border-radius:8px;padding:20px;margin:0 0 24px 0;">
+                <table width="100%" cellpadding="0" cellspacing="0">
+                  <tr>
+                    <td colspan="2" style="padding:0 0 12px 0;font-size:12px;font-weight:700;letter-spacing:2px;text-transform:uppercase;color:#FF2A5F;border-bottom:2px solid #000;">Date Details</td>
+                  </tr>
+                  <tr><td style="padding:6px 0;font-size:14px;color:#555;">With</td><td style="padding:6px 0;font-size:14px;color:#000;font-weight:600;">${data.companionName}</td></tr>
+                  <tr><td style="padding:6px 0;font-size:14px;color:#555;">Date</td><td style="padding:6px 0;font-size:14px;color:#000;font-weight:600;">${data.dateStr}</td></tr>
+                  <tr><td style="padding:6px 0;font-size:14px;color:#555;">Time</td><td style="padding:6px 0;font-size:14px;color:#000;font-weight:600;">${data.timeStr}</td></tr>
+                  <tr><td style="padding:6px 0;font-size:14px;color:#555;">Duration</td><td style="padding:6px 0;font-size:14px;color:#000;font-weight:600;">${data.duration} hour${data.duration !== 1 ? 's' : ''}</td></tr>
+                  <tr><td style="padding:6px 0;font-size:14px;color:#555;">Activity</td><td style="padding:6px 0;font-size:14px;color:#000;font-weight:600;">${activityFormatted}</td></tr>
+                  ${locationRow}
+                  <tr>
+                    <td style="padding:12px 0 6px 0;font-size:14px;color:#555;border-top:2px solid #eee;margin-top:8px;">Total</td>
+                    <td style="padding:12px 0 6px 0;font-size:18px;color:#000;font-weight:700;border-top:2px solid #eee;">$${Number(data.totalPrice).toFixed(2)}</td>
+                  </tr>
+                </table>
+              </div>
+
+              <p style="margin:0;font-size:13px;color:#666;">Open the DateRabbit app to view full details or message your companion.</p>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>
+    `.trim();
+  }
+
+  private buildBookingConfirmedCompanionTemplate(data: {
+    companionName: string;
+    seekerName: string;
+    dateStr: string;
+    timeStr: string;
+    duration: number;
+    activity: string;
+    location?: string;
+    totalPrice: number;
+  }): string {
+    const activityFormatted =
+      data.activity.charAt(0).toUpperCase() + data.activity.slice(1).toLowerCase();
+    const locationRow = data.location
+      ? `<tr><td style="padding:6px 0;font-size:14px;color:#555;">Location</td><td style="padding:6px 0;font-size:14px;color:#000;font-weight:600;">${data.location}</td></tr>`
+      : '';
+
+    return `
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>New Booking Confirmed</title>
+</head>
+<body style="margin:0;padding:0;background:#F4F0EA;font-family:Arial,sans-serif;">
+  <table width="100%" cellpadding="0" cellspacing="0" style="background:#F4F0EA;padding:40px 20px;">
+    <tr>
+      <td align="center">
+        <table width="480" cellpadding="0" cellspacing="0" style="background:#F4F0EA;border:3px solid #000;border-radius:12px;padding:32px;">
+          <tr>
+            <td>
+              <p style="margin:0 0 4px 0;font-size:11px;font-weight:700;letter-spacing:3px;text-transform:uppercase;color:#FF2A5F;">DateRabbit</p>
+              <h1 style="margin:0 0 8px 0;font-size:24px;font-weight:700;color:#000;">New Booking!</h1>
+              <p style="margin:0 0 24px 0;font-size:15px;color:#333;">Hi ${data.companionName}, you confirmed a date with <strong>${data.seekerName}</strong>.</p>
+
+              <div style="background:#fff;border:3px solid #000;border-radius:8px;padding:20px;margin:0 0 24px 0;">
+                <table width="100%" cellpadding="0" cellspacing="0">
+                  <tr>
+                    <td colspan="2" style="padding:0 0 12px 0;font-size:12px;font-weight:700;letter-spacing:2px;text-transform:uppercase;color:#FF2A5F;border-bottom:2px solid #000;">Booking Details</td>
+                  </tr>
+                  <tr><td style="padding:6px 0;font-size:14px;color:#555;">Guest</td><td style="padding:6px 0;font-size:14px;color:#000;font-weight:600;">${data.seekerName}</td></tr>
+                  <tr><td style="padding:6px 0;font-size:14px;color:#555;">Date</td><td style="padding:6px 0;font-size:14px;color:#000;font-weight:600;">${data.dateStr}</td></tr>
+                  <tr><td style="padding:6px 0;font-size:14px;color:#555;">Time</td><td style="padding:6px 0;font-size:14px;color:#000;font-weight:600;">${data.timeStr}</td></tr>
+                  <tr><td style="padding:6px 0;font-size:14px;color:#555;">Duration</td><td style="padding:6px 0;font-size:14px;color:#000;font-weight:600;">${data.duration} hour${data.duration !== 1 ? 's' : ''}</td></tr>
+                  <tr><td style="padding:6px 0;font-size:14px;color:#555;">Activity</td><td style="padding:6px 0;font-size:14px;color:#000;font-weight:600;">${activityFormatted}</td></tr>
+                  ${locationRow}
+                  <tr>
+                    <td style="padding:12px 0 6px 0;font-size:14px;color:#555;border-top:2px solid #eee;">Your earnings</td>
+                    <td style="padding:12px 0 6px 0;font-size:18px;color:#000;font-weight:700;border-top:2px solid #eee;">$${Number(data.totalPrice).toFixed(2)}</td>
+                  </tr>
+                </table>
+              </div>
+
+              <p style="margin:0;font-size:13px;color:#666;">Open the DateRabbit app to message your guest or view booking details.</p>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>
+    `.trim();
+  }
+}


### PR DESCRIPTION
## Summary

- Extracts email sending into a dedicated EmailService (src/email/) with clean Brevo API integration via fetch
- Removes inline Brevo API calls from AuthService — now delegates to EmailService.sendOtp()
- Adds BookingsService.confirm() which triggers confirmation emails to both seeker and companion when a booking is confirmed
- Adds EmailModule (importable from any other NestJS module)
- Graceful fallback: if BREVO_API_KEY is not set, logs a warning and continues without crashing

## Behavior

- DEV_AUTH=true (staging): OTP skipped (hardcoded 000000), booking emails sent if key present
- DEV_AUTH=false (production): OTP sent via Brevo, booking confirmation emails sent via Brevo

## Files changed

- src/email/email.service.ts — new EmailService
- src/email/email.module.ts — new EmailModule
- src/auth/auth.service.ts — refactored to use EmailService
- src/auth/auth.module.ts — imports EmailModule
- src/bookings/bookings.service.ts — injects EmailService, adds confirm() method
- src/bookings/bookings.module.ts — imports EmailModule
- src/bookings/bookings.controller.ts — calls bookingsService.confirm() on confirm endpoint

## Test plan

- [ ] Staging: OTP still works with 000000, no email errors in logs
- [ ] Production: real OTP email delivered after setting BREVO_API_KEY
- [ ] Confirm a booking: both seeker and companion receive confirmation emails
- [ ] Missing BREVO_API_KEY: no 500 errors, warning logged only