### PR TITLE
feat: add missing admin endpoints and payout validation (#684, #696-701)

### DIFF
--- a/backend/daterabbit-api/src/admin/admin.controller.ts
+++ b/backend/daterabbit-api/src/admin/admin.controller.ts
@@ -1,12 +1,15 @@
 import {
   Controller,
   Get,
+  Post,
+  Delete,
   Patch,
   Put,
   Param,
   Body,
   Query,
   UseGuards,
+  Request,
   ParseIntPipe,
   DefaultValuePipe,
 } from '@nestjs/common';
@@ -18,9 +21,44 @@ import { AdminService } from './admin.service';
 export class AdminController {
   constructor(private readonly adminService: AdminService) {}
 
+  // #696 - admin identity
+  @Get('me')
+  getMe(@Request() req) {
+    return req.user;
+  }
+
   @Get('stats')
   getStats() {
     return this.adminService.getStats();
+  }
+
+  // #700 - revenue
+  @Get('revenue')
+  getRevenue() {
+    return this.adminService.getRevenue();
+  }
+
+  // #700 - transactions
+  @Get('transactions')
+  getTransactions(
+    @Query('page', new DefaultValuePipe(1), ParseIntPipe) page: number,
+    @Query('limit', new DefaultValuePipe(20), ParseIntPipe) limit: number,
+  ) {
+    return this.adminService.getTransactions(page, Math.min(limit, 100));
+  }
+
+  // #701 - reviews
+  @Get('reviews')
+  getReviews(
+    @Query('page', new DefaultValuePipe(1), ParseIntPipe) page: number,
+    @Query('limit', new DefaultValuePipe(20), ParseIntPipe) limit: number,
+  ) {
+    return this.adminService.getReviews(page, Math.min(limit, 100));
+  }
+
+  @Delete('reviews/:id')
+  deleteReview(@Param('id') id: string) {
+    return this.adminService.deleteReview(id);
   }
 
   @Get('users')
@@ -45,6 +83,27 @@ export class AdminController {
     return this.adminService.updateUser(id, body);
   }
 
+  // #697 - ban/unban
+  @Post('users/:id/ban')
+  banUser(@Param('id') id: string) {
+    return this.adminService.banUser(id);
+  }
+
+  @Post('users/:id/unban')
+  unbanUser(@Param('id') id: string) {
+    return this.adminService.unbanUser(id);
+  }
+
+  // #698 - user bookings
+  @Get('users/:userId/bookings')
+  getUserBookings(
+    @Param('userId') userId: string,
+    @Query('page', new DefaultValuePipe(1), ParseIntPipe) page: number,
+    @Query('limit', new DefaultValuePipe(20), ParseIntPipe) limit: number,
+  ) {
+    return this.adminService.getUserBookings(userId, page, Math.min(limit, 100));
+  }
+
   @Get('bookings')
   getBookings(
     @Query('status') status?: string,
@@ -57,6 +116,15 @@ export class AdminController {
   @Get('bookings/:id')
   getBookingById(@Param('id') id: string) {
     return this.adminService.getBookingById(id);
+  }
+
+  // #699 - cancel booking
+  @Post('bookings/:id/cancel')
+  cancelBooking(
+    @Param('id') id: string,
+    @Body() body: { reason?: string },
+  ) {
+    return this.adminService.cancelBooking(id, body.reason);
   }
 
   @Get('verifications')

--- a/backend/daterabbit-api/src/admin/admin.module.ts
+++ b/backend/daterabbit-api/src/admin/admin.module.ts
@@ -8,11 +8,12 @@ import { AdminGuard } from './admin.guard';
 import { User } from '../users/entities/user.entity';
 import { Booking } from '../bookings/entities/booking.entity';
 import { Verification } from '../verification/entities/verification.entity';
+import { Review } from '../reviews/entities/review.entity';
 import { UsersModule } from '../users/users.module';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([User, Booking, Verification]),
+    TypeOrmModule.forFeature([User, Booking, Verification, Review]),
     JwtModule.registerAsync({
       imports: [ConfigModule],
       inject: [ConfigService],

--- a/backend/daterabbit-api/src/admin/admin.service.ts
+++ b/backend/daterabbit-api/src/admin/admin.service.ts
@@ -1,9 +1,10 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { Injectable, NotFoundException, BadRequestException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository, ILike } from 'typeorm';
+import { Repository, ILike, In } from 'typeorm';
 import { User } from '../users/entities/user.entity';
 import { Booking, BookingStatus } from '../bookings/entities/booking.entity';
 import { Verification, VerificationStatus } from '../verification/entities/verification.entity';
+import { Review } from '../reviews/entities/review.entity';
 
 @Injectable()
 export class AdminService {
@@ -14,6 +15,8 @@ export class AdminService {
     private bookingsRepo: Repository<Booking>,
     @InjectRepository(Verification)
     private verificationsRepo: Repository<Verification>,
+    @InjectRepository(Review)
+    private reviewsRepo: Repository<Review>,
   ) {}
 
   async getStats() {
@@ -34,6 +37,82 @@ export class AdminService {
       totalBookings,
       revenue: parseFloat(revenueResult?.total ?? '0'),
     };
+  }
+
+  // #700 - revenue breakdown
+  async getRevenue() {
+    const [totalResult, monthResult, bookingCounts] = await Promise.all([
+      this.bookingsRepo
+        .createQueryBuilder('b')
+        .select('COALESCE(SUM(b.totalPrice), 0)', 'total')
+        .where('b.status IN (:...statuses)', {
+          statuses: [BookingStatus.PAID, BookingStatus.COMPLETED],
+        })
+        .getRawOne<{ total: string }>(),
+      this.bookingsRepo
+        .createQueryBuilder('b')
+        .select('COALESCE(SUM(b.totalPrice), 0)', 'total')
+        .where('b.status IN (:...statuses)', {
+          statuses: [BookingStatus.PAID, BookingStatus.COMPLETED],
+        })
+        .andWhere("b.createdAt >= date_trunc('month', NOW())")
+        .getRawOne<{ total: string }>(),
+      this.bookingsRepo
+        .createQueryBuilder('b')
+        .select('b.status', 'status')
+        .addSelect('COUNT(*)', 'count')
+        .groupBy('b.status')
+        .getRawMany<{ status: string; count: string }>(),
+    ]);
+
+    const countsByStatus: Record<string, number> = {};
+    for (const row of bookingCounts) {
+      countsByStatus[row.status] = parseInt(row.count, 10);
+    }
+
+    return {
+      totalRevenue: parseFloat(totalResult?.total ?? '0'),
+      monthRevenue: parseFloat(monthResult?.total ?? '0'),
+      bookingsByStatus: countsByStatus,
+    };
+  }
+
+  // #700 - transactions (paid/completed bookings)
+  async getTransactions(page: number, limit: number) {
+    const skip = (page - 1) * limit;
+
+    const [items, total] = await this.bookingsRepo.findAndCount({
+      where: { status: In([BookingStatus.PAID, BookingStatus.COMPLETED]) },
+      relations: ['seeker', 'companion'],
+      order: { createdAt: 'DESC' },
+      skip,
+      take: limit,
+    });
+
+    return { items, total, page, limit };
+  }
+
+  // #701 - reviews
+  async getReviews(page: number, limit: number) {
+    const skip = (page - 1) * limit;
+
+    const [items, total] = await this.reviewsRepo.findAndCount({
+      relations: ['reviewer', 'reviewee'],
+      order: { createdAt: 'DESC' },
+      skip,
+      take: limit,
+    });
+
+    return { items, total, page, limit };
+  }
+
+  async deleteReview(id: string) {
+    const review = await this.reviewsRepo.findOne({ where: { id } });
+    if (!review) {
+      throw new NotFoundException('Review not found');
+    }
+    await this.reviewsRepo.delete(id);
+    return { success: true };
   }
 
   async getUsers(search: string, page: number, limit: number) {
@@ -105,6 +184,51 @@ export class AdminService {
     return this.getUserById(id);
   }
 
+  // #697 - ban/unban
+  async banUser(id: string) {
+    const user = await this.usersRepo.findOne({ where: { id } });
+    if (!user) {
+      throw new NotFoundException('User not found');
+    }
+    if (!user.isActive) {
+      throw new BadRequestException('User is already banned');
+    }
+    await this.usersRepo.update(id, { isActive: false });
+    return { success: true, userId: id, banned: true };
+  }
+
+  async unbanUser(id: string) {
+    const user = await this.usersRepo.findOne({ where: { id } });
+    if (!user) {
+      throw new NotFoundException('User not found');
+    }
+    if (user.isActive) {
+      throw new BadRequestException('User is not banned');
+    }
+    await this.usersRepo.update(id, { isActive: true });
+    return { success: true, userId: id, banned: false };
+  }
+
+  // #698 - user bookings
+  async getUserBookings(userId: string, page: number, limit: number) {
+    const user = await this.usersRepo.findOne({ where: { id: userId } });
+    if (!user) {
+      throw new NotFoundException('User not found');
+    }
+
+    const skip = (page - 1) * limit;
+
+    const [items, total] = await this.bookingsRepo.findAndCount({
+      where: [{ seekerId: userId }, { companionId: userId }],
+      relations: ['seeker', 'companion'],
+      order: { createdAt: 'DESC' },
+      skip,
+      take: limit,
+    });
+
+    return { items, total, page, limit };
+  }
+
   async getBookings(status: string | undefined, page: number, limit: number) {
     const skip = (page - 1) * limit;
     const where = status ? { status: status as BookingStatus } : {};
@@ -131,6 +255,27 @@ export class AdminService {
     }
 
     return booking;
+  }
+
+  // #699 - cancel booking
+  async cancelBooking(id: string, reason?: string) {
+    const booking = await this.bookingsRepo.findOne({ where: { id } });
+    if (!booking) {
+      throw new NotFoundException('Booking not found');
+    }
+    if (booking.status === BookingStatus.CANCELLED) {
+      throw new BadRequestException('Booking is already cancelled');
+    }
+    if (booking.status === BookingStatus.COMPLETED) {
+      throw new BadRequestException('Cannot cancel a completed booking');
+    }
+
+    await this.bookingsRepo.update(id, {
+      status: BookingStatus.CANCELLED,
+      cancellationReason: reason || 'Cancelled by admin',
+    });
+
+    return this.getBookingById(id);
   }
 
   async getVerifications(status: string | undefined, page: number, limit: number) {

--- a/backend/daterabbit-api/src/payments/payments.controller.ts
+++ b/backend/daterabbit-api/src/payments/payments.controller.ts
@@ -77,6 +77,11 @@ export class PaymentsController {
   @Post('payouts/create')
   @UseGuards(JwtAuthGuard)
   async createPayout(@Request() req, @Body() body: { amount?: number }) {
+    if (body.amount !== undefined) {
+      if (typeof body.amount !== 'number' || body.amount <= 0) {
+        throw new HttpException('Amount must be a positive number', HttpStatus.BAD_REQUEST);
+      }
+    }
     return this.paymentsService.createPayout(req.user.id, body.amount);
   }
 


### PR DESCRIPTION
## Summary

- **#684**: `POST /payments/payouts/create` — validate amount > 0, reject negative/zero values with 400
- **#696**: `GET /admin/me` — returns current admin user from JWT
- **#697**: `POST /admin/users/:id/ban` / `unban` — toggles `isActive` flag
- **#698**: `GET /admin/users/:userId/bookings` — paginated bookings for a specific user (both seeker and companion roles)
- **#699**: `POST /admin/bookings/:id/cancel` — admin force-cancel with optional reason
- **#700**: `GET /admin/revenue` (breakdown: total, month, by status) + `GET /admin/transactions` (paid/completed bookings)
- **#701**: `GET /admin/reviews` (paginated) + `DELETE /admin/reviews/:id` — admin review moderation

## Changes

- `payments.controller.ts`: payout amount validation
- `admin.controller.ts`: 8 new endpoints
- `admin.service.ts`: corresponding service methods (ban/unban, getUserBookings, cancelBooking, getRevenue, getTransactions, getReviews, deleteReview)
- `admin.module.ts`: added `Review` entity to TypeORM feature imports

## Test plan

- [ ] `POST /payments/payouts/create` with `amount: -50` → 400
- [ ] `POST /payments/payouts/create` with `amount: 0` → 400
- [ ] `GET /admin/me` with admin token → returns user object
- [ ] `POST /admin/users/:id/ban` → user.isActive = false
- [ ] `POST /admin/users/:id/unban` → user.isActive = true
- [ ] `GET /admin/users/:userId/bookings` → paginated list
- [ ] `POST /admin/bookings/:id/cancel` → status = cancelled
- [ ] `GET /admin/revenue` → totals and breakdown
- [ ] `GET /admin/transactions` → paid/completed bookings
- [ ] `GET /admin/reviews` + `DELETE /admin/reviews/:id`

🤖 Generated with [Claude Code](https://claude.com/claude-code)