### PR TITLE
fix: Stripe escrow capture/refund + race condition check

### DIFF
--- a/backend/daterabbit-api/src/bookings/bookings.controller.ts
+++ b/backend/daterabbit-api/src/bookings/bookings.controller.ts
@@ -1,12 +1,16 @@
 import { Controller, Get, Post, Put, Body, Param, Query, UseGuards, Request, HttpException, HttpStatus } from '@nestjs/common';
 import { BookingsService } from './bookings.service';
+import { PaymentsService } from '../payments/payments.service';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { BookingStatus, ActivityType } from './entities/booking.entity';
 
 @Controller('bookings')
 @UseGuards(JwtAuthGuard)
 export class BookingsController {
-  constructor(private bookingsService: BookingsService) {}
+  constructor(
+    private bookingsService: BookingsService,
+    private paymentsService: PaymentsService,
+  ) {}
 
   @Post()
   async createBooking(
@@ -148,12 +152,20 @@ export class BookingsController {
       throw new HttpException('Cannot cancel a completed booking', HttpStatus.BAD_REQUEST);
     }
     const updated = await this.bookingsService.updateStatus(id, BookingStatus.CANCELLED, body.reason);
+    // Release Stripe hold or refund (fire-and-forget, don't fail the cancel if Stripe fails)
+    this.paymentsService.cancelPaymentHold(id).catch(err =>
+      console.error('Stripe cancel error for booking', id, err),
+    );
     return this.formatBooking(updated);
   }
 
   @Put(':id/complete')
   async completeBooking(@Param('id') id: string, @Request() req) {
     const updated = await this.bookingsService.complete(id, req.user.id);
+    // Capture the Stripe hold (fire-and-forget)
+    this.paymentsService.capturePayment(id).catch(err =>
+      console.error('Stripe capture error for booking', id, err),
+    );
     return this.formatBooking(updated);
   }
 

--- a/backend/daterabbit-api/src/bookings/bookings.module.ts
+++ b/backend/daterabbit-api/src/bookings/bookings.module.ts
@@ -5,9 +5,10 @@ import { BookingsService } from './bookings.service';
 import { BookingsController } from './bookings.controller';
 import { UsersModule } from '../users/users.module';
 import { EmailModule } from '../email/email.module';
+import { PaymentsModule } from '../payments/payments.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Booking]), UsersModule, EmailModule],
+  imports: [TypeOrmModule.forFeature([Booking]), UsersModule, EmailModule, PaymentsModule],
   providers: [BookingsService],
   controllers: [BookingsController],
   exports: [BookingsService],

--- a/backend/daterabbit-api/src/bookings/bookings.service.ts
+++ b/backend/daterabbit-api/src/bookings/bookings.service.ts
@@ -27,6 +27,31 @@ export class BookingsService {
     if (!companion) {
       throw new HttpException('Companion not found', HttpStatus.NOT_FOUND);
     }
+
+    // Check for overlapping bookings for this companion (race condition guard)
+    const bookingStart = new Date(data.dateTime);
+    const bookingEnd = new Date(bookingStart.getTime() + data.duration * 60 * 60 * 1000);
+
+    const existing = await this.bookingsRepository
+      .createQueryBuilder('b')
+      .where('b.companionId = :companionId', { companionId: data.companionId })
+      .andWhere('b.status IN (:...statuses)', {
+        statuses: [BookingStatus.PENDING, BookingStatus.CONFIRMED, BookingStatus.PAID],
+      })
+      .andWhere('b.dateTime < :end', { end: bookingEnd })
+      .andWhere(
+        "b.dateTime + (b.duration * interval '1 hour') > :start",
+        { start: bookingStart },
+      )
+      .getOne();
+
+    if (existing) {
+      throw new HttpException(
+        'Companion already has a booking at that time',
+        HttpStatus.CONFLICT,
+      );
+    }
+
     const totalPrice = (companion.hourlyRate || 100) * data.duration;
 
     const booking = this.bookingsRepository.create({

--- a/backend/daterabbit-api/src/payments/payments.service.ts
+++ b/backend/daterabbit-api/src/payments/payments.service.ts
@@ -118,6 +118,7 @@ export class PaymentsService {
     const paymentIntent = await this.stripe.paymentIntents.create({
       amount,
       currency: 'usd',
+      capture_method: 'manual',
       application_fee_amount: platformFee,
       transfer_data: {
         destination: companion.stripeAccountId,
@@ -134,6 +135,39 @@ export class PaymentsService {
     });
 
     return { clientSecret: paymentIntent.client_secret! };
+  }
+
+  // --- Capture / Cancel (escrow) ---
+
+  async capturePayment(bookingId: string): Promise<void> {
+    const booking = await this.bookingsRepo.findOne({ where: { id: bookingId } });
+    if (!booking?.paymentIntentId) return;
+    this.ensureStripe();
+    try {
+      await this.stripe.paymentIntents.capture(booking.paymentIntentId);
+    } catch (err: any) {
+      // already captured or cancelled — log but don't throw
+      console.error('Stripe capture error:', err.message);
+    }
+  }
+
+  async cancelPaymentHold(bookingId: string): Promise<void> {
+    const booking = await this.bookingsRepo.findOne({ where: { id: bookingId } });
+    if (!booking?.paymentIntentId) return;
+    this.ensureStripe();
+    try {
+      const pi = await this.stripe.paymentIntents.retrieve(booking.paymentIntentId);
+      if (pi.status === 'requires_capture') {
+        // Cancel the hold (no charge)
+        await this.stripe.paymentIntents.cancel(booking.paymentIntentId);
+      } else if (pi.status === 'succeeded') {
+        // Already captured — create refund
+        await this.stripe.refunds.create({ payment_intent: booking.paymentIntentId });
+      }
+      // other statuses (canceled, etc.) — do nothing
+    } catch (err: any) {
+      console.error('Stripe cancel/refund error:', err.message);
+    }
   }
 
   // --- Earnings ---


### PR DESCRIPTION
## Summary
- **BUG-682**: Add `capture_method: 'manual'` to PaymentIntent creation + `capturePayment()` called on booking completion — funds are now properly captured
- **BUG-681**: Add `cancelPaymentHold()` called on booking cancellation — releases hold or creates refund
- **BUG-683**: Add overlapping booking check in `create()` — prevents double-booking for same companion/time slot

## Changes
- `payments.service.ts` — `capture_method: 'manual'`, new `capturePayment()` and `cancelPaymentHold()` methods
- `bookings.controller.ts` — inject `PaymentsService`, call capture/cancel in complete/cancel endpoints (fire-and-forget)
- `bookings.module.ts` — import `PaymentsModule`
- `bookings.service.ts` — overlapping booking query check before insert

## Test plan
- [ ] Create booking, verify PaymentIntent has `capture_method: manual`
- [ ] Complete booking, verify `paymentIntents.capture()` is called
- [ ] Cancel booking, verify hold is released or refund created
- [ ] Try creating overlapping bookings for same companion — should get 409 Conflict