### PR TITLE
fix: BUG-053 companion profile hero blank on web

### DIFF
--- a/app/app/profile/[id].tsx
+++ b/app/app/profile/[id].tsx
@@ -5,14 +5,16 @@ import {
   StyleSheet,
   ScrollView,
   TouchableOpacity,
-  Dimensions,
+  useWindowDimensions,
   Modal,
   TextInput,
   ActivityIndicator,
+  Platform,
 } from 'react-native';
 import { router, useLocalSearchParams } from 'expo-router';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import * as Location from 'expo-location';
+import { Image } from 'expo-image';
 import { Button } from '../../src/components/Button';
 import { showAlert, showConfirm } from '../../src/utils/alert';
 import { Card } from '../../src/components/Card';
@@ -22,7 +24,8 @@ import { useTheme, spacing, typography, borderRadius, colors } from '../../src/c
 import { useFavoritesStore } from '../../src/store/favoritesStore';
 import { usersApi, companionsApi, CompanionDetail } from '../../src/services/api';
 
-const { width } = Dimensions.get('window');
+// Max width for photo container — prevents giant hero on wide screens
+const MAX_PHOTO_WIDTH = 430;
 
 interface ProfileData {
   id: string;
@@ -64,6 +67,8 @@ export default function ProfileViewScreen() {
   const { id } = useLocalSearchParams<{ id: string }>();
   const insets = useSafeAreaInsets();
   const { colors } = useTheme();
+  const { width: windowWidth } = useWindowDimensions();
+  const photoWidth = Platform.OS === 'web' ? Math.min(windowWidth, MAX_PHOTO_WIDTH) : windowWidth;
   
   const [profile, setProfile] = useState<ProfileData>(defaultProfile);
   const [isLoading, setIsLoading] = useState(true);
@@ -233,17 +238,19 @@ export default function ProfileViewScreen() {
     <View style={[styles.container, { backgroundColor: colors.background }]}>
       <ScrollView style={styles.scrollView} showsVerticalScrollIndicator={false}>
         {/* Photo Gallery */}
-        <View style={styles.photoContainer}>
+        <View style={[styles.photoContainer, { width: photoWidth, height: photoWidth * 1.1, alignSelf: 'center' }]}>
           {profile.photos.length > 0 ? (
             <TouchableOpacity
               activeOpacity={0.9}
               onPress={() => setPhotoModalVisible(true)}
               style={styles.photoWrapper}
             >
-              <View style={[styles.photo, { backgroundColor: colors.surface }]}>
-                <UserImage name={profile.name} size={120} />
-                <Text style={[styles.photoText, { color: colors.text }]}>{profile.name}</Text>
-              </View>
+              <Image
+                source={{ uri: profile.photos[currentPhotoIndex]?.url }}
+                style={styles.heroImage}
+                contentFit="cover"
+                transition={250}
+              />
 
               {/* Photo navigation dots */}
               <View style={styles.photoDots}>
@@ -553,8 +560,17 @@ export default function ProfileViewScreen() {
           >
             <Icon name="x" size={24} color={colors.white} />
           </TouchableOpacity>
-          <View style={[styles.modalPhoto, { backgroundColor: colors.surface }]}>
-            <UserImage name={profile.name} size={200} />
+          <View style={[styles.modalPhoto, { width: photoWidth - spacing.xl * 2, height: photoWidth - spacing.xl * 2, backgroundColor: colors.surface }]}>
+            {profile.photos[currentPhotoIndex]?.url ? (
+              <Image
+                source={{ uri: profile.photos[currentPhotoIndex].url }}
+                style={styles.modalImage}
+                contentFit="contain"
+                transition={250}
+              />
+            ) : (
+              <UserImage name={profile.name} size={200} />
+            )}
             <Text style={[styles.modalPhotoText, { color: colors.textSecondary }]}>
               Photo {currentPhotoIndex + 1} of {profile.photos.length}
             </Text>
@@ -586,12 +602,14 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   photoContainer: {
-    width: width,
-    height: width * 1.1,
     position: 'relative',
   },
   photoWrapper: {
     flex: 1,
+  },
+  heroImage: {
+    width: '100%',
+    height: '100%',
   },
   photo: {
     flex: 1,
@@ -978,11 +996,14 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   modalPhoto: {
-    width: width - spacing.xl * 2,
-    height: width - spacing.xl * 2,
     borderRadius: borderRadius.lg,
     justifyContent: 'center',
     alignItems: 'center',
+    overflow: 'hidden',
+  },
+  modalImage: {
+    width: '100%',
+    height: '100%',
   },
   modalPhotoText: {
     fontFamily: typography.fonts.body,


### PR DESCRIPTION
## Summary
- Cap hero photo container width at 430px on web (was using full viewport width e.g. 1920px, causing ~2112px blank hero)
- Render actual companion photos via expo-image `Image` instead of `UserImage` with only name (was always showing initials)
- Fix photo modal to also use capped dimensions and actual photo URLs

## Root cause
`Dimensions.get('window').width` was called at module level and used for `photoContainer` style. On web this returns the full browser width (1920px), giving `height: 1920 * 1.1 = 2112px`. Additionally, `UserImage` was called without the `uri` prop, so even though photos existed in the API response, only the initials placeholder was shown.

## Test plan
- [ ] Open companion profile on web at staging
- [ ] Verify hero section is ~430px wide (not full viewport) and shows actual photo
- [ ] Verify photo navigation dots and arrows still work
- [ ] Verify photo modal shows actual images
- [ ] Verify mobile layout is unchanged (uses full window width as before)