### PR TITLE
fix: require JWT auth on register endpoint (BUG-685)

### DIFF
--- a/backend/daterabbit-api/src/auth/auth.controller.ts
+++ b/backend/daterabbit-api/src/auth/auth.controller.ts
@@ -1,6 +1,7 @@
-import { Controller, Post, Body, HttpException, HttpStatus, Request } from '@nestjs/common';
+import { Controller, Post, Body, HttpException, HttpStatus, Request, UseGuards } from '@nestjs/common';
 import { Throttle } from '@nestjs/throttler';
 import { AuthService } from './auth.service';
+import { JwtAuthGuard } from './guards/jwt-auth.guard';
 import { UserRole } from '../users/entities/user.entity';
 
 @Controller('auth')
@@ -58,10 +59,10 @@ export class AuthController {
   }
 
   @Post('register')
+  @UseGuards(JwtAuthGuard)
   async register(
     @Request() req,
     @Body() body: {
-      email?: string;
       name: string;
       role: 'seeker' | 'companion';
       age?: number;
@@ -74,24 +75,8 @@ export class AuthController {
       throw new HttpException('Name is required', HttpStatus.BAD_REQUEST);
     }
 
-    // If JWT provided, use email from token (more secure)
-    // Otherwise require email in body (frontend compat)
-    let email: string;
-    const authHeader = req.headers?.authorization;
-    if (authHeader?.startsWith('Bearer ')) {
-      const decoded = this.authService.validateToken(authHeader.slice(7));
-      if (decoded) {
-        email = decoded.email;
-      } else if (body.email) {
-        email = body.email.toLowerCase();
-      } else {
-        throw new HttpException('Authentication required', HttpStatus.UNAUTHORIZED);
-      }
-    } else if (body.email) {
-      email = body.email.toLowerCase();
-    } else {
-      throw new HttpException('Email is required', HttpStatus.BAD_REQUEST);
-    }
+    // Email always from JWT token (set by JwtAuthGuard)
+    const email: string = req.user.email;
 
     const result = await this.authService.register({
       email,


### PR DESCRIPTION
## Summary
- **CRITICAL security fix**: `/auth/register` endpoint allowed account takeover by accepting email from request body without authentication
- Added `JwtAuthGuard` to require valid JWT token on `/auth/register`
- Email is now extracted exclusively from the verified JWT, never from request body

## Test plan
- [ ] Verify `POST /auth/register` without Bearer token returns 401
- [ ] Verify `POST /auth/register` with valid JWT completes registration using token email
- [ ] Verify existing auth flow (start -> verify -> register) still works end-to-end

Generated with [Claude Code](https://claude.com/claude-code)