### PR TITLE
feat: Active Date frontend wiring (screens, store, navigation)

### DIFF
--- a/app/app/(tabs)/female/requests.tsx
+++ b/app/app/(tabs)/female/requests.tsx
@@ -200,9 +200,29 @@ function RequestCard({ request, type, colors, onAccept, onDecline, formatDate }:
             size="sm"
             style={{ flex: 1 }}
           />
+          {request.isPaid ? (
+            <Button
+              title="Start Date"
+              onPress={() => router.push(`/date/companion-checkin/${request.id}`)}
+              size="sm"
+              style={{ flex: 1 }}
+            />
+          ) : (
+            <Button
+              title="View Details"
+              onPress={() => router.push(`/booking/${request.id}`)}
+              size="sm"
+              style={{ flex: 1 }}
+            />
+          )}
+        </View>
+      )}
+
+      {request.status === 'active' && (
+        <View style={styles.actions}>
           <Button
-            title="View Details"
-            onPress={() => router.push(`/booking/${request.id}`)}
+            title="Resume Date"
+            onPress={() => router.push(`/date/active/${request.id}`)}
             size="sm"
             style={{ flex: 1 }}
           />

--- a/app/app/(tabs)/male/bookings.tsx
+++ b/app/app/(tabs)/male/bookings.tsx
@@ -169,6 +169,7 @@ function BookingCard({ booking, type, colors, onCancel, formatDate }: BookingCar
       case 'cancelled': return { bg: colors.error + '20', text: colors.error };
       case 'completed': return { bg: colors.primary + '20', text: colors.primary };
       case 'paid': return { bg: colors.success + '20', text: colors.success };
+      case 'active': return { bg: colors.accent + '20', text: colors.accent };
       default: return { bg: colors.warning + '20', text: colors.warning };
     }
   };
@@ -208,10 +209,18 @@ function BookingCard({ booking, type, colors, onCancel, formatDate }: BookingCar
             />
           )}
           {booking.isPaid && (
-            <View style={[styles.paidBadge, { backgroundColor: colors.success + '20' }]}>
-              <Icon name="check-circle" size={14} color={colors.success} />
-              <Text style={[styles.paidText, { color: colors.success }]}>Paid</Text>
-            </View>
+            <>
+              <View style={[styles.paidBadge, { backgroundColor: colors.success + '20' }]}>
+                <Icon name="check-circle" size={14} color={colors.success} />
+                <Text style={[styles.paidText, { color: colors.success }]}>Paid</Text>
+              </View>
+              <Button
+                title="Start Date"
+                onPress={() => router.push(`/date/checkin/${booking.id}`)}
+                size="sm"
+                style={{ flex: 1 }}
+              />
+            </>
           )}
           <Button
             title="Message"
@@ -233,6 +242,17 @@ function BookingCard({ booking, type, colors, onCancel, formatDate }: BookingCar
               textStyle={{ color: colors.error }}
             />
           )}
+        </View>
+      )}
+
+      {booking.status === 'active' && (
+        <View style={styles.actions}>
+          <Button
+            title="Resume Date"
+            onPress={() => router.push(`/date/active/${booking.id}`)}
+            size="sm"
+            style={{ flex: 1 }}
+          />
         </View>
       )}
 

