### PR TITLE
fix: show companion photo on Book a Date screen

### DIFF
--- a/app/app/booking/[id].tsx
+++ b/app/app/booking/[id].tsx
@@ -168,7 +168,7 @@ export default function BookingScreen() {
         {/* Companion Info */}
         <Card style={styles.companionCard}>
           <View style={styles.companionInfo}>
-            <UserImage name={companion?.name ?? ''} size={56} />
+            <UserImage uri={companion?.photos?.[0]?.url ?? companion?.primaryPhoto} name={companion?.name ?? ''} size={56} />
             <View style={styles.companionDetails}>
               <Text style={[styles.companionName, { color: colors.text }]}>{companion?.name}</Text>
               <Text style={[styles.companionRate, { color: colors.primary }]}>${companion?.hourlyRate}/hour</Text>


### PR DESCRIPTION
## Summary
- Fix BUG-059: Companion photo missing on Book a Date screen
- Pass `companion.photos[0].url` (with `primaryPhoto` fallback) to the `UserImage` component's `uri` prop
- Previously only `name` and `size` were passed, so `UserImage` always rendered the placeholder icon

## Test plan
- [ ] Open a companion profile from Browse page, tap "Book a Date"
- [ ] Verify the companion's actual photo appears in the booking card (not a grey placeholder)
- [ ] Verify fallback to initials if companion has no photos