### PR TITLE
feat: missing UC endpoints (pre-chat, request_sent, seeker_declined)

### DIFF
--- a/backend/daterabbit-api/src/app.module.ts
+++ b/backend/daterabbit-api/src/app.module.ts
@@ -13,6 +13,7 @@ import { VerificationModule } from './verification/verification.module';
 import { ReviewsModule } from './reviews/reviews.module';
 import { PaymentsModule } from './payments/payments.module';
 import { AdminModule } from './admin/admin.module';
+import { NotificationsModule } from './notifications/notifications.module';
 
 @Module({
   imports: [
@@ -58,6 +59,7 @@ import { AdminModule } from './admin/admin.module';
     ReviewsModule,
     PaymentsModule,
     AdminModule,
+    NotificationsModule,
   ],
   providers: [
     {

--- a/backend/daterabbit-api/src/bookings/bookings.controller.ts
+++ b/backend/daterabbit-api/src/bookings/bookings.controller.ts
@@ -3,6 +3,8 @@ import { BookingsService } from './bookings.service';
 import { PaymentsService } from '../payments/payments.service';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { BookingStatus, ActivityType } from './entities/booking.entity';
+import { NotificationsService } from '../notifications/notifications.service';
+import { NotificationType } from '../notifications/entities/notification.entity';
 
 @Controller('bookings')
 @UseGuards(JwtAuthGuard)
@@ -10,6 +12,7 @@ export class BookingsController {
   constructor(
     private bookingsService: BookingsService,
     private paymentsService: PaymentsService,
+    private notificationsService: NotificationsService,
   ) {}
 
   @Post()
@@ -112,6 +115,38 @@ export class BookingsController {
     return this.formatBooking(booking);
   }
 
+  /**
+   * UC-050: Get booking status for request_sent polling screen.
+   * Returns status, companion info, and elapsed time since request was sent.
+   */
+  @Get(':id/status')
+  async getBookingStatus(@Param('id') id: string, @Request() req) {
+    const booking = await this.bookingsService.findById(id);
+    if (!booking) {
+      throw new HttpException('Booking not found', HttpStatus.NOT_FOUND);
+    }
+    if (booking.seekerId !== req.user.id && booking.companionId !== req.user.id) {
+      throw new HttpException('Unauthorized', HttpStatus.FORBIDDEN);
+    }
+
+    const now = new Date();
+    const createdAt = new Date(booking.createdAt);
+    const elapsedSeconds = Math.floor((now.getTime() - createdAt.getTime()) / 1000);
+
+    return {
+      id: booking.id,
+      status: booking.status,
+      elapsedSeconds,
+      createdAt: booking.createdAt,
+      companion: booking.companion ? {
+        id: booking.companion.id,
+        name: booking.companion.name,
+        photos: booking.companion.photos,
+      } : undefined,
+      cancellationReason: booking.cancellationReason || undefined,
+    };
+  }
+
   @Get(':id')
   async getBooking(@Param('id') id: string, @Request() req) {
     const booking = await this.bookingsService.findById(id);
@@ -163,6 +198,39 @@ export class BookingsController {
     this.paymentsService.cancelPaymentHold(id).catch(err =>
       console.error('Stripe cancel error for booking', id, err),
     );
+
+    // UC-051: Notify the other party about cancellation
+    const isCompanionCancelling = booking.companionId === req.user.id;
+    if (isCompanionCancelling) {
+      // Companion declined -> notify seeker
+      await this.notificationsService.create({
+        userId: booking.seekerId,
+        type: NotificationType.BOOKING_DECLINED,
+        title: 'Booking Declined',
+        body: `${booking.companion?.name || 'The companion'} has declined your booking request.${body.reason ? ` Reason: ${body.reason}` : ''}`,
+        data: {
+          bookingId: booking.id,
+          companionId: booking.companionId,
+          companionName: booking.companion?.name,
+          reason: body.reason,
+        },
+      });
+    } else {
+      // Seeker cancelled -> notify companion
+      await this.notificationsService.create({
+        userId: booking.companionId,
+        type: NotificationType.BOOKING_CANCELLED,
+        title: 'Booking Cancelled',
+        body: `${booking.seeker?.name || 'The seeker'} has cancelled the booking.${body.reason ? ` Reason: ${body.reason}` : ''}`,
+        data: {
+          bookingId: booking.id,
+          seekerId: booking.seekerId,
+          seekerName: booking.seeker?.name,
+          reason: body.reason,
+        },
+      });
+    }
+
     return this.formatBooking(updated);
   }
 

--- a/backend/daterabbit-api/src/bookings/bookings.module.ts
+++ b/backend/daterabbit-api/src/bookings/bookings.module.ts
@@ -8,9 +8,10 @@ import { BookingsCron } from './bookings.cron';
 import { UsersModule } from '../users/users.module';
 import { EmailModule } from '../email/email.module';
 import { PaymentsModule } from '../payments/payments.module';
+import { NotificationsModule } from '../notifications/notifications.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Booking, DatePhoto]), UsersModule, EmailModule, PaymentsModule],
+  imports: [TypeOrmModule.forFeature([Booking, DatePhoto]), UsersModule, EmailModule, PaymentsModule, NotificationsModule],
   providers: [BookingsService, BookingsCron],
   controllers: [BookingsController],
   exports: [BookingsService],

--- a/backend/daterabbit-api/src/bookings/bookings.service.ts
+++ b/backend/daterabbit-api/src/bookings/bookings.service.ts
@@ -492,4 +492,14 @@ export class BookingsService {
     await this.bookingsRepository.update(bookingId, update);
     return this.findById(bookingId) as Promise<Booking>;
   }
+
+  /**
+   * Check if any booking exists between a seeker and companion (any status).
+   */
+  async hasAnyBooking(seekerId: string, companionId: string): Promise<boolean> {
+    const count = await this.bookingsRepository.count({
+      where: { seekerId, companionId },
+    });
+    return count > 0;
+  }
 }

--- a/backend/daterabbit-api/src/messages/messages.controller.ts
+++ b/backend/daterabbit-api/src/messages/messages.controller.ts
@@ -81,6 +81,17 @@ export class MessagesController {
     }));
   }
 
+  /**
+   * UC-037: Get pre-chat status (how many messages can be sent before booking).
+   */
+  @Get(':userId/pre-chat')
+  async getPreChatStatus(
+    @Param('userId') companionId: string,
+    @Request() req,
+  ) {
+    return this.messagesService.getPreChatStatus(req.user.id, companionId);
+  }
+
   @Post(':userId')
   async sendMessage(
     @Param('userId') receiverId: string,
@@ -101,6 +112,15 @@ export class MessagesController {
     ]);
     if (blockedByMe || blockedByThem) {
       throw new HttpException('Cannot send message to this user', HttpStatus.FORBIDDEN);
+    }
+
+    // UC-037: Enforce pre-chat message limit
+    const preChatStatus = await this.messagesService.getPreChatStatus(req.user.id, receiverId);
+    if (!preChatStatus.allowed) {
+      throw new HttpException(
+        `Pre-chat limit reached (${preChatStatus.limit} messages). Create a booking to continue chatting.`,
+        HttpStatus.FORBIDDEN,
+      );
     }
 
     const message = await this.messagesService.sendMessage(

--- a/backend/daterabbit-api/src/messages/messages.module.ts
+++ b/backend/daterabbit-api/src/messages/messages.module.ts
@@ -4,11 +4,13 @@ import { Message, Conversation } from './entities/message.entity';
 import { MessagesService } from './messages.service';
 import { MessagesController } from './messages.controller';
 import { UsersModule } from '../users/users.module';
+import { BookingsModule } from '../bookings/bookings.module';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([Message, Conversation]),
     UsersModule,
+    BookingsModule,
   ],
   providers: [MessagesService],
   controllers: [MessagesController],

--- a/backend/daterabbit-api/src/messages/messages.service.ts
+++ b/backend/daterabbit-api/src/messages/messages.service.ts
@@ -2,6 +2,10 @@ import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Message, Conversation } from './entities/message.entity';
+import { BookingsService } from '../bookings/bookings.service';
+
+// Max messages a seeker can send to a companion before booking
+const PRE_CHAT_LIMIT = 3;
 
 @Injectable()
 export class MessagesService {
@@ -10,6 +14,7 @@ export class MessagesService {
     private messagesRepository: Repository<Message>,
     @InjectRepository(Conversation)
     private conversationsRepository: Repository<Conversation>,
+    private bookingsService: BookingsService,
   ) {}
 
   async getOrCreateConversation(user1Id: string, user2Id: string): Promise<Conversation> {
@@ -87,5 +92,33 @@ export class MessagesService {
     return this.messagesRepository.count({
       where: { receiverId: userId, isRead: false },
     });
+  }
+
+  /**
+   * UC-037: Check if seeker can send pre-chat message to companion.
+   * Returns { allowed, sent, limit } indicating whether the seeker
+   * can still send messages before creating a booking.
+   */
+  async getPreChatStatus(
+    senderId: string,
+    receiverId: string,
+  ): Promise<{ allowed: boolean; sent: number; limit: number }> {
+    // Check if any booking exists between these users
+    const hasBooking = await this.bookingsService.hasAnyBooking(senderId, receiverId);
+    if (hasBooking) {
+      // No limit if a booking already exists
+      return { allowed: true, sent: 0, limit: PRE_CHAT_LIMIT };
+    }
+
+    // Count messages sent by this sender to this receiver
+    const sent = await this.messagesRepository.count({
+      where: { senderId, receiverId },
+    });
+
+    return {
+      allowed: sent < PRE_CHAT_LIMIT,
+      sent,
+      limit: PRE_CHAT_LIMIT,
+    };
   }
 }

--- a/backend/daterabbit-api/src/notifications/entities/notification.entity.ts
+++ b/backend/daterabbit-api/src/notifications/entities/notification.entity.ts
@@ -1,0 +1,48 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  ManyToOne,
+  JoinColumn,
+} from 'typeorm';
+import { User } from '../../users/entities/user.entity';
+
+export enum NotificationType {
+  BOOKING_CONFIRMED = 'booking_confirmed',
+  BOOKING_DECLINED = 'booking_declined',
+  BOOKING_CANCELLED = 'booking_cancelled',
+  BOOKING_COMPLETED = 'booking_completed',
+  NEW_MESSAGE = 'new_message',
+}
+
+@Entity('notifications')
+export class Notification {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  userId: string;
+
+  @ManyToOne(() => User)
+  @JoinColumn({ name: 'userId' })
+  user: User;
+
+  @Column({ type: 'enum', enum: NotificationType })
+  type: NotificationType;
+
+  @Column()
+  title: string;
+
+  @Column({ type: 'text' })
+  body: string;
+
+  @Column({ type: 'jsonb', nullable: true })
+  data: Record<string, any>;
+
+  @Column({ default: false })
+  isRead: boolean;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}

--- a/backend/daterabbit-api/src/notifications/notifications.controller.ts
+++ b/backend/daterabbit-api/src/notifications/notifications.controller.ts
@@ -1,0 +1,50 @@
+import { Controller, Get, Put, Param, Query, UseGuards, Request } from '@nestjs/common';
+import { NotificationsService } from './notifications.service';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+
+@Controller('notifications')
+@UseGuards(JwtAuthGuard)
+export class NotificationsController {
+  constructor(private notificationsService: NotificationsService) {}
+
+  @Get()
+  async getNotifications(
+    @Request() req,
+    @Query('limit') limit?: string,
+    @Query('offset') offset?: string,
+  ) {
+    const notifications = await this.notificationsService.getByUser(
+      req.user.id,
+      Math.min(limit ? parseInt(limit) || 20 : 20, 50),
+      offset ? parseInt(offset) || 0 : 0,
+    );
+
+    return notifications.map((n) => ({
+      id: n.id,
+      type: n.type,
+      title: n.title,
+      body: n.body,
+      data: n.data,
+      isRead: n.isRead,
+      createdAt: n.createdAt,
+    }));
+  }
+
+  @Get('unread-count')
+  async getUnreadCount(@Request() req) {
+    const count = await this.notificationsService.getUnreadCount(req.user.id);
+    return { count };
+  }
+
+  @Put(':id/read')
+  async markAsRead(@Param('id') id: string, @Request() req) {
+    await this.notificationsService.markAsRead(id, req.user.id);
+    return { success: true };
+  }
+
+  @Put('read-all')
+  async markAllAsRead(@Request() req) {
+    await this.notificationsService.markAllAsRead(req.user.id);
+    return { success: true };
+  }
+}

--- a/backend/daterabbit-api/src/notifications/notifications.module.ts
+++ b/backend/daterabbit-api/src/notifications/notifications.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Notification } from './entities/notification.entity';
+import { NotificationsService } from './notifications.service';
+import { NotificationsController } from './notifications.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Notification])],
+  providers: [NotificationsService],
+  controllers: [NotificationsController],
+  exports: [NotificationsService],
+})
+export class NotificationsModule {}