--- a/app/app/_layout.tsx
+++ b/app/app/_layout.tsx
@@ -26,6 +26,7 @@ const NON_TAB_AUTH_ROUTES = [
   'stripe',
   'favorites',
   'settings',
+  'date',
 ];
 
 function NavigationGuard() {
@@ -161,6 +162,7 @@ export default function RootLayout() {
         <Stack.Screen name="settings/verification" />
         <Stack.Screen name="settings/delete-account" />
         <Stack.Screen name="settings/payment-methods" />
+        <Stack.Screen name="date" />
       </Stack>
       <NavigationGuard />
     </StripeProvider>

--- a/app/app/date/extend/[bookingId].tsx
+++ b/app/app/date/extend/[bookingId].tsx
@@ -2,7 +2,6 @@ import React, { useState } from 'react';
 import { View, Text, StyleSheet, TouchableOpacity, Alert, ActivityIndicator } from 'react-native';
 import { useLocalSearchParams, router } from 'expo-router';
 import { activeDateApi } from '../../../src/services/activeDateApi';
-import { apiRequest } from '../../../src/services/api';
 
 const HOURS_OPTIONS = [1, 2, 3];
 
@@ -15,10 +14,7 @@ export default function ExtendDateScreen() {
   const handleSend = async () => {
     setSending(true);
     try {
-      await apiRequest(`/bookings/${bookingId}/extend-request`, {
-        method: 'POST',
-        body: { additionalHours: selected },
-      });
+      await activeDateApi.extendDate(bookingId, selected);
       setSent(true);
     } catch (e: any) {
       Alert.alert('Error', e.message || 'Failed to send request');

--- a/app/src/services/activeDateApi.ts
+++ b/app/src/services/activeDateApi.ts
@@ -28,6 +28,17 @@ export const activeDateApi = {
   getBookingById: (id: string) =>
     apiRequest<ActiveBooking>(`/bookings/${id}`),
 
+  startDate: (bookingId: string) =>
+    apiRequest<ActiveBooking>(`/bookings/${bookingId}/start-date`, {
+      method: 'POST',
+    }),
+
+  extendDate: (bookingId: string, additionalHours: number) =>
+    apiRequest<ActiveBooking>(`/bookings/${bookingId}/extend`, {
+      method: 'POST',
+      body: { additionalHours },
+    }),
+
   seekerCheckin: (bookingId: string, coords?: { lat: number; lon: number }) =>
     apiRequest<ActiveBooking>(`/bookings/${bookingId}/checkin`, {
       method: 'POST',
@@ -80,12 +91,12 @@ export const activeDateApi = {
 
   savePlan: (bookingId: string, places: { name: string; address: string; time?: string }[]) =>
     apiRequest<{ ok: boolean }>(`/bookings/${bookingId}/plan`, {
-      method: 'PUT',
+      method: 'POST',
       body: { places },
     }),
 
   reportIssue: (bookingId: string, type: string, description: string) =>
-    apiRequest<{ ok: boolean }>(`/bookings/${bookingId}/report-issue`, {
+    apiRequest<{ ok: boolean }>(`/bookings/${bookingId}/report`, {
       method: 'POST',
       body: { type, description },
     }),

--- a/app/src/store/activeDateStore.ts
+++ b/app/src/store/activeDateStore.ts
@@ -1,0 +1,119 @@
+import { create } from 'zustand';
+import { activeDateApi, ActiveBooking } from '../services/activeDateApi';
+
+interface ActiveDateState {
+  activeBooking: ActiveBooking | null;
+  isLoading: boolean;
+  error: string | null;
+
+  // Actions
+  fetchActive: () => Promise<void>;
+  fetchBooking: (id: string) => Promise<void>;
+  startDate: (bookingId: string) => Promise<{ success: boolean; error?: string }>;
+  seekerCheckin: (bookingId: string, coords?: { lat: number; lon: number }) => Promise<{ success: boolean; error?: string }>;
+  companionCheckin: (bookingId: string, coords?: { lat: number; lon: number }) => Promise<{ success: boolean; error?: string }>;
+  safetyCheckin: (bookingId: string) => Promise<{ success: boolean; error?: string }>;
+  extendDate: (bookingId: string, additionalHours: number) => Promise<{ success: boolean; error?: string }>;
+  endEarly: (bookingId: string) => Promise<{ success: boolean; error?: string }>;
+  triggerSOS: (bookingId: string, coords?: { lat: number; lon: number }) => Promise<{ success: boolean; error?: string }>;
+  clearError: () => void;
+  clearActive: () => void;
+}
+
+export const useActiveDateStore = create<ActiveDateState>((set) => ({
+  activeBooking: null,
+  isLoading: false,
+  error: null,
+
+  fetchActive: async () => {
+    set({ isLoading: true, error: null });
+    try {
+      const booking = await activeDateApi.getActive();
+      set({ activeBooking: booking, isLoading: false });
+    } catch (e: any) {
+      set({ error: e.message || 'Failed to fetch active date', isLoading: false });
+    }
+  },
+
+  fetchBooking: async (id: string) => {
+    set({ isLoading: true, error: null });
+    try {
+      const booking = await activeDateApi.getBookingById(id);
+      set({ activeBooking: booking, isLoading: false });
+    } catch (e: any) {
+      set({ error: e.message || 'Failed to fetch booking', isLoading: false });
+    }
+  },
+
+  startDate: async (bookingId: string) => {
+    try {
+      const booking = await activeDateApi.startDate(bookingId);
+      set({ activeBooking: booking });
+      return { success: true };
+    } catch (e: any) {
+      return { success: false, error: e.message || 'Failed to start date' };
+    }
+  },
+
+  seekerCheckin: async (bookingId: string, coords?) => {
+    try {
+      const booking = await activeDateApi.seekerCheckin(bookingId, coords);
+      set({ activeBooking: booking });
+      return { success: true };
+    } catch (e: any) {
+      return { success: false, error: e.message || 'Check-in failed' };
+    }
+  },
+
+  companionCheckin: async (bookingId: string, coords?) => {
+    try {
+      const booking = await activeDateApi.companionCheckin(bookingId, coords);
+      set({ activeBooking: booking });
+      return { success: true };
+    } catch (e: any) {
+      return { success: false, error: e.message || 'Check-in failed' };
+    }
+  },
+
+  safetyCheckin: async (bookingId: string) => {
+    try {
+      await activeDateApi.safetyCheckin(bookingId);
+      return { success: true };
+    } catch (e: any) {
+      return { success: false, error: e.message || 'Safety check-in failed' };
+    }
+  },
+
+  extendDate: async (bookingId: string, additionalHours: number) => {
+    try {
+      const booking = await activeDateApi.extendDate(bookingId, additionalHours);
+      set({ activeBooking: booking });
+      return { success: true };
+    } catch (e: any) {
+      return { success: false, error: e.message || 'Extend request failed' };
+    }
+  },
+
+  endEarly: async (bookingId: string) => {
+    try {
+      const booking = await activeDateApi.endEarly(bookingId);
+      set({ activeBooking: booking });
+      return { success: true };
+    } catch (e: any) {
+      return { success: false, error: e.message || 'Failed to end date' };
+    }
+  },
+
+  triggerSOS: async (bookingId: string, coords?) => {
+    try {
+      const booking = await activeDateApi.triggerSOS(bookingId, coords);
+      set({ activeBooking: booking });
+      return { success: true };
+    } catch (e: any) {
+      return { success: false, error: e.message || 'SOS failed' };
+    }
+  },
+
+  clearError: () => set({ error: null }),
+  clearActive: () => set({ activeBooking: null }),
+}));


### PR DESCRIPTION
## Summary
- Wire existing Active Date screens (`app/app/date/`) into the navigation stack (root `_layout.tsx`)
- Add "Start Date" / "Resume Date" buttons to seeker bookings and companion requests screens
- Create `activeDateStore` (Zustand) centralizing all active date actions
- Add missing API methods (`startDate`, `extendDate`) to `activeDateApi` service
- Fix endpoint mismatches: `report-issue` -> `report`, `PUT plan` -> `POST plan`, `extend-request` -> `extend`

## Files changed
- `app/app/_layout.tsx` -- register `date` route group + navigation guard
- `app/app/(tabs)/male/bookings.tsx` -- Start Date + Resume Date buttons
- `app/app/(tabs)/female/requests.tsx` -- Start Date + Resume Date buttons
- `app/src/services/activeDateApi.ts` -- add startDate, extendDate; fix endpoints
- `app/src/store/activeDateStore.ts` -- new Zustand store
- `app/app/date/extend/[bookingId].tsx` -- use activeDateApi.extendDate

## Test plan
- [ ] Seeker with paid+confirmed booking sees "Start Date" button
- [ ] Tapping "Start Date" navigates to `/date/checkin/:bookingId`
- [ ] Companion with paid+accepted request sees "Start Date" button
- [ ] Tapping navigates to `/date/companion-checkin/:bookingId`
- [ ] Active booking shows "Resume Date" -> `/date/active/:bookingId`
- [ ] Extend screen sends request to correct `/extend` endpoint
- [ ] Report screen sends to correct `/report` endpoint

Trinity: #805

Generated with [Claude Code](https://claude.com/claude-code)