### PR TITLE
fix: GET /bookings/active route order (500 bug)

### DIFF
--- a/backend/daterabbit-api/src/bookings/bookings.controller.ts
+++ b/backend/daterabbit-api/src/bookings/bookings.controller.ts
@@ -105,6 +105,13 @@ export class BookingsController {
     return requests.map((b) => this.formatBooking(b));
   }
 
+  @Get('active')
+  async getActiveDateBooking(@Request() req) {
+    const booking = await this.bookingsService.getActiveDateBooking(req.user.id);
+    if (!booking) return null;
+    return this.formatBooking(booking);
+  }
+
   @Get(':id')
   async getBooking(@Param('id') id: string, @Request() req) {
     const booking = await this.bookingsService.findById(id);
@@ -169,13 +176,6 @@ export class BookingsController {
     return this.formatBooking(updated);
   }
 
-  @Get('active')
-  async getActiveDateBooking(@Request() req) {
-    const booking = await this.bookingsService.getActiveDateBooking(req.user.id);
-    if (!booking) return null;
-    return this.formatBooking(booking);
-  }
-
   @Post(':id/checkin')
   async seekerCheckin(@Param('id') id: string, @Request() req, @Body() body: { lat?: number; lon?: number }) {
     const booking = await this.bookingsService.seekerCheckin(id, req.user.id, body.lat, body.lon);
@@ -217,6 +217,7 @@ export class BookingsController {
       activeDateEndedAt: booking.activeDateEndedAt || undefined,
       actualDurationHours: booking.actualDurationHours || undefined,
       sosTriggeredAt: booking.sosTriggeredAt || undefined,
+      sosTriggeredBy: booking.sosTriggeredBy || undefined,
       noShowReason: booking.noShowReason || undefined,
       seeker: booking.seeker ? {
         id: booking.seeker.id,


### PR DESCRIPTION
## Problem
`GET /bookings/active` was declared **after** `GET /:id` in the controller. NestJS matched `active` as a booking UUID parameter, passed it to the DB, and PostgreSQL returned 500 (invalid UUID format).

## Fix
- Moved `@Get('active')` handler **before** `@Get(':id')` in `bookings.controller.ts`
- Also added missing `sosTriggeredBy` field to `formatBooking()` response

## Test results (staging, DEV_AUTH mode)
Before fix: `GET /bookings/active → 500`
After fix: `GET /bookings/active → 200` (null when no active date, booking object when ACTIVE)

Overall test suite: 40/45 PASS → 42/45 PASS after this fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)