### PR TITLE
fix: add missing admin endpoints (BUG-696..702)

### DIFF
--- a/backend/daterabbit-api/src/admin/admin.controller.ts
+++ b/backend/daterabbit-api/src/admin/admin.controller.ts
@@ -148,4 +148,24 @@ export class AdminController {
   ) {
     return this.adminService.rejectVerification(id, body.reason);
   }
+
+  // #702 - platform settings
+  @Get('settings')
+  getSettings() {
+    return this.adminService.getSettings();
+  }
+
+  @Patch('settings')
+  updateSettings(
+    @Body() body: {
+      commissionRate?: number;
+      minHourlyRate?: number;
+      maxHourlyRate?: number;
+      requireVerification?: boolean;
+      requirePhotoForCompanion?: boolean;
+      minimumAge?: number;
+    },
+  ) {
+    return this.adminService.updateSettings(body);
+  }
 }

--- a/backend/daterabbit-api/src/admin/admin.module.ts
+++ b/backend/daterabbit-api/src/admin/admin.module.ts
@@ -9,11 +9,12 @@ import { User } from '../users/entities/user.entity';
 import { Booking } from '../bookings/entities/booking.entity';
 import { Verification } from '../verification/entities/verification.entity';
 import { Review } from '../reviews/entities/review.entity';
+import { PlatformSettings } from './entities/platform-settings.entity';
 import { UsersModule } from '../users/users.module';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([User, Booking, Verification, Review]),
+    TypeOrmModule.forFeature([User, Booking, Verification, Review, PlatformSettings]),
     JwtModule.registerAsync({
       imports: [ConfigModule],
       inject: [ConfigService],

--- a/backend/daterabbit-api/src/admin/admin.service.ts
+++ b/backend/daterabbit-api/src/admin/admin.service.ts
@@ -5,6 +5,7 @@ import { User } from '../users/entities/user.entity';
 import { Booking, BookingStatus } from '../bookings/entities/booking.entity';
 import { Verification, VerificationStatus } from '../verification/entities/verification.entity';
 import { Review } from '../reviews/entities/review.entity';
+import { PlatformSettings } from './entities/platform-settings.entity';
 
 @Injectable()
 export class AdminService {
@@ -17,6 +18,8 @@ export class AdminService {
     private verificationsRepo: Repository<Verification>,
     @InjectRepository(Review)
     private reviewsRepo: Repository<Review>,
+    @InjectRepository(PlatformSettings)
+    private settingsRepo: Repository<PlatformSettings>,
   ) {}
 
   async getStats() {
@@ -323,5 +326,72 @@ export class AdminService {
     });
 
     return { success: true };
+  }
+
+  // #702 - platform settings
+  private async getOrCreateSettings(): Promise<PlatformSettings> {
+    let settings = await this.settingsRepo.findOne({ where: {} });
+    if (!settings) {
+      settings = this.settingsRepo.create({});
+      await this.settingsRepo.save(settings);
+    }
+    return settings;
+  }
+
+  async getSettings() {
+    const settings = await this.getOrCreateSettings();
+    return {
+      commissionRate: parseFloat(String(settings.commissionRate)),
+      minHourlyRate: parseFloat(String(settings.minHourlyRate)),
+      maxHourlyRate: parseFloat(String(settings.maxHourlyRate)),
+      requireVerification: settings.requireVerification,
+      requirePhotoForCompanion: settings.requirePhotoForCompanion,
+      minimumAge: settings.minimumAge,
+    };
+  }
+
+  async updateSettings(data: Partial<{
+    commissionRate: number;
+    minHourlyRate: number;
+    maxHourlyRate: number;
+    requireVerification: boolean;
+    requirePhotoForCompanion: boolean;
+    minimumAge: number;
+  }>) {
+    const settings = await this.getOrCreateSettings();
+
+    if (data.commissionRate !== undefined) {
+      if (data.commissionRate < 0 || data.commissionRate > 100) {
+        throw new BadRequestException('Commission rate must be between 0 and 100');
+      }
+      settings.commissionRate = data.commissionRate;
+    }
+    if (data.minHourlyRate !== undefined) {
+      if (data.minHourlyRate < 0) {
+        throw new BadRequestException('Min hourly rate cannot be negative');
+      }
+      settings.minHourlyRate = data.minHourlyRate;
+    }
+    if (data.maxHourlyRate !== undefined) {
+      if (data.maxHourlyRate < 0) {
+        throw new BadRequestException('Max hourly rate cannot be negative');
+      }
+      settings.maxHourlyRate = data.maxHourlyRate;
+    }
+    if (data.requireVerification !== undefined) {
+      settings.requireVerification = data.requireVerification;
+    }
+    if (data.requirePhotoForCompanion !== undefined) {
+      settings.requirePhotoForCompanion = data.requirePhotoForCompanion;
+    }
+    if (data.minimumAge !== undefined) {
+      if (data.minimumAge < 18) {
+        throw new BadRequestException('Minimum age cannot be less than 18');
+      }
+      settings.minimumAge = data.minimumAge;
+    }
+
+    await this.settingsRepo.save(settings);
+    return this.getSettings();
   }
 }

--- a/backend/daterabbit-api/src/admin/entities/platform-settings.entity.ts
+++ b/backend/daterabbit-api/src/admin/entities/platform-settings.entity.ts
@@ -1,0 +1,37 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+
+@Entity('platform_settings')
+export class PlatformSettings {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'decimal', precision: 5, scale: 2, default: 15.0 })
+  commissionRate: number; // platform fee %
+
+  @Column({ type: 'decimal', precision: 10, scale: 2, default: 10.0 })
+  minHourlyRate: number;
+
+  @Column({ type: 'decimal', precision: 10, scale: 2, default: 500.0 })
+  maxHourlyRate: number;
+
+  @Column({ default: true })
+  requireVerification: boolean;
+
+  @Column({ default: true })
+  requirePhotoForCompanion: boolean;
+
+  @Column({ type: 'int', default: 18 })
+  minimumAge: number;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}


### PR DESCRIPTION
## Summary
- Cherry-picked existing admin endpoint fixes (BUG-696 through BUG-701) from `fix/admin-endpoints-684-696-701` branch
- Added new platform settings endpoints for BUG-702: GET/PATCH /admin/settings with PlatformSettings entity

## Endpoints added
- **BUG-696:** GET /admin/me -- current admin user identity
- **BUG-697:** POST /admin/users/:id/ban, POST /admin/users/:id/unban
- **BUG-698:** GET /admin/users/:userId/bookings -- user booking history
- **BUG-699:** POST /admin/bookings/:id/cancel -- admin booking cancellation
- **BUG-700:** GET /admin/revenue, GET /admin/transactions -- financial analytics
- **BUG-701:** GET /admin/reviews, DELETE /admin/reviews/:id -- review moderation
- **BUG-702:** GET /admin/settings, PATCH /admin/settings -- platform configuration

## Test plan
- [ ] Verify all endpoints respond with correct status codes
- [ ] Verify AdminGuard protects all endpoints
- [ ] Verify PlatformSettings table auto-creates on staging (synchronize: true)
- [ ] Verify settings validation (commission 0-100, min age >= 18, rates >= 0)

Generated with [Claude Code](https://claude.com/claude-code)