### PR TITLE
fix: use real user location instead of hardcoded San Francisco (BUG-058)

### DIFF
--- a/app/app/(tabs)/male/profile.tsx
+++ b/app/app/(tabs)/male/profile.tsx
@@ -86,7 +86,7 @@ export default function MaleProfileScreen() {
       <View style={styles.section}>
         <Text style={[styles.sectionTitle, { color: colors.text }]}>Preferences</Text>
         <Card>
-          <MenuItem icon="map-pin" label="Location" value="San Francisco" colors={colors} />
+          <MenuItem icon="map-pin" label="Location" value={user?.location || 'Not set'} colors={colors} />
           <View style={[styles.divider, { backgroundColor: colors.border }]} />
           <MenuItem icon="cake" label="Age Range" value="25-35" colors={colors} />
           <View style={[styles.divider, { backgroundColor: colors.border }]} />


### PR DESCRIPTION
## Summary
- Profile Preferences section was showing hardcoded "San Francisco" for Location instead of the user's actual location
- Now reads `user.location` from authStore profile data
- Falls back to "Not set" if user has no location configured

## Test plan
- [ ] Log in as a user with a known location (e.g., New York) and verify the Profile Preferences section shows that location
- [ ] Log in as a user with no location set and verify it shows "Not set"

Generated with [Claude Code](https://claude.com/claude-code)