### PR TITLE
feat: Active Date endpoints (Group 1 + Group 2)

### DIFF
--- a/backend/daterabbit-api/src/bookings/bookings.controller.ts
+++ b/backend/daterabbit-api/src/bookings/bookings.controller.ts
@@ -105,6 +105,13 @@ export class BookingsController {
     return requests.map((b) => this.formatBooking(b));
   }
 
+  @Get('active')
+  async getActiveDateBooking(@Request() req) {
+    const booking = await this.bookingsService.getActiveDateBooking(req.user.id);
+    if (!booking) return null;
+    return this.formatBooking(booking);
+  }
+
   @Get(':id')
   async getBooking(@Param('id') id: string, @Request() req) {
     const booking = await this.bookingsService.findById(id);
@@ -169,13 +176,6 @@ export class BookingsController {
     return this.formatBooking(updated);
   }
 
-  @Get('active')
-  async getActiveDateBooking(@Request() req) {
-    const booking = await this.bookingsService.getActiveDateBooking(req.user.id);
-    if (!booking) return null;
-    return this.formatBooking(booking);
-  }
-
   @Post(':id/checkin')
   async seekerCheckin(@Param('id') id: string, @Request() req, @Body() body: { lat?: number; lon?: number }) {
     const booking = await this.bookingsService.seekerCheckin(id, req.user.id, body.lat, body.lon);
@@ -200,6 +200,105 @@ export class BookingsController {
     return this.formatBooking(booking);
   }
 
+  // --- Group 1: Safety check-in ---
+
+  @Post(':id/safety-checkin')
+  async safetyCheckin(@Param('id') id: string, @Request() req) {
+    const booking = await this.bookingsService.safetyCheckin(id, req.user.id);
+    return this.formatBooking(booking);
+  }
+
+  // --- Group 1: Photos ---
+
+  @Post(':id/photos')
+  async uploadPhoto(
+    @Param('id') id: string,
+    @Request() req,
+    @Body() body: { url: string },
+  ) {
+    if (!body.url) {
+      throw new HttpException('Photo URL is required', HttpStatus.BAD_REQUEST);
+    }
+    return this.bookingsService.addPhoto(id, req.user.id, body.url);
+  }
+
+  @Get(':id/photos')
+  async getPhotos(@Param('id') id: string, @Request() req) {
+    return this.bookingsService.getPhotos(id, req.user.id);
+  }
+
+  // --- Group 1: Date plan ---
+
+  @Get(':id/plan')
+  async getDatePlan(@Param('id') id: string, @Request() req) {
+    return this.bookingsService.getDatePlan(id, req.user.id);
+  }
+
+  @Put(':id/plan')
+  async updateDatePlan(
+    @Param('id') id: string,
+    @Request() req,
+    @Body() body: { plan: Record<string, any> },
+  ) {
+    if (!body.plan) {
+      throw new HttpException('Plan data is required', HttpStatus.BAD_REQUEST);
+    }
+    const booking = await this.bookingsService.updateDatePlan(id, req.user.id, body.plan);
+    return this.formatBooking(booking);
+  }
+
+  // --- Group 1: Report issue ---
+
+  @Post(':id/report-issue')
+  async reportIssue(
+    @Param('id') id: string,
+    @Request() req,
+    @Body() body: { type: string; text: string },
+  ) {
+    if (!body.type || !body.text) {
+      throw new HttpException('Issue type and text are required', HttpStatus.BAD_REQUEST);
+    }
+    const validTypes = ['safety', 'behavior', 'scam', 'other'];
+    if (!validTypes.includes(body.type)) {
+      throw new HttpException(
+        `Invalid issue type. Must be one of: ${validTypes.join(', ')}`,
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+    const booking = await this.bookingsService.reportIssue(id, req.user.id, body.type, body.text);
+    return this.formatBooking(booking);
+  }
+
+  // --- Group 1: Extend request ---
+
+  @Post(':id/extend-request')
+  async extendRequest(
+    @Param('id') id: string,
+    @Request() req,
+    @Body() body: { hours: number },
+  ) {
+    if (!body.hours || typeof body.hours !== 'number') {
+      throw new HttpException('Hours is required and must be a number', HttpStatus.BAD_REQUEST);
+    }
+    const booking = await this.bookingsService.requestExtend(id, req.user.id, body.hours);
+    return this.formatBooking(booking);
+  }
+
+  // --- Group 2: Extend response ---
+
+  @Put(':id/extend-response')
+  async extendResponse(
+    @Param('id') id: string,
+    @Request() req,
+    @Body() body: { approved: boolean },
+  ) {
+    if (typeof body.approved !== 'boolean') {
+      throw new HttpException('approved (boolean) is required', HttpStatus.BAD_REQUEST);
+    }
+    const booking = await this.bookingsService.respondExtend(id, req.user.id, body.approved);
+    return this.formatBooking(booking);
+  }
+
   private formatBooking(booking: any) {
     return {
       id: booking.id,
@@ -218,6 +317,13 @@ export class BookingsController {
       actualDurationHours: booking.actualDurationHours || undefined,
       sosTriggeredAt: booking.sosTriggeredAt || undefined,
       noShowReason: booking.noShowReason || undefined,
+      datePlan: booking.datePlan || undefined,
+      safetyCheckinAt: booking.safetyCheckinAt || undefined,
+      extendRequestedHours: booking.extendRequestedHours || undefined,
+      extendRequestedAt: booking.extendRequestedAt || undefined,
+      extendApproved: booking.extendApproved !== null && booking.extendApproved !== undefined ? booking.extendApproved : undefined,
+      reportIssueType: booking.reportIssueType || undefined,
+      reportIssueText: booking.reportIssueText || undefined,
       seeker: booking.seeker ? {
         id: booking.seeker.id,
         name: booking.seeker.name,

--- a/backend/daterabbit-api/src/bookings/bookings.cron.ts
+++ b/backend/daterabbit-api/src/bookings/bookings.cron.ts
@@ -29,6 +29,10 @@ export class BookingsCron {
       this.logger.log(`No-show detected for booking ${booking.id}`);
       const reason = !booking.companionCheckinAt ? 'seeker' : 'companion';
       await this.bookingsService.handleNoShow(booking.id, reason).catch(() => {});
+      // TODO: Trigger Stripe refund for no-show bookings
+      // If seeker no-show: release hold / partial charge for companion compensation
+      // If companion no-show: full refund to seeker
+      // Implement via PaymentsService when Stripe logic is ready
     }
   }
 }

--- a/backend/daterabbit-api/src/bookings/bookings.module.ts
+++ b/backend/daterabbit-api/src/bookings/bookings.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Booking } from './entities/booking.entity';
+import { DatePhoto } from './entities/date-photo.entity';
 import { BookingsService } from './bookings.service';
 import { BookingsController } from './bookings.controller';
 import { BookingsCron } from './bookings.cron';
@@ -9,7 +10,7 @@ import { EmailModule } from '../email/email.module';
 import { PaymentsModule } from '../payments/payments.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Booking]), UsersModule, EmailModule, PaymentsModule],
+  imports: [TypeOrmModule.forFeature([Booking, DatePhoto]), UsersModule, EmailModule, PaymentsModule],
   providers: [BookingsService, BookingsCron],
   controllers: [BookingsController],
   exports: [BookingsService],

--- a/backend/daterabbit-api/src/bookings/bookings.service.ts
+++ b/backend/daterabbit-api/src/bookings/bookings.service.ts
@@ -2,6 +2,7 @@ import { Injectable, HttpException, HttpStatus } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository, MoreThanOrEqual, LessThan } from 'typeorm';
 import { Booking, BookingStatus, ActivityType } from './entities/booking.entity';
+import { DatePhoto } from './entities/date-photo.entity';
 import { UsersService } from '../users/users.service';
 import { EmailService } from '../email/email.service';
 
@@ -10,6 +11,8 @@ export class BookingsService {
   constructor(
     @InjectRepository(Booking)
     private bookingsRepository: Repository<Booking>,
+    @InjectRepository(DatePhoto)
+    private datePhotosRepository: Repository<DatePhoto>,
     private usersService: UsersService,
     private emailService: EmailService,
   ) {}
@@ -268,6 +271,10 @@ export class BookingsService {
     if (booking.status !== BookingStatus.CONFIRMED && booking.status !== BookingStatus.PAID) {
       throw new HttpException('Booking is not in a confirmable state', HttpStatus.BAD_REQUEST);
     }
+    // Group 2: Log geo coordinates for future distance validation
+    if (lat !== undefined && lon !== undefined) {
+      console.log(`[GEO] Seeker checkin booking=${bookingId} lat=${lat} lon=${lon}`);
+    }
     const now = new Date();
     const update: Partial<Booking> = { seekerCheckinAt: now };
     if (booking.companionCheckinAt) {
@@ -284,6 +291,10 @@ export class BookingsService {
     if (booking.companionId !== companionId) throw new HttpException('Unauthorized', HttpStatus.FORBIDDEN);
     if (booking.status !== BookingStatus.CONFIRMED && booking.status !== BookingStatus.PAID) {
       throw new HttpException('Booking is not in a confirmable state', HttpStatus.BAD_REQUEST);
+    }
+    // Group 2: Log geo coordinates for future distance validation
+    if (lat !== undefined && lon !== undefined) {
+      console.log(`[GEO] Companion checkin booking=${bookingId} lat=${lat} lon=${lon}`);
     }
     const now = new Date();
     const update: Partial<Booking> = { companionCheckinAt: now };
@@ -348,5 +359,137 @@ export class BookingsService {
       ],
       relations: ['seeker', 'companion'],
     });
+  }
+
+  // --- Group 1: Safety check-in ---
+
+  async safetyCheckin(bookingId: string, userId: string): Promise<Booking> {
+    const booking = await this.findById(bookingId);
+    if (!booking) throw new HttpException('Booking not found', HttpStatus.NOT_FOUND);
+    if (booking.seekerId !== userId && booking.companionId !== userId) {
+      throw new HttpException('Unauthorized', HttpStatus.FORBIDDEN);
+    }
+    if (booking.status !== BookingStatus.ACTIVE) {
+      throw new HttpException('Booking is not active', HttpStatus.BAD_REQUEST);
+    }
+    await this.bookingsRepository.update(bookingId, { safetyCheckinAt: new Date() });
+    return this.findById(bookingId) as Promise<Booking>;
+  }
+
+  // --- Group 1: Photos ---
+
+  async addPhoto(bookingId: string, userId: string, url: string): Promise<DatePhoto> {
+    const booking = await this.findById(bookingId);
+    if (!booking) throw new HttpException('Booking not found', HttpStatus.NOT_FOUND);
+    if (booking.seekerId !== userId && booking.companionId !== userId) {
+      throw new HttpException('Unauthorized', HttpStatus.FORBIDDEN);
+    }
+    const photo = this.datePhotosRepository.create({
+      bookingId,
+      url,
+      uploadedBy: userId,
+    });
+    return this.datePhotosRepository.save(photo);
+  }
+
+  async getPhotos(bookingId: string, userId: string): Promise<DatePhoto[]> {
+    const booking = await this.findById(bookingId);
+    if (!booking) throw new HttpException('Booking not found', HttpStatus.NOT_FOUND);
+    if (booking.seekerId !== userId && booking.companionId !== userId) {
+      throw new HttpException('Unauthorized', HttpStatus.FORBIDDEN);
+    }
+    return this.datePhotosRepository.find({
+      where: { bookingId },
+      order: { createdAt: 'ASC' },
+    });
+  }
+
+  // --- Group 1: Date plan ---
+
+  async getDatePlan(bookingId: string, userId: string): Promise<Record<string, any> | null> {
+    const booking = await this.findById(bookingId);
+    if (!booking) throw new HttpException('Booking not found', HttpStatus.NOT_FOUND);
+    if (booking.seekerId !== userId && booking.companionId !== userId) {
+      throw new HttpException('Unauthorized', HttpStatus.FORBIDDEN);
+    }
+    return booking.datePlan || null;
+  }
+
+  async updateDatePlan(bookingId: string, userId: string, plan: Record<string, any>): Promise<Booking> {
+    const booking = await this.findById(bookingId);
+    if (!booking) throw new HttpException('Booking not found', HttpStatus.NOT_FOUND);
+    if (booking.seekerId !== userId) {
+      throw new HttpException('Only seeker can update the date plan', HttpStatus.FORBIDDEN);
+    }
+    if (booking.status === BookingStatus.COMPLETED || booking.status === BookingStatus.CANCELLED) {
+      throw new HttpException('Cannot update plan for a finished booking', HttpStatus.BAD_REQUEST);
+    }
+    await this.bookingsRepository.update(bookingId, { datePlan: plan });
+    return this.findById(bookingId) as Promise<Booking>;
+  }
+
+  // --- Group 1: Report issue ---
+
+  async reportIssue(
+    bookingId: string,
+    userId: string,
+    issueType: string,
+    issueText: string,
+  ): Promise<Booking> {
+    const booking = await this.findById(bookingId);
+    if (!booking) throw new HttpException('Booking not found', HttpStatus.NOT_FOUND);
+    if (booking.seekerId !== userId && booking.companionId !== userId) {
+      throw new HttpException('Unauthorized', HttpStatus.FORBIDDEN);
+    }
+    await this.bookingsRepository.update(bookingId, {
+      reportIssueType: issueType,
+      reportIssueText: issueText,
+    });
+    return this.findById(bookingId) as Promise<Booking>;
+  }
+
+  // --- Group 1: Extend request ---
+
+  async requestExtend(bookingId: string, userId: string, hours: number): Promise<Booking> {
+    const booking = await this.findById(bookingId);
+    if (!booking) throw new HttpException('Booking not found', HttpStatus.NOT_FOUND);
+    if (booking.seekerId !== userId) {
+      throw new HttpException('Only seeker can request extension', HttpStatus.FORBIDDEN);
+    }
+    if (booking.status !== BookingStatus.ACTIVE) {
+      throw new HttpException('Can only extend an active date', HttpStatus.BAD_REQUEST);
+    }
+    if (hours <= 0 || hours > 8) {
+      throw new HttpException('Extension hours must be between 0 and 8', HttpStatus.BAD_REQUEST);
+    }
+    await this.bookingsRepository.update(bookingId, {
+      extendRequestedHours: hours,
+      extendRequestedAt: new Date(),
+      extendApproved: undefined,
+    });
+    return this.findById(bookingId) as Promise<Booking>;
+  }
+
+  // --- Group 2: Extend response (companion accept/reject) ---
+
+  async respondExtend(bookingId: string, companionId: string, approved: boolean): Promise<Booking> {
+    const booking = await this.findById(bookingId);
+    if (!booking) throw new HttpException('Booking not found', HttpStatus.NOT_FOUND);
+    if (booking.companionId !== companionId) {
+      throw new HttpException('Only companion can respond to extension', HttpStatus.FORBIDDEN);
+    }
+    if (!booking.extendRequestedAt || booking.extendApproved !== null && booking.extendApproved !== undefined) {
+      throw new HttpException('No pending extension request', HttpStatus.BAD_REQUEST);
+    }
+    const update: Partial<Booking> = { extendApproved: approved };
+    if (approved && booking.extendRequestedHours) {
+      update.duration = booking.duration + booking.extendRequestedHours;
+      // Recalculate total price
+      const companion = await this.usersService.findById(companionId);
+      const hourlyRate = companion?.hourlyRate || 100;
+      update.totalPrice = booking.totalPrice + booking.extendRequestedHours * hourlyRate;
+    }
+    await this.bookingsRepository.update(bookingId, update);
+    return this.findById(bookingId) as Promise<Booking>;
   }
 }

--- a/backend/daterabbit-api/src/bookings/entities/booking.entity.ts
+++ b/backend/daterabbit-api/src/bookings/entities/booking.entity.ts
@@ -98,6 +98,27 @@ export class Booking {
   @Column({ type: 'text', nullable: true })
   noShowReason: string;
 
+  @Column({ type: 'jsonb', nullable: true })
+  datePlan: Record<string, any>;
+
+  @Column({ type: 'decimal', precision: 10, scale: 2, nullable: true })
+  extendRequestedHours: number;
+
+  @Column({ type: 'timestamp', nullable: true })
+  extendRequestedAt: Date;
+
+  @Column({ type: 'boolean', nullable: true })
+  extendApproved: boolean;
+
+  @Column({ type: 'timestamp', nullable: true })
+  safetyCheckinAt: Date;
+
+  @Column({ type: 'text', nullable: true })
+  reportIssueText: string;
+
+  @Column({ nullable: true })
+  reportIssueType: string;
+
   @CreateDateColumn()
   createdAt: Date;
 

--- a/backend/daterabbit-api/src/bookings/entities/date-photo.entity.ts
+++ b/backend/daterabbit-api/src/bookings/entities/date-photo.entity.ts
@@ -1,0 +1,31 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  ManyToOne,
+  JoinColumn,
+} from 'typeorm';
+import { Booking } from './booking.entity';
+
+@Entity('date_photos')
+export class DatePhoto {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  bookingId: string;
+
+  @ManyToOne(() => Booking)
+  @JoinColumn({ name: 'bookingId' })
+  booking: Booking;
+
+  @Column()
+  url: string;
+
+  @Column()
+  uploadedBy: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}


### PR DESCRIPTION
## Summary
- Added 7 new endpoints for Active Date feature: safety-checkin, photos (upload/get), date plan (get/update), report-issue, extend-request
- Added extend-response endpoint for companion to accept/reject extension
- Added geo-coordinate logging in check-in endpoints (stub for future distance validation)
- Added TODO for Stripe refund in no-show cron
- Created DatePhoto entity for photo storage
- Extended Booking entity with: datePlan, extendRequestedHours/At/Approved, safetyCheckinAt, reportIssueType/Text
- Fixed GET /active route ordering (was after GET /:id, causing route conflict)

## New Endpoints
| Method | Path | Description |
|--------|------|-------------|
| POST | /bookings/:id/safety-checkin | Safety confirmation |
| POST | /bookings/:id/photos | Upload photo URL |
| GET | /bookings/:id/photos | Get photos |
| GET | /bookings/:id/plan | Get date plan |
| PUT | /bookings/:id/plan | Update date plan |
| POST | /bookings/:id/report-issue | Report issue |
| POST | /bookings/:id/extend-request | Request extension |
| PUT | /bookings/:id/extend-response | Accept/reject extension |

## Test plan
- [ ] Verify safety-checkin updates safetyCheckinAt on active booking
- [ ] Verify photo upload/retrieval via DatePhoto entity
- [ ] Verify date plan CRUD (only seeker can update)
- [ ] Verify report-issue saves type + text
- [ ] Verify extend request/response flow with price recalculation
- [ ] Verify GET /active no longer conflicts with GET /:id

Generated with [Claude Code](https://claude.com/claude-code)