### PR TITLE
fix: ignore chown errors for missing platform-specific binaries

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -74,7 +74,7 @@ jobs:
             echo "NEXT_PUBLIC_API_URL=https://daterabbit.smartlaunchhub.com/api" > /var/www/daterabbit/admin-panel/.env.local
           fi
           sudo pm2 restart daterabbit-admin || sudo pm2 start npm --name daterabbit-admin -- start -- -p 3005
-          sudo chown -R www-data:www-data /var/www/daterabbit/
+          sudo chown -R www-data:www-data /var/www/daterabbit/ 2>/dev/null || true
 
       - name: Create backend .env if missing
         run: |
@@ -177,7 +177,7 @@ jobs:
         run: |
           cd /var/www/daterabbit/api
           sudo pm2 restart daterabbit || sudo pm2 start dist/main.js --name daterabbit
-          sudo chown -R www-data:www-data /var/www/daterabbit/
+          sudo chown -R www-data:www-data /var/www/daterabbit/ 2>/dev/null || true
 
       - name: Deploy nginx config
         run: |
@@ -304,7 +304,7 @@ jobs:
             echo "NEXT_PUBLIC_API_URL=https://daterabbit.smartlaunchhub.com/api" > /var/www/daterabbit/admin-panel/.env.local
           fi
           sudo pm2 restart daterabbit-admin || sudo pm2 start npm --name daterabbit-admin -- start -- -p 3005
-          sudo chown -R www-data:www-data /var/www/daterabbit/
+          sudo chown -R www-data:www-data /var/www/daterabbit/ 2>/dev/null || true
 
       - name: Verify backend .env exists
         run: |
@@ -395,7 +395,7 @@ jobs:
         run: |
           cd /var/www/daterabbit/api
           sudo pm2 restart daterabbit || sudo pm2 start dist/main.js --name daterabbit
-          sudo chown -R www-data:www-data /var/www/daterabbit/
+          sudo chown -R www-data:www-data /var/www/daterabbit/ 2>/dev/null || true
 
       - name: Deploy nginx config
         run: |


### PR DESCRIPTION
## Summary
- CI deploy fails at "Restart backend" step because `chown -R` encounters missing lightningcss platform-specific binaries (darwin-x64, win32-x64, freebsd-x64, etc.) in admin-panel/node_modules
- These are optional dependencies that npm only installs for the current platform (Linux), so darwin/win32/freebsd variants don't exist
- Added `2>/dev/null || true` to all 4 `chown -R www-data:www-data /var/www/daterabbit/` commands (staging + production, admin + backend steps)

## Test plan
- [ ] CI should pass on merge to development
- [ ] Verify version.json updates on staging