### PR TITLE
feat: selfie verification MVP (UC-061)

### DIFF
--- a/backend/daterabbit-api/src/bookings/bookings.controller.ts
+++ b/backend/daterabbit-api/src/bookings/bookings.controller.ts
@@ -352,6 +352,25 @@ export class BookingsController {
     return this.formatBooking(booking);
   }
 
+  // --- UC-061: Selfie verification ---
+
+  @Post(':id/verify-selfie')
+  async submitSelfie(
+    @Param('id') id: string,
+    @Request() req,
+    @Body() body: { photoUrl: string },
+  ) {
+    if (!body.photoUrl) {
+      throw new HttpException('photoUrl is required', HttpStatus.BAD_REQUEST);
+    }
+    return this.bookingsService.submitSelfie(id, req.user.id, body.photoUrl);
+  }
+
+  @Get(':id/verify-selfie')
+  async getSelfieStatus(@Param('id') id: string, @Request() req) {
+    return this.bookingsService.getSelfieStatus(id, req.user.id);
+  }
+
   // --- Group 2: Extend response ---
 
   @Put(':id/extend-response')
@@ -393,6 +412,7 @@ export class BookingsController {
       extendApproved: booking.extendApproved !== null && booking.extendApproved !== undefined ? booking.extendApproved : undefined,
       reportIssueType: booking.reportIssueType || undefined,
       reportIssueText: booking.reportIssueText || undefined,
+      selfieVerified: booking.selfieVerified || false,
       seeker: booking.seeker ? {
         id: booking.seeker.id,
         name: booking.seeker.name,

--- a/backend/daterabbit-api/src/bookings/bookings.module.ts
+++ b/backend/daterabbit-api/src/bookings/bookings.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Booking } from './entities/booking.entity';
 import { DatePhoto } from './entities/date-photo.entity';
+import { SelfieVerification } from './entities/selfie-verification.entity';
 import { BookingsService } from './bookings.service';
 import { BookingsController } from './bookings.controller';
 import { BookingsCron } from './bookings.cron';
@@ -11,7 +12,7 @@ import { PaymentsModule } from '../payments/payments.module';
 import { NotificationsModule } from '../notifications/notifications.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Booking, DatePhoto]), UsersModule, EmailModule, PaymentsModule, NotificationsModule],
+  imports: [TypeOrmModule.forFeature([Booking, DatePhoto, SelfieVerification]), UsersModule, EmailModule, PaymentsModule, NotificationsModule],
   providers: [BookingsService, BookingsCron],
   controllers: [BookingsController],
   exports: [BookingsService],

--- a/backend/daterabbit-api/src/bookings/bookings.service.ts
+++ b/backend/daterabbit-api/src/bookings/bookings.service.ts
@@ -3,6 +3,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository, MoreThanOrEqual, LessThan } from 'typeorm';
 import { Booking, BookingStatus, ActivityType } from './entities/booking.entity';
 import { DatePhoto } from './entities/date-photo.entity';
+import { SelfieVerification } from './entities/selfie-verification.entity';
 import { UsersService } from '../users/users.service';
 import { EmailService } from '../email/email.service';
 
@@ -13,6 +14,8 @@ export class BookingsService {
     private bookingsRepository: Repository<Booking>,
     @InjectRepository(DatePhoto)
     private datePhotosRepository: Repository<DatePhoto>,
+    @InjectRepository(SelfieVerification)
+    private selfieVerificationsRepository: Repository<SelfieVerification>,
     private usersService: UsersService,
     private emailService: EmailService,
   ) {}
@@ -501,5 +504,92 @@ export class BookingsService {
       where: { seekerId, companionId },
     });
     return count > 0;
