### PR TITLE
fix: remove orphan step breaking deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,13 +11,6 @@ on:
         default: ''
 
 jobs:
-
-      - name: Cleanup node_modules
-        if: always()
-        run: |
-          find . -type d -name "node_modules" -exec rm -rf {} + 2>/dev/null || true
-          echo "Cleanup done — runner disk freed"
-
   deploy-staging:
     name: Deploy → Staging
     if: github.ref == 'refs/heads/development'


### PR DESCRIPTION
## Summary
- Removed orphan `Cleanup node_modules` step that was placed directly under `jobs:` without a job definition
- This caused GitHub Actions YAML parser to reject the entire workflow, failing all runs with "workflow file issue" and 0 jobs
- The cleanup steps inside `deploy-staging` and `deploy-production` jobs are already present and correct

## Root cause
Commit `aa4b760` ("chore: cleanup node_modules after deploy") added the step in the wrong YAML location.

## Test plan
- [x] YAML validates locally with Python yaml parser
- [x] TypeScript compiles with zero errors
- [ ] Verify GitHub Actions run succeeds after merge

Generated with [Claude Code](https://claude.com/claude-code)