### PR TITLE
feat: add selfie + geolocation to check-in screens (#704)

### DIFF
--- a/app/app/date/checkin/[bookingId].tsx
+++ b/app/app/date/checkin/[bookingId].tsx
@@ -1,14 +1,31 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import { View, Text, StyleSheet, TouchableOpacity, ActivityIndicator, Alert } from 'react-native';
+import {
+  View,
+  Text,
+  StyleSheet,
+  TouchableOpacity,
+  ActivityIndicator,
+  Alert,
+  Image,
+  ScrollView,
+} from 'react-native';
 import { useLocalSearchParams, router } from 'expo-router';
+import * as ImagePicker from 'expo-image-picker';
+import * as Location from 'expo-location';
 import { activeDateApi, ActiveBooking } from '../../../src/services/activeDateApi';
+
+type Step = 'selfie' | 'location' | 'ready' | 'waiting';
 
 export default function SeekerCheckinScreen() {
   const { bookingId } = useLocalSearchParams<{ bookingId: string }>();
   const [booking, setBooking] = useState<ActiveBooking | null>(null);
   const [loading, setLoading] = useState(true);
   const [checkingIn, setCheckingIn] = useState(false);
-  const [checkedIn, setCheckedIn] = useState(false);
+  const [step, setStep] = useState<Step>('selfie');
+
+  const [selfieUri, setSelfieUri] = useState<string | null>(null);
+  const [coords, setCoords] = useState<{ lat: number; lon: number } | null>(null);
+  const [locationStatus, setLocationStatus] = useState<'idle' | 'loading' | 'done' | 'denied'>('idle');
 
   const loadBooking = useCallback(async () => {
     try {
@@ -28,9 +45,9 @@ export default function SeekerCheckinScreen() {
     loadBooking();
   }, [loadBooking]);
 
-  // Poll every 5 seconds after seeker checked in
+  // Poll every 5 seconds after check-in, waiting for companion
   useEffect(() => {
-    if (!checkedIn) return;
+    if (step !== 'waiting') return;
     const interval = setInterval(async () => {
       try {
         const data = await activeDateApi.getBookingById(bookingId);
@@ -41,17 +58,53 @@ export default function SeekerCheckinScreen() {
       } catch (e) {}
     }, 5000);
     return () => clearInterval(interval);
-  }, [checkedIn, bookingId]);
+  }, [step, bookingId]);
+
+  const handleTakeSelfie = async () => {
+    const { status } = await ImagePicker.requestCameraPermissionsAsync();
+    if (status !== 'granted') {
+      Alert.alert('Camera Required', 'Camera access is needed for identity verification.');
+      return;
+    }
+    const result = await ImagePicker.launchCameraAsync({
+      mediaTypes: ImagePicker.MediaTypeOptions.Images,
+      allowsEditing: false,
+      quality: 0.7,
+      cameraType: ImagePicker.CameraType.front,
+    });
+    if (!result.canceled && result.assets[0]) {
+      setSelfieUri(result.assets[0].uri);
+      setStep('location');
+    }
+  };
+
+  const handleGetLocation = async () => {
+    setLocationStatus('loading');
+    const { status } = await Location.requestForegroundPermissionsAsync();
+    if (status !== 'granted') {
+      setLocationStatus('denied');
+      setStep('ready');
+      return;
+    }
+    try {
+      const loc = await Location.getCurrentPositionAsync({ accuracy: Location.Accuracy.High });
+      setCoords({ lat: loc.coords.latitude, lon: loc.coords.longitude });
+      setLocationStatus('done');
+    } catch (e) {
+      setLocationStatus('denied');
+    }
+    setStep('ready');
+  };
 
   const handleCheckin = async () => {
     setCheckingIn(true);
     try {
-      const updated = await activeDateApi.seekerCheckin(bookingId);
+      const updated = await activeDateApi.seekerCheckin(bookingId, coords ?? undefined);
       setBooking(updated);
       if (updated.status === 'active') {
         router.replace(`/date/active/${bookingId}`);
       } else {
-        setCheckedIn(true);
+        setStep('waiting');
       }
     } catch (e: any) {
       Alert.alert('Error', e.message || 'Check-in failed');
@@ -60,14 +113,41 @@ export default function SeekerCheckinScreen() {
     }
   };
 
-  if (loading) return (
-    <View style={styles.center}>
-      <ActivityIndicator size="large" color="#FF2A5F" />
-    </View>
-  );
+  if (loading) {
+    return (
+      <View style={styles.center}>
+        <ActivityIndicator size="large" color="#FF2A5F" />
+      </View>
+    );
+  }
+
+  if (step === 'waiting') {
+    return (
+      <View style={styles.container}>
+        <Text style={styles.title}>You're{'\n'}Checked In!</Text>
+        {booking?.location && (
+          <View style={styles.locationCard}>
+            <Text style={styles.locationLabel}>Meeting at</Text>
+            <Text style={styles.locationText}>{booking.location}</Text>
+          </View>
+        )}
+        <View style={styles.waitingCard}>
+          <Text style={styles.waitingText}>Waiting for {booking?.companion?.name ?? 'your companion'}...</Text>
+          <Text style={styles.waitingSubtext}>They'll check in when they arrive</Text>
+          <ActivityIndicator color="#FF2A5F" style={{ marginTop: 16 }} />
+        </View>
+        <View style={styles.statusRow}>
+          <View style={[styles.dot, styles.dotGreen]} />
+          <Text style={styles.statusName}>You</Text>
+          <View style={[styles.dot, booking?.companionCheckinAt ? styles.dotGreen : styles.dotGray, { marginLeft: 24 }]} />
+          <Text style={styles.statusName}>{booking?.companion?.name}</Text>
+        </View>
+      </View>
+    );
+  }
 
   return (
-    <View style={styles.container}>
+    <ScrollView style={styles.scroll} contentContainerStyle={styles.container}>
       <Text style={styles.title}>Time to{'\n'}Check In</Text>
 
       {booking?.location && (
@@ -77,57 +157,109 @@ export default function SeekerCheckinScreen() {
         </View>
       )}
 
-      <View style={styles.pinIcon}>
-        <Text style={styles.pinEmoji}>📍</Text>
+      {/* Step 1: Selfie */}
+      <View style={styles.stepCard}>
+        <View style={styles.stepHeader}>
+          <View style={[styles.stepBadge, selfieUri ? styles.stepBadgeDone : styles.stepBadgeTodo]}>
+            <Text style={styles.stepBadgeText}>{selfieUri ? '✓' : '1'}</Text>
+          </View>
+          <Text style={styles.stepTitle}>Take a Selfie</Text>
+        </View>
+        <Text style={styles.stepDesc}>Verify your identity at the location</Text>
+        {selfieUri ? (
+          <View style={styles.selfieRow}>
+            <Image source={{ uri: selfieUri }} style={styles.selfieThumb} />
+            <TouchableOpacity style={styles.retakeBtn} onPress={handleTakeSelfie}>
+              <Text style={styles.retakeBtnText}>Retake</Text>
+            </TouchableOpacity>
+          </View>
+        ) : (
+          <TouchableOpacity style={styles.cameraBtn} onPress={handleTakeSelfie}>
+            <Text style={styles.cameraBtnText}>📸  Open Camera</Text>
+          </TouchableOpacity>
+        )}
       </View>
 
-      {!checkedIn ? (
-        <TouchableOpacity
-          style={[styles.button, checkingIn && styles.buttonDisabled]}
-          onPress={handleCheckin}
-          disabled={checkingIn}
-        >
-          {checkingIn
-            ? <ActivityIndicator color="#fff" />
-            : <Text style={styles.buttonText}>I'm Here</Text>
-          }
-        </TouchableOpacity>
-      ) : (
-        <View style={styles.waitingCard}>
-          <Text style={styles.waitingText}>You're checked in!</Text>
-          <Text style={styles.waitingSubtext}>Waiting for {booking?.companion?.name ?? 'your companion'} to check in...</Text>
-          <ActivityIndicator color="#FF2A5F" style={{ marginTop: 16 }} />
+      {/* Step 2: Location */}
+      <View style={[styles.stepCard, step === 'selfie' && styles.stepCardDimmed]}>
+        <View style={styles.stepHeader}>
+          <View style={[styles.stepBadge, locationStatus === 'done' ? styles.stepBadgeDone : styles.stepBadgeTodo]}>
+            <Text style={styles.stepBadgeText}>{locationStatus === 'done' ? '✓' : '2'}</Text>
+          </View>
+          <Text style={styles.stepTitle}>Share Location</Text>
         </View>
-      )}
+        <Text style={styles.stepDesc}>Confirm you're at the meeting spot</Text>
+        {locationStatus === 'done' ? (
+          <View style={styles.locationDoneRow}>
+            <Text style={styles.locationDoneText}>📍 Location captured</Text>
+          </View>
+        ) : locationStatus === 'denied' ? (
+          <View style={styles.locationDoneRow}>
+            <Text style={styles.locationDoneText}>⚠️ Location skipped</Text>
+          </View>
+        ) : (
+          <TouchableOpacity
+            style={[styles.locationBtn, (step === 'selfie' || locationStatus === 'loading') && styles.btnDisabled]}
+            onPress={handleGetLocation}
+            disabled={step === 'selfie' || locationStatus === 'loading'}
+          >
+            {locationStatus === 'loading'
+              ? <ActivityIndicator color="#000" size="small" />
+              : <Text style={styles.locationBtnText}>📍  Get Location</Text>
+            }
+          </TouchableOpacity>
+        )}
+      </View>
 
-      {booking && (
-        <View style={styles.statusRow}>
-          <View style={[styles.dot, booking.seekerCheckinAt ? styles.dotGreen : styles.dotGray]} />
-          <Text style={styles.statusName}>You</Text>
-          <View style={[styles.dot, booking.companionCheckinAt ? styles.dotGreen : styles.dotGray, { marginLeft: 24 }]} />
-          <Text style={styles.statusName}>{booking.companion?.name}</Text>
-        </View>
-      )}
-    </View>
+      {/* Check In Button */}
+      <TouchableOpacity
+        style={[styles.checkinBtn, (step !== 'ready' || checkingIn) && styles.btnDisabled]}
+        onPress={handleCheckin}
+        disabled={step !== 'ready' || checkingIn}
+      >
+        {checkingIn
+          ? <ActivityIndicator color="#fff" />
+          : <Text style={styles.checkinBtnText}>I'm Here — Check In</Text>
+        }
+      </TouchableOpacity>
+    </ScrollView>
   );
 }
 
 const styles = StyleSheet.create({
-  container: { flex: 1, backgroundColor: '#F4F0EA', padding: 24, paddingTop: 60 },
+  scroll: { flex: 1, backgroundColor: '#F4F0EA' },
+  container: { padding: 24, paddingTop: 60, paddingBottom: 40 },
   center: { flex: 1, backgroundColor: '#F4F0EA', justifyContent: 'center', alignItems: 'center' },
-  title: { fontSize: 40, fontFamily: 'SpaceGrotesk-Bold', fontWeight: '700', color: '#000', lineHeight: 48, marginBottom: 32 },
-  locationCard: { backgroundColor: '#4DF0FF', borderWidth: 2, borderColor: '#000', padding: 16, marginBottom: 32, shadowOffset: { width: 3, height: 3 }, shadowColor: '#000', shadowOpacity: 1, shadowRadius: 0 },
+  title: { fontSize: 40, fontFamily: 'SpaceGrotesk-Bold', fontWeight: '700', color: '#000', lineHeight: 48, marginBottom: 24 },
+  locationCard: { backgroundColor: '#4DF0FF', borderWidth: 2, borderColor: '#000', padding: 16, marginBottom: 24, shadowOffset: { width: 3, height: 3 }, shadowColor: '#000', shadowOpacity: 1, shadowRadius: 0 },
   locationLabel: { fontSize: 12, fontFamily: 'SpaceGrotesk-Bold', fontWeight: '700', textTransform: 'uppercase', color: '#000', marginBottom: 4 },
   locationText: { fontSize: 18, fontFamily: 'SpaceGrotesk-Bold', fontWeight: '700', color: '#000' },
-  pinIcon: { alignItems: 'center', marginBottom: 40 },
-  pinEmoji: { fontSize: 80 },
-  button: { backgroundColor: '#FF2A5F', borderWidth: 2, borderColor: '#000', paddingVertical: 18, alignItems: 'center', shadowOffset: { width: 4, height: 4 }, shadowColor: '#000', shadowOpacity: 1, shadowRadius: 0 },
-  buttonDisabled: { opacity: 0.6 },
-  buttonText: { fontSize: 20, fontFamily: 'SpaceGrotesk-Bold', fontWeight: '700', color: '#fff' },
-  waitingCard: { backgroundColor: '#FFE600', borderWidth: 2, borderColor: '#000', padding: 20, alignItems: 'center', shadowOffset: { width: 3, height: 3 }, shadowColor: '#000', shadowOpacity: 1, shadowRadius: 0 },
+  stepCard: { backgroundColor: '#fff', borderWidth: 2, borderColor: '#000', padding: 16, marginBottom: 16, shadowOffset: { width: 3, height: 3 }, shadowColor: '#000', shadowOpacity: 1, shadowRadius: 0 },
+  stepCardDimmed: { opacity: 0.4 },
+  stepHeader: { flexDirection: 'row', alignItems: 'center', marginBottom: 6 },
+  stepBadge: { width: 28, height: 28, borderRadius: 14, borderWidth: 2, borderColor: '#000', justifyContent: 'center', alignItems: 'center', marginRight: 10 },
+  stepBadgeTodo: { backgroundColor: '#fff' },
+  stepBadgeDone: { backgroundColor: '#00CC66' },
+  stepBadgeText: { fontSize: 12, fontFamily: 'SpaceGrotesk-Bold', fontWeight: '700', color: '#000' },
+  stepTitle: { fontSize: 18, fontFamily: 'SpaceGrotesk-Bold', fontWeight: '700', color: '#000' },
+  stepDesc: { fontSize: 13, color: '#555', marginBottom: 14, marginLeft: 38 },
+  selfieRow: { flexDirection: 'row', alignItems: 'center', gap: 12 },
+  selfieThumb: { width: 72, height: 72, borderWidth: 2, borderColor: '#000' },
+  retakeBtn: { borderWidth: 2, borderColor: '#000', paddingHorizontal: 16, paddingVertical: 8 },
+  retakeBtnText: { fontSize: 14, fontFamily: 'SpaceGrotesk-Bold', fontWeight: '700', color: '#000' },
+  cameraBtn: { backgroundColor: '#FFE600', borderWidth: 2, borderColor: '#000', paddingVertical: 14, alignItems: 'center', shadowOffset: { width: 3, height: 3 }, shadowColor: '#000', shadowOpacity: 1, shadowRadius: 0 },
+  cameraBtnText: { fontSize: 16, fontFamily: 'SpaceGrotesk-Bold', fontWeight: '700', color: '#000' },
+  locationBtn: { backgroundColor: '#4DF0FF', borderWidth: 2, borderColor: '#000', paddingVertical: 14, alignItems: 'center', shadowOffset: { width: 3, height: 3 }, shadowColor: '#000', shadowOpacity: 1, shadowRadius: 0 },
+  locationBtnText: { fontSize: 16, fontFamily: 'SpaceGrotesk-Bold', fontWeight: '700', color: '#000' },
+  locationDoneRow: { backgroundColor: '#F4F0EA', borderWidth: 1, borderColor: '#ccc', padding: 10 },
+  locationDoneText: { fontSize: 14, fontFamily: 'SpaceGrotesk-Bold', color: '#000' },
+  checkinBtn: { backgroundColor: '#FF2A5F', borderWidth: 2, borderColor: '#000', paddingVertical: 20, alignItems: 'center', marginTop: 8, shadowOffset: { width: 4, height: 4 }, shadowColor: '#000', shadowOpacity: 1, shadowRadius: 0 },
+  btnDisabled: { opacity: 0.4 },
+  checkinBtnText: { fontSize: 20, fontFamily: 'SpaceGrotesk-Bold', fontWeight: '700', color: '#fff' },
+  waitingCard: { backgroundColor: '#FFE600', borderWidth: 2, borderColor: '#000', padding: 20, alignItems: 'center', shadowOffset: { width: 3, height: 3 }, shadowColor: '#000', shadowOpacity: 1, shadowRadius: 0, marginBottom: 24 },
   waitingText: { fontSize: 20, fontFamily: 'SpaceGrotesk-Bold', fontWeight: '700', color: '#000' },
   waitingSubtext: { fontSize: 14, color: '#000', marginTop: 8, textAlign: 'center' },
-  statusRow: { flexDirection: 'row', alignItems: 'center', marginTop: 32, justifyContent: 'center' },
+  statusRow: { flexDirection: 'row', alignItems: 'center', justifyContent: 'center' },
   dot: { width: 14, height: 14, borderRadius: 7, borderWidth: 2, borderColor: '#000' },
   dotGreen: { backgroundColor: '#00CC66' },
   dotGray: { backgroundColor: '#ccc' },

--- a/app/app/date/companion-checkin/[bookingId].tsx
+++ b/app/app/date/companion-checkin/[bookingId].tsx
@@ -1,14 +1,31 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import { View, Text, StyleSheet, TouchableOpacity, ActivityIndicator, Alert } from 'react-native';
+import {
+  View,
+  Text,
+  StyleSheet,
+  TouchableOpacity,
+  ActivityIndicator,
+  Alert,
+  Image,
+  ScrollView,
+} from 'react-native';
 import { useLocalSearchParams, router } from 'expo-router';
+import * as ImagePicker from 'expo-image-picker';
+import * as Location from 'expo-location';
 import { activeDateApi, ActiveBooking } from '../../../src/services/activeDateApi';
+
+type Step = 'selfie' | 'location' | 'ready' | 'waiting';
 
 export default function CompanionCheckinScreen() {
   const { bookingId } = useLocalSearchParams<{ bookingId: string }>();
   const [booking, setBooking] = useState<ActiveBooking | null>(null);
   const [loading, setLoading] = useState(true);
   const [checkingIn, setCheckingIn] = useState(false);
-  const [checkedIn, setCheckedIn] = useState(false);
+  const [step, setStep] = useState<Step>('selfie');
+
+  const [selfieUri, setSelfieUri] = useState<string | null>(null);
+  const [coords, setCoords] = useState<{ lat: number; lon: number } | null>(null);
+  const [locationStatus, setLocationStatus] = useState<'idle' | 'loading' | 'done' | 'denied'>('idle');
 
   const loadBooking = useCallback(async () => {
     try {
@@ -28,9 +45,9 @@ export default function CompanionCheckinScreen() {
     loadBooking();
   }, [loadBooking]);
 
-  // Poll every 5 seconds after companion checked in
+  // Poll every 5 seconds after check-in, waiting for seeker
   useEffect(() => {
-    if (!checkedIn) return;
+    if (step !== 'waiting') return;
     const interval = setInterval(async () => {
       try {
         const data = await activeDateApi.getBookingById(bookingId);
@@ -41,17 +58,53 @@ export default function CompanionCheckinScreen() {
       } catch (e) {}
     }, 5000);
     return () => clearInterval(interval);
-  }, [checkedIn, bookingId]);
+  }, [step, bookingId]);
+
+  const handleTakeSelfie = async () => {
+    const { status } = await ImagePicker.requestCameraPermissionsAsync();
+    if (status !== 'granted') {
+      Alert.alert('Camera Required', 'Camera access is needed for identity verification.');
+      return;
+    }
+    const result = await ImagePicker.launchCameraAsync({
+      mediaTypes: ImagePicker.MediaTypeOptions.Images,
+      allowsEditing: false,
+      quality: 0.7,
+      cameraType: ImagePicker.CameraType.front,
+    });
+    if (!result.canceled && result.assets[0]) {
+      setSelfieUri(result.assets[0].uri);
+      setStep('location');
+    }
+  };
+
+  const handleGetLocation = async () => {
+    setLocationStatus('loading');
+    const { status } = await Location.requestForegroundPermissionsAsync();
+    if (status !== 'granted') {
+      setLocationStatus('denied');
+      setStep('ready');
+      return;
+    }
+    try {
+      const loc = await Location.getCurrentPositionAsync({ accuracy: Location.Accuracy.High });
+      setCoords({ lat: loc.coords.latitude, lon: loc.coords.longitude });
+      setLocationStatus('done');
+    } catch (e) {
+      setLocationStatus('denied');
+    }
+    setStep('ready');
+  };
 
   const handleCheckin = async () => {
     setCheckingIn(true);
     try {
-      const updated = await activeDateApi.companionCheckin(bookingId);
+      const updated = await activeDateApi.companionCheckin(bookingId, coords ?? undefined);
       setBooking(updated);
       if (updated.status === 'active') {
         router.replace(`/date/active/${bookingId}`);
       } else {
-        setCheckedIn(true);
+        setStep('waiting');
       }
     } catch (e: any) {
       Alert.alert('Error', e.message || 'Check-in failed');
@@ -60,14 +113,41 @@ export default function CompanionCheckinScreen() {
     }
   };
 
-  if (loading) return (
-    <View style={styles.center}>
-      <ActivityIndicator size="large" color="#FF2A5F" />
-    </View>
-  );
+  if (loading) {
+    return (
+      <View style={styles.center}>
+        <ActivityIndicator size="large" color="#FF2A5F" />
+      </View>
+    );
+  }
+
+  if (step === 'waiting') {
+    return (
+      <View style={styles.container}>
+        <Text style={styles.title}>You're{'\n'}Checked In!</Text>
+        {booking?.location && (
+          <View style={styles.locationCard}>
+            <Text style={styles.locationLabel}>Meeting at</Text>
+            <Text style={styles.locationText}>{booking.location}</Text>
+          </View>
+        )}
+        <View style={styles.waitingCard}>
+          <Text style={styles.waitingText}>Waiting for {booking?.seeker?.name ?? 'your guest'}...</Text>
+          <Text style={styles.waitingSubtext}>They'll check in when they arrive</Text>
+          <ActivityIndicator color="#FF2A5F" style={{ marginTop: 16 }} />
+        </View>
+        <View style={styles.statusRow}>
+          <View style={[styles.dot, styles.dotGreen]} />
+          <Text style={styles.statusName}>You</Text>
+          <View style={[styles.dot, booking?.seekerCheckinAt ? styles.dotGreen : styles.dotGray, { marginLeft: 24 }]} />
+          <Text style={styles.statusName}>{booking?.seeker?.name ?? 'Guest'}</Text>
+        </View>
+      </View>
+    );
+  }
 
   return (
-    <View style={styles.container}>
+    <ScrollView style={styles.scroll} contentContainerStyle={styles.container}>
       <Text style={styles.title}>Confirm Your{'\n'}Arrival</Text>
 
       {booking?.location && (
@@ -77,57 +157,109 @@ export default function CompanionCheckinScreen() {
         </View>
       )}
 
-      <View style={styles.pinIcon}>
-        <Text style={styles.pinEmoji}>📍</Text>
+      {/* Step 1: Selfie */}
+      <View style={styles.stepCard}>
+        <View style={styles.stepHeader}>
+          <View style={[styles.stepBadge, selfieUri ? styles.stepBadgeDone : styles.stepBadgeTodo]}>
+            <Text style={styles.stepBadgeText}>{selfieUri ? '✓' : '1'}</Text>
+          </View>
+          <Text style={styles.stepTitle}>Take a Selfie</Text>
+        </View>
+        <Text style={styles.stepDesc}>Verify your identity at the location</Text>
+        {selfieUri ? (
+          <View style={styles.selfieRow}>
+            <Image source={{ uri: selfieUri }} style={styles.selfieThumb} />
+            <TouchableOpacity style={styles.retakeBtn} onPress={handleTakeSelfie}>
+              <Text style={styles.retakeBtnText}>Retake</Text>
+            </TouchableOpacity>
+          </View>
+        ) : (
+          <TouchableOpacity style={styles.cameraBtn} onPress={handleTakeSelfie}>
+            <Text style={styles.cameraBtnText}>📸  Open Camera</Text>
+          </TouchableOpacity>
+        )}
       </View>
 
-      {!checkedIn ? (
-        <TouchableOpacity
-          style={[styles.button, checkingIn && styles.buttonDisabled]}
-          onPress={handleCheckin}
-          disabled={checkingIn}
-        >
-          {checkingIn
-            ? <ActivityIndicator color="#fff" />
-            : <Text style={styles.buttonText}>I'm Here</Text>
-          }
-        </TouchableOpacity>
-      ) : (
-        <View style={styles.waitingCard}>
-          <Text style={styles.waitingText}>You're checked in!</Text>
-          <Text style={styles.waitingSubtext}>Waiting for seeker to check in...</Text>
-          <ActivityIndicator color="#FF2A5F" style={{ marginTop: 16 }} />
+      {/* Step 2: Location */}
+      <View style={[styles.stepCard, step === 'selfie' && styles.stepCardDimmed]}>
+        <View style={styles.stepHeader}>
+          <View style={[styles.stepBadge, locationStatus === 'done' ? styles.stepBadgeDone : styles.stepBadgeTodo]}>
+            <Text style={styles.stepBadgeText}>{locationStatus === 'done' ? '✓' : '2'}</Text>
+          </View>
+          <Text style={styles.stepTitle}>Share Location</Text>
         </View>
-      )}
+        <Text style={styles.stepDesc}>Confirm you're at the meeting spot</Text>
+        {locationStatus === 'done' ? (
+          <View style={styles.locationDoneRow}>
+            <Text style={styles.locationDoneText}>📍 Location captured</Text>
+          </View>
+        ) : locationStatus === 'denied' ? (
+          <View style={styles.locationDoneRow}>
+            <Text style={styles.locationDoneText}>⚠️ Location skipped</Text>
+          </View>
+        ) : (
+          <TouchableOpacity
+            style={[styles.locationBtn, (step === 'selfie' || locationStatus === 'loading') && styles.btnDisabled]}
+            onPress={handleGetLocation}
+            disabled={step === 'selfie' || locationStatus === 'loading'}
+          >
+            {locationStatus === 'loading'
+              ? <ActivityIndicator color="#000" size="small" />
+              : <Text style={styles.locationBtnText}>📍  Get Location</Text>
+            }
+          </TouchableOpacity>
+        )}
+      </View>
 
-      {booking && (
-        <View style={styles.statusRow}>
-          <View style={[styles.dot, booking.companionCheckinAt ? styles.dotGreen : styles.dotGray]} />
-          <Text style={styles.statusName}>You</Text>
-          <View style={[styles.dot, booking.seekerCheckinAt ? styles.dotGreen : styles.dotGray, { marginLeft: 24 }]} />
-          <Text style={styles.statusName}>{booking.seeker?.name ?? 'Seeker'}</Text>
-        </View>
-      )}
-    </View>
+      {/* Check In Button */}
+      <TouchableOpacity
+        style={[styles.checkinBtn, (step !== 'ready' || checkingIn) && styles.btnDisabled]}
+        onPress={handleCheckin}
+        disabled={step !== 'ready' || checkingIn}
+      >
+        {checkingIn
+          ? <ActivityIndicator color="#fff" />
+          : <Text style={styles.checkinBtnText}>I'm Here — Check In</Text>
+        }
+      </TouchableOpacity>
+    </ScrollView>
   );
 }
 
 const styles = StyleSheet.create({
-  container: { flex: 1, backgroundColor: '#F4F0EA', padding: 24, paddingTop: 60 },
+  scroll: { flex: 1, backgroundColor: '#F4F0EA' },
+  container: { padding: 24, paddingTop: 60, paddingBottom: 40 },
   center: { flex: 1, backgroundColor: '#F4F0EA', justifyContent: 'center', alignItems: 'center' },
-  title: { fontSize: 40, fontFamily: 'SpaceGrotesk-Bold', fontWeight: '700', color: '#000', lineHeight: 48, marginBottom: 32 },
-  locationCard: { backgroundColor: '#4DF0FF', borderWidth: 2, borderColor: '#000', padding: 16, marginBottom: 32, shadowOffset: { width: 3, height: 3 }, shadowColor: '#000', shadowOpacity: 1, shadowRadius: 0 },
+  title: { fontSize: 40, fontFamily: 'SpaceGrotesk-Bold', fontWeight: '700', color: '#000', lineHeight: 48, marginBottom: 24 },
+  locationCard: { backgroundColor: '#4DF0FF', borderWidth: 2, borderColor: '#000', padding: 16, marginBottom: 24, shadowOffset: { width: 3, height: 3 }, shadowColor: '#000', shadowOpacity: 1, shadowRadius: 0 },
   locationLabel: { fontSize: 12, fontFamily: 'SpaceGrotesk-Bold', fontWeight: '700', textTransform: 'uppercase', color: '#000', marginBottom: 4 },
   locationText: { fontSize: 18, fontFamily: 'SpaceGrotesk-Bold', fontWeight: '700', color: '#000' },
-  pinIcon: { alignItems: 'center', marginBottom: 40 },
-  pinEmoji: { fontSize: 80 },
-  button: { backgroundColor: '#FF2A5F', borderWidth: 2, borderColor: '#000', paddingVertical: 18, alignItems: 'center', shadowOffset: { width: 4, height: 4 }, shadowColor: '#000', shadowOpacity: 1, shadowRadius: 0 },
-  buttonDisabled: { opacity: 0.6 },
-  buttonText: { fontSize: 20, fontFamily: 'SpaceGrotesk-Bold', fontWeight: '700', color: '#fff' },
-  waitingCard: { backgroundColor: '#FFE600', borderWidth: 2, borderColor: '#000', padding: 20, alignItems: 'center', shadowOffset: { width: 3, height: 3 }, shadowColor: '#000', shadowOpacity: 1, shadowRadius: 0 },
+  stepCard: { backgroundColor: '#fff', borderWidth: 2, borderColor: '#000', padding: 16, marginBottom: 16, shadowOffset: { width: 3, height: 3 }, shadowColor: '#000', shadowOpacity: 1, shadowRadius: 0 },
+  stepCardDimmed: { opacity: 0.4 },
+  stepHeader: { flexDirection: 'row', alignItems: 'center', marginBottom: 6 },
+  stepBadge: { width: 28, height: 28, borderRadius: 14, borderWidth: 2, borderColor: '#000', justifyContent: 'center', alignItems: 'center', marginRight: 10 },
+  stepBadgeTodo: { backgroundColor: '#fff' },
+  stepBadgeDone: { backgroundColor: '#00CC66' },
+  stepBadgeText: { fontSize: 12, fontFamily: 'SpaceGrotesk-Bold', fontWeight: '700', color: '#000' },
+  stepTitle: { fontSize: 18, fontFamily: 'SpaceGrotesk-Bold', fontWeight: '700', color: '#000' },
+  stepDesc: { fontSize: 13, color: '#555', marginBottom: 14, marginLeft: 38 },
+  selfieRow: { flexDirection: 'row', alignItems: 'center', gap: 12 },
+  selfieThumb: { width: 72, height: 72, borderWidth: 2, borderColor: '#000' },
+  retakeBtn: { borderWidth: 2, borderColor: '#000', paddingHorizontal: 16, paddingVertical: 8 },
+  retakeBtnText: { fontSize: 14, fontFamily: 'SpaceGrotesk-Bold', fontWeight: '700', color: '#000' },
+  cameraBtn: { backgroundColor: '#FFE600', borderWidth: 2, borderColor: '#000', paddingVertical: 14, alignItems: 'center', shadowOffset: { width: 3, height: 3 }, shadowColor: '#000', shadowOpacity: 1, shadowRadius: 0 },
+  cameraBtnText: { fontSize: 16, fontFamily: 'SpaceGrotesk-Bold', fontWeight: '700', color: '#000' },
+  locationBtn: { backgroundColor: '#4DF0FF', borderWidth: 2, borderColor: '#000', paddingVertical: 14, alignItems: 'center', shadowOffset: { width: 3, height: 3 }, shadowColor: '#000', shadowOpacity: 1, shadowRadius: 0 },
+  locationBtnText: { fontSize: 16, fontFamily: 'SpaceGrotesk-Bold', fontWeight: '700', color: '#000' },
+  locationDoneRow: { backgroundColor: '#F4F0EA', borderWidth: 1, borderColor: '#ccc', padding: 10 },
+  locationDoneText: { fontSize: 14, fontFamily: 'SpaceGrotesk-Bold', color: '#000' },
+  checkinBtn: { backgroundColor: '#FF2A5F', borderWidth: 2, borderColor: '#000', paddingVertical: 20, alignItems: 'center', marginTop: 8, shadowOffset: { width: 4, height: 4 }, shadowColor: '#000', shadowOpacity: 1, shadowRadius: 0 },
+  btnDisabled: { opacity: 0.4 },
+  checkinBtnText: { fontSize: 20, fontFamily: 'SpaceGrotesk-Bold', fontWeight: '700', color: '#fff' },
+  waitingCard: { backgroundColor: '#FFE600', borderWidth: 2, borderColor: '#000', padding: 20, alignItems: 'center', shadowOffset: { width: 3, height: 3 }, shadowColor: '#000', shadowOpacity: 1, shadowRadius: 0, marginBottom: 24 },
   waitingText: { fontSize: 20, fontFamily: 'SpaceGrotesk-Bold', fontWeight: '700', color: '#000' },
   waitingSubtext: { fontSize: 14, color: '#000', marginTop: 8, textAlign: 'center' },
-  statusRow: { flexDirection: 'row', alignItems: 'center', marginTop: 32, justifyContent: 'center' },
+  statusRow: { flexDirection: 'row', alignItems: 'center', justifyContent: 'center' },
   dot: { width: 14, height: 14, borderRadius: 7, borderWidth: 2, borderColor: '#000' },
   dotGreen: { backgroundColor: '#00CC66' },
   dotGray: { backgroundColor: '#ccc' },


### PR DESCRIPTION
## Summary

Upgrades both seeker and companion pre-date check-in screens with identity verification and location capture.

**Step 1 — Selfie**: Front camera via `expo-image-picker`. Required before proceeding. Shows thumbnail + Retake option.
**Step 2 — Location**: GPS via `expo-location` (Accuracy.High). Non-blocking — denied permission skips with warning.
**Check In button**: Unlocks only after both steps. Passes coords to API.

## Test plan

- [ ] Selfie required before location step unlocks
- [ ] Coords passed to `POST /bookings/:id/checkin`
- [ ] Location denied → skips gracefully, check-in still works
- [ ] Both checked in → redirect to `/date/active/:id`
- [ ] Same flow for companion: `POST /bookings/:id/companion-checkin`

🤖 Generated with [Claude Code](https://claude.com/claude-code)