+  }
+
+  // --- UC-061: Selfie verification ---
+
+  async submitSelfie(bookingId: string, userId: string, photoUrl: string): Promise<SelfieVerification> {
+    const booking = await this.findById(bookingId);
+    if (!booking) throw new HttpException('Booking not found', HttpStatus.NOT_FOUND);
+    if (booking.seekerId !== userId && booking.companionId !== userId) {
+      throw new HttpException('Unauthorized', HttpStatus.FORBIDDEN);
+    }
+    if (booking.status !== BookingStatus.CONFIRMED && booking.status !== BookingStatus.PAID) {
+      throw new HttpException('Selfie verification is only available for confirmed/paid bookings', HttpStatus.BAD_REQUEST);
+    }
+
+    // Check if user already submitted a selfie for this booking
+    const existing = await this.selfieVerificationsRepository.findOne({
+      where: { bookingId, userId },
+    });
+    if (existing) {
+      // Update existing selfie
+      await this.selfieVerificationsRepository.update(existing.id, {
+        photoUrl,
+        verified: true,
+      });
+      await this.checkBothSelfiesSubmitted(bookingId);
+      return (await this.selfieVerificationsRepository.findOne({ where: { id: existing.id } }))!;
+    }
+
+    // Create new selfie verification record (MVP: auto-verified on upload)
+    const selfie = this.selfieVerificationsRepository.create({
+      bookingId,
+      userId,
+      photoUrl,
+      verified: true, // MVP: no AI face matching, auto-verify on upload
+    });
+    const saved = await this.selfieVerificationsRepository.save(selfie);
+
+    // Check if both participants have submitted selfies
+    await this.checkBothSelfiesSubmitted(bookingId);
+
+    return saved;
+  }
+
+  async getSelfieStatus(bookingId: string, userId: string): Promise<{
+    selfieVerified: boolean;
+    seeker: { submitted: boolean; photoUrl?: string; verifiedAt?: Date } | null;
+    companion: { submitted: boolean; photoUrl?: string; verifiedAt?: Date } | null;
+  }> {
+    const booking = await this.findById(bookingId);
+    if (!booking) throw new HttpException('Booking not found', HttpStatus.NOT_FOUND);
+    if (booking.seekerId !== userId && booking.companionId !== userId) {
+      throw new HttpException('Unauthorized', HttpStatus.FORBIDDEN);
+    }
+
+    const selfies = await this.selfieVerificationsRepository.find({
+      where: { bookingId },
+    });
+
+    const seekerSelfie = selfies.find(s => s.userId === booking.seekerId);
+    const companionSelfie = selfies.find(s => s.userId === booking.companionId);
+
+    return {
+      selfieVerified: booking.selfieVerified,
+      seeker: seekerSelfie ? {
+        submitted: true,
+        photoUrl: seekerSelfie.photoUrl,
+        verifiedAt: seekerSelfie.createdAt,
+      } : { submitted: false },
+      companion: companionSelfie ? {
+        submitted: true,
+        photoUrl: companionSelfie.photoUrl,
+        verifiedAt: companionSelfie.createdAt,
+      } : { submitted: false },
+    };
+  }
+
+  private async checkBothSelfiesSubmitted(bookingId: string): Promise<void> {
+    const booking = await this.findById(bookingId);
+    if (!booking) return;
+
+    const count = await this.selfieVerificationsRepository.count({
+      where: { bookingId, verified: true },
+    });
+
+    if (count >= 2 && !booking.selfieVerified) {
+      await this.bookingsRepository.update(bookingId, { selfieVerified: true });
+    }
   }
 }

--- a/backend/daterabbit-api/src/bookings/entities/booking.entity.ts
+++ b/backend/daterabbit-api/src/bookings/entities/booking.entity.ts
@@ -119,6 +119,9 @@ export class Booking {
   @Column({ nullable: true })
   reportIssueType: string;
 
+  @Column({ type: 'boolean', default: false })
+  selfieVerified: boolean;
+
   @CreateDateColumn()
   createdAt: Date;
 

--- a/backend/daterabbit-api/src/bookings/entities/selfie-verification.entity.ts
+++ b/backend/daterabbit-api/src/bookings/entities/selfie-verification.entity.ts
@@ -1,0 +1,39 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  ManyToOne,
+  JoinColumn,
+} from 'typeorm';
+import { Booking } from './booking.entity';
+import { User } from '../../users/entities/user.entity';
+
+@Entity('selfie_verifications')
+export class SelfieVerification {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  bookingId: string;
+
+  @ManyToOne(() => Booking)
+  @JoinColumn({ name: 'bookingId' })
+  booking: Booking;
+
+  @Column()
+  userId: string;
+
+  @ManyToOne(() => User)
+  @JoinColumn({ name: 'userId' })
+  user: User;
+
+  @Column()
+  photoUrl: string;
+
+  @Column({ type: 'boolean', default: false })
+  verified: boolean;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}


### PR DESCRIPTION
## Summary
- Implements UC-061: Selfie verification before Active Date (MVP)
- New `SelfieVerification` entity with `selfie_verifications` table
- Added `selfieVerified` boolean column to `Booking` entity
- `POST /bookings/:id/verify-selfie` -- submit selfie photo URL
- `GET /bookings/:id/verify-selfie` -- get verification status for both participants
- When both seeker and companion submit selfies, booking is auto-marked as `selfieVerified=true`
- MVP approach: no AI face matching, photo upload = verified

## Test plan
- [ ] POST selfie as seeker -- should create SelfieVerification record
- [ ] POST selfie as companion -- should create record and mark booking selfieVerified=true
- [ ] GET verify-selfie -- should return status for both participants
- [ ] Submitting twice should update existing record, not create duplicate
- [ ] Unauthorized user should get 403
- [ ] Non-confirmed booking should get 400

Trinity task: #815