--- a/backend/daterabbit-api/src/notifications/notifications.service.ts
+++ b/backend/daterabbit-api/src/notifications/notifications.service.ts
@@ -1,0 +1,52 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Notification, NotificationType } from './entities/notification.entity';
+
+@Injectable()
+export class NotificationsService {
+  constructor(
+    @InjectRepository(Notification)
+    private notificationsRepository: Repository<Notification>,
+  ) {}
+
+  async create(data: {
+    userId: string;
+    type: NotificationType;
+    title: string;
+    body: string;
+    data?: Record<string, any>;
+  }): Promise<Notification> {
+    const notification = this.notificationsRepository.create(data);
+    return this.notificationsRepository.save(notification);
+  }
+
+  async getByUser(userId: string, limit = 20, offset = 0): Promise<Notification[]> {
+    return this.notificationsRepository.find({
+      where: { userId },
+      order: { createdAt: 'DESC' },
+      take: limit,
+      skip: offset,
+    });
+  }
+
+  async getUnreadCount(userId: string): Promise<number> {
+    return this.notificationsRepository.count({
+      where: { userId, isRead: false },
+    });
+  }
+
+  async markAsRead(id: string, userId: string): Promise<void> {
+    await this.notificationsRepository.update(
+      { id, userId },
+      { isRead: true },
+    );
+  }
+
+  async markAllAsRead(userId: string): Promise<void> {
+    await this.notificationsRepository.update(
+      { userId, isRead: false },
+      { isRead: true },
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- **UC-037 (pre-chat):** Added 3-message limit for seekers messaging companions before any booking exists. New `GET /messages/:userId/pre-chat` endpoint returns remaining quota. `POST /messages/:userId` now enforces the limit (403 if exceeded).
- **UC-050 (request_sent):** Added `GET /bookings/:id/status` endpoint for polling booking status with elapsed time and companion info, supporting the request_sent waiting screen.
- **UC-051 (seeker_declined):** Created full notifications module. When companion declines a booking, a `booking_declined` notification is automatically created for the seeker. Endpoints: `GET /notifications`, `GET /notifications/unread-count`, `PUT /notifications/:id/read`, `PUT /notifications/read-all`.

## Test plan
- [ ] Verify pre-chat: send 3 messages to companion without booking, 4th should return 403
- [ ] Verify pre-chat: after creating booking, message limit is lifted
- [ ] Verify `GET /bookings/:id/status` returns correct elapsed time and status
- [ ] Verify companion cancel creates notification for seeker
- [ ] Verify seeker cancel creates notification for companion
- [ ] Verify `GET /notifications` returns notifications list
- [ ] Build passes with no errors

Trinity task: #804

Generated with [Claude Code](https://claude.com/claude-code)