### PR TITLE
feat: MVP screen gaps (UC-050, UC-051, UC-087)

### DIFF
--- a/app/app/booking/[id].tsx
+++ b/app/app/booking/[id].tsx
@@ -138,11 +138,12 @@ export default function BookingScreen() {
       return;
     }
 
-    showAlert(
-      'Request Sent!',
-      `Your date request has been sent to ${companion.name}. You'll be notified when they respond.`,
-      () => router.replace('/(tabs)/male/bookings'),
-    );
+    // Navigate to request-sent screen with polling
+    if (result.booking?.id) {
+      router.replace(`/booking/request-sent/${result.booking.id}`);
+    } else {
+      router.replace('/(tabs)/male/bookings');
+    }
   };
 
   if (isLoadingCompanion) {

--- a/app/app/booking/declined/[bookingId].tsx
+++ b/app/app/booking/declined/[bookingId].tsx
@@ -1,0 +1,165 @@
+import React, { useEffect, useState } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  ActivityIndicator,
+} from 'react-native';
+import { router, useLocalSearchParams } from 'expo-router';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { Button } from '../../../src/components/Button';
+import { Icon } from '../../../src/components/Icon';
+import { UserImage } from '../../../src/components/UserImage';
+import { useTheme, spacing, typography, borderRadius } from '../../../src/constants/theme';
+import { useBookingsStore } from '../../../src/store/bookingsStore';
+import { Booking } from '../../../src/services/api';
+
+export default function DeclinedScreen() {
+  const { bookingId } = useLocalSearchParams<{ bookingId: string }>();
+  const insets = useSafeAreaInsets();
+  const { colors } = useTheme();
+  const { getBookingById } = useBookingsStore();
+
+  const [booking, setBooking] = useState<Booking | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!bookingId) return;
+    getBookingById(bookingId)
+      .then((b) => setBooking(b))
+      .finally(() => setLoading(false));
+  }, [bookingId, getBookingById]);
+
+  if (loading) {
+    return (
+      <View style={[styles.container, styles.centered, { backgroundColor: colors.background }]}>
+        <ActivityIndicator size="large" color={colors.primary} />
+      </View>
+    );
+  }
+
+  return (
+    <View style={[styles.container, { backgroundColor: colors.background, paddingTop: insets.top + spacing.xl }]}>
+      <View style={styles.content}>
+        {/* Declined icon */}
+        <View style={[styles.iconCircle, { backgroundColor: colors.errorLight }]}>
+          <Icon name="x" size={48} color={colors.error} />
+        </View>
+
+        <Text style={[styles.title, { color: colors.text }]}>Request Declined</Text>
+        <Text style={[styles.subtitle, { color: colors.textSecondary }]}>
+          Unfortunately, {booking?.companion?.name || 'the companion'} wasn't available for this date.
+          Don't worry -- there are many other great companions to choose from!
+        </Text>
+
+        {/* Booking summary */}
+        {booking && (
+          <View style={[styles.summaryCard, { backgroundColor: colors.white, borderColor: colors.border }]}>
+            <View style={styles.companionRow}>
+              <UserImage
+                uri={booking.companion.photo}
+                name={booking.companion.name}
+                size={48}
+              />
+              <View style={styles.companionInfo}>
+                <Text style={[styles.companionName, { color: colors.text }]}>
+                  {booking.companion.name}
+                </Text>
+                <Text style={[styles.detail, { color: colors.textSecondary }]}>
+                  {booking.activity} - {booking.duration}h
+                </Text>
+              </View>
+              <View style={[styles.statusBadge, { backgroundColor: colors.errorLight }]}>
+                <Text style={[styles.statusText, { color: colors.error }]}>Declined</Text>
+              </View>
+            </View>
+          </View>
+        )}
+      </View>
+
+      {/* Bottom actions */}
+      <View style={[styles.bottomBar, { paddingBottom: insets.bottom || spacing.xl }]}>
+        <Button
+          title="Browse Companions"
+          onPress={() => router.replace('/(tabs)/male/browse')}
+          style={{ marginBottom: spacing.sm }}
+        />
+        <Button
+          title="View My Bookings"
+          onPress={() => router.replace('/(tabs)/male/bookings')}
+          variant="outline"
+        />
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  centered: {
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  content: {
+    flex: 1,
+    alignItems: 'center',
+    paddingHorizontal: spacing.xl,
+  },
+  iconCircle: {
+    width: 96,
+    height: 96,
+    borderRadius: 48,
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginBottom: spacing.lg,
+  },
+  title: {
+    fontFamily: typography.fonts.heading,
+    fontSize: typography.sizes.xl,
+    textAlign: 'center',
+    marginBottom: spacing.sm,
+  },
+  subtitle: {
+    fontFamily: typography.fonts.body,
+    fontSize: typography.sizes.md,
+    textAlign: 'center',
+    lineHeight: 24,
+    marginBottom: spacing.xl,
+  },
+  summaryCard: {
+    padding: spacing.lg,
+    borderRadius: borderRadius.lg,
+    borderWidth: 3,
+    width: '100%',
+  },
+  companionRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  companionInfo: {
+    flex: 1,
+    marginLeft: spacing.md,
+  },
+  companionName: {
+    fontFamily: typography.fonts.bodySemiBold,
+    fontSize: typography.sizes.md,
+  },
+  detail: {
+    fontFamily: typography.fonts.body,
+    fontSize: typography.sizes.sm,
+  },
+  statusBadge: {
+    paddingHorizontal: spacing.sm,
+    paddingVertical: spacing.xs,
+    borderRadius: borderRadius.sm,
+  },
+  statusText: {
+    fontFamily: typography.fonts.bodySemiBold,
+    fontSize: typography.sizes.xs,
+  },
+  bottomBar: {
+    padding: spacing.lg,
+  },
+});

--- a/app/app/booking/request-sent/[bookingId].tsx
+++ b/app/app/booking/request-sent/[bookingId].tsx
@@ -1,0 +1,253 @@
+import React, { useEffect, useRef, useState, useCallback } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  ActivityIndicator,
+} from 'react-native';
+import { router, useLocalSearchParams } from 'expo-router';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { Button } from '../../../src/components/Button';
+import { Icon } from '../../../src/components/Icon';
+import { UserImage } from '../../../src/components/UserImage';
+import { useTheme, spacing, typography, borderRadius } from '../../../src/constants/theme';
+import { useBookingsStore } from '../../../src/store/bookingsStore';
+import { Booking } from '../../../src/services/api';
+
+const POLL_INTERVAL = 10_000; // 10 seconds
+
+export default function RequestSentScreen() {
+  const { bookingId } = useLocalSearchParams<{ bookingId: string }>();
+  const insets = useSafeAreaInsets();
+  const { colors } = useTheme();
+  const { getBookingById, cancelBooking } = useBookingsStore();
+
+  const [booking, setBooking] = useState<Booking | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [cancelling, setCancelling] = useState(false);
+  const [elapsedMinutes, setElapsedMinutes] = useState(0);
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const fetchBooking = useCallback(async () => {
+    if (!bookingId) return;
+    const b = await getBookingById(bookingId);
+    if (!b) return;
+    setBooking(b);
+    setLoading(false);
+
+    if (b.status === 'accepted' || b.status === 'confirmed') {
+      // Companion accepted - navigate to payment
+      if (pollRef.current) clearInterval(pollRef.current);
+      if (timerRef.current) clearInterval(timerRef.current);
+      router.replace(`/payment/${bookingId}`);
+    } else if (b.status === 'declined') {
+      // Companion declined - navigate to declined screen
+      if (pollRef.current) clearInterval(pollRef.current);
+      if (timerRef.current) clearInterval(timerRef.current);
+      router.replace(`/booking/declined/${bookingId}`);
+    } else if (b.status === 'cancelled') {
+      if (pollRef.current) clearInterval(pollRef.current);
+      if (timerRef.current) clearInterval(timerRef.current);
+      router.replace('/(tabs)/male/bookings');
+    }
+  }, [bookingId, getBookingById]);
+
+  useEffect(() => {
+    fetchBooking();
+
+    // Poll for status updates
+    pollRef.current = setInterval(fetchBooking, POLL_INTERVAL);
+
+    // Elapsed time counter
+    timerRef.current = setInterval(() => {
+      setElapsedMinutes((prev) => prev + 1);
+    }, 60_000);
+
+    return () => {
+      if (pollRef.current) clearInterval(pollRef.current);
+      if (timerRef.current) clearInterval(timerRef.current);
+    };
+  }, [fetchBooking]);
+
+  const handleCancel = async () => {
+    if (!bookingId) return;
+    setCancelling(true);
+    const result = await cancelBooking(bookingId, 'Cancelled by seeker');
+    setCancelling(false);
+    if (result.success) {
+      router.replace('/(tabs)/male/bookings');
+    }
+  };
+
+  const formatElapsed = () => {
+    if (elapsedMinutes < 1) return 'Just now';
+    if (elapsedMinutes === 1) return '1 minute ago';
+    if (elapsedMinutes < 60) return `${elapsedMinutes} minutes ago`;
+    const hours = Math.floor(elapsedMinutes / 60);
+    return hours === 1 ? '1 hour ago' : `${hours} hours ago`;
+  };
+
+  if (loading) {
+    return (
+      <View style={[styles.container, styles.centered, { backgroundColor: colors.background }]}>
+        <ActivityIndicator size="large" color={colors.primary} />
+      </View>
+    );
+  }
+
+  return (
+    <View style={[styles.container, { backgroundColor: colors.background, paddingTop: insets.top + spacing.xl }]}>
+      <View style={styles.content}>
+        {/* Animated pulse icon */}
+        <View style={[styles.iconCircle, { backgroundColor: colors.primary + '15' }]}>
+          <View style={[styles.iconInner, { backgroundColor: colors.primary + '25' }]}>
+            <Icon name="send" size={40} color={colors.primary} />
+          </View>
+        </View>
+
+        <Text style={[styles.title, { color: colors.text }]}>Request Sent!</Text>
+        <Text style={[styles.subtitle, { color: colors.textSecondary }]}>
+          Your date request has been sent. We'll notify you when they respond.
+        </Text>
+
+        {/* Companion info card */}
+        {booking && (
+          <View style={[styles.companionCard, { backgroundColor: colors.white, borderColor: colors.border }]}>
+            <UserImage
+              uri={booking.companion.photo}
+              name={booking.companion.name}
+              size={56}
+            />
+            <View style={styles.companionInfo}>
+              <Text style={[styles.companionName, { color: colors.text }]}>
+                {booking.companion.name}
+              </Text>
+              <Text style={[styles.bookingDetail, { color: colors.textSecondary }]}>
+                {booking.activity} - {booking.duration}h
+              </Text>
+              <Text style={[styles.bookingDetail, { color: colors.textSecondary }]}>
+                ${booking.total} total
+              </Text>
+            </View>
+          </View>
+        )}
+
+        {/* Waiting indicator */}
+        <View style={[styles.waitingRow, { backgroundColor: colors.white, borderColor: colors.border }]}>
+          <ActivityIndicator size="small" color={colors.primary} />
+          <View style={styles.waitingInfo}>
+            <Text style={[styles.waitingLabel, { color: colors.text }]}>Waiting for response</Text>
+            <Text style={[styles.waitingTime, { color: colors.textSecondary }]}>
+              Sent {formatElapsed()}
+            </Text>
+          </View>
+        </View>
+      </View>
+
+      {/* Bottom actions */}
+      <View style={[styles.bottomBar, { paddingBottom: insets.bottom || spacing.xl }]}>
+        <Button
+          title="View My Bookings"
+          onPress={() => router.replace('/(tabs)/male/bookings')}
+          style={{ marginBottom: spacing.sm }}
+        />
+        <Button
+          title={cancelling ? 'Cancelling...' : 'Cancel Request'}
+          onPress={handleCancel}
+          variant="outline"
+          disabled={cancelling}
+          loading={cancelling}
+        />
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  centered: {
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  content: {
+    flex: 1,
+    alignItems: 'center',
+    paddingHorizontal: spacing.xl,
+  },
+  iconCircle: {
+    width: 120,
+    height: 120,
+    borderRadius: 60,
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginBottom: spacing.lg,
+  },
+  iconInner: {
+    width: 88,
+    height: 88,
+    borderRadius: 44,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  title: {
+    fontFamily: typography.fonts.heading,
+    fontSize: typography.sizes.xl,
+    textAlign: 'center',
+    marginBottom: spacing.sm,
+  },
+  subtitle: {
+    fontFamily: typography.fonts.body,
+    fontSize: typography.sizes.md,
+    textAlign: 'center',
+    lineHeight: 24,
+    marginBottom: spacing.xl,
+  },
+  companionCard: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    padding: spacing.lg,
+    borderRadius: borderRadius.lg,
+    borderWidth: 3,
+    width: '100%',
+    marginBottom: spacing.lg,
+  },
+  companionInfo: {
+    marginLeft: spacing.md,
+    flex: 1,
+  },
+  companionName: {
+    fontFamily: typography.fonts.bodySemiBold,
+    fontSize: typography.sizes.lg,
+    marginBottom: spacing.xs,
+  },
+  bookingDetail: {
+    fontFamily: typography.fonts.body,
+    fontSize: typography.sizes.sm,
+    lineHeight: 20,
+  },
+  waitingRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    padding: spacing.lg,
+    borderRadius: borderRadius.lg,
+    borderWidth: 3,
+    width: '100%',
+  },
+  waitingInfo: {
+    marginLeft: spacing.md,
+  },
+  waitingLabel: {
+    fontFamily: typography.fonts.bodySemiBold,
+    fontSize: typography.sizes.md,
+  },
+  waitingTime: {
+    fontFamily: typography.fonts.body,
+    fontSize: typography.sizes.sm,
+  },
+  bottomBar: {
+    padding: spacing.lg,
+  },
+});

--- a/app/app/stripe/connect.tsx
+++ b/app/app/stripe/connect.tsx
@@ -1,0 +1,196 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, StyleSheet, Platform, Linking, ActivityIndicator } from 'react-native';
+import { useRouter } from 'expo-router';
+import * as WebBrowser from 'expo-web-browser';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { Icon } from '../../src/components/Icon';
+import { Button } from '../../src/components/Button';
+import { useTheme, spacing, typography, borderRadius } from '../../src/constants/theme';
+import { useEarningsStore } from '../../src/store/earningsStore';
+
+export default function StripeConnectScreen() {
+  const router = useRouter();
+  const insets = useSafeAreaInsets();
+  const { colors } = useTheme();
+  const { connectStatus, fetchConnectStatus, startStripeOnboarding } = useEarningsStore();
+
+  const [loading, setLoading] = useState(true);
+  const [onboardingLoading, setOnboardingLoading] = useState(false);
+
+  useEffect(() => {
+    fetchConnectStatus().finally(() => setLoading(false));
+  }, []);
+
+  const isConnected = connectStatus?.complete === true;
+  const payoutsEnabled = connectStatus?.payoutsEnabled === true;
+
+  const handleSetup = async () => {
+    setOnboardingLoading(true);
+    const result = await startStripeOnboarding();
+    setOnboardingLoading(false);
+
+    if (result.success && result.url) {
+      if (Platform.OS === 'web') {
+        Linking.openURL(result.url);
+      } else {
+        await WebBrowser.openAuthSessionAsync(result.url, 'daterabbit://');
+        // Re-check status after returning
+        fetchConnectStatus();
+      }
+    }
+  };
+
+  if (loading) {
+    return (
+      <View style={[styles.container, styles.centered, { backgroundColor: colors.background }]}>
+        <ActivityIndicator size="large" color={colors.primary} />
+      </View>
+    );
+  }
+
+  // Already connected
+  if (isConnected) {
+    return (
+      <View style={[styles.container, { backgroundColor: colors.background, paddingTop: insets.top + spacing.xl }]}>
+        <View style={styles.content}>
+          <View style={[styles.iconCircle, { backgroundColor: colors.successLight }]}>
+            <Icon name="check" size={48} color={colors.success} />
+          </View>
+          <Text style={[styles.title, { color: colors.text }]}>
+            {payoutsEnabled ? 'Payouts Active' : 'Account Connected'}
+          </Text>
+          <Text style={[styles.subtitle, { color: colors.textSecondary }]}>
+            {payoutsEnabled
+              ? 'Your Stripe account is connected and payouts are enabled. You will receive earnings from completed bookings.'
+              : 'Your Stripe account is connected but payouts are pending verification. Stripe is reviewing your account.'}
+          </Text>
+          <Button
+            title="Go to Earnings"
+            onPress={() => router.replace('/(tabs)/female/earnings')}
+            style={{ marginTop: spacing.lg, width: '100%' }}
+          />
+        </View>
+      </View>
+    );
+  }
+
+  // Not connected - show setup flow
+  return (
+    <View style={[styles.container, { backgroundColor: colors.background, paddingTop: insets.top + spacing.xl }]}>
+      <View style={styles.content}>
+        <View style={[styles.iconCircle, { backgroundColor: colors.primary + '15' }]}>
+          <Icon name="credit-card" size={48} color={colors.primary} />
+        </View>
+
+        <Text style={[styles.title, { color: colors.text }]}>Set Up Payouts</Text>
+        <Text style={[styles.subtitle, { color: colors.textSecondary }]}>
+          Connect your bank account through Stripe to receive earnings from completed bookings.
+        </Text>
+
+        {/* Steps */}
+        <View style={[styles.stepsCard, { backgroundColor: colors.white, borderColor: colors.border }]}>
+          {[
+            { icon: 'user', label: 'Verify your identity' },
+            { icon: 'building', label: 'Add your bank account' },
+            { icon: 'dollar-sign', label: 'Start receiving payouts' },
+          ].map((step, index) => (
+            <View key={index} style={styles.stepRow}>
+              <View style={[styles.stepNumber, { backgroundColor: colors.primary }]}>
+                <Text style={[styles.stepNumberText, { color: colors.white }]}>{index + 1}</Text>
+              </View>
+              <Text style={[styles.stepLabel, { color: colors.text }]}>{step.label}</Text>
+            </View>
+          ))}
+        </View>
+
+        <Text style={[styles.securityNote, { color: colors.textMuted }]}>
+          Your information is securely handled by Stripe, a PCI-certified payment processor.
+        </Text>
+
+        <Button
+          title={onboardingLoading ? 'Redirecting to Stripe...' : 'Set Up with Stripe'}
+          onPress={handleSetup}
+          disabled={onboardingLoading}
+          loading={onboardingLoading}
+          style={{ width: '100%', marginTop: spacing.lg }}
+        />
+        <Button
+          title="Back"
+          onPress={() => router.back()}
+          variant="outline"
+          style={{ width: '100%', marginTop: spacing.sm }}
+        />
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  centered: {
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  content: {
+    flex: 1,
+    alignItems: 'center',
+    paddingHorizontal: spacing.xl,
+  },
+  iconCircle: {
+    width: 96,
+    height: 96,
+    borderRadius: 48,
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginBottom: spacing.lg,
+  },
+  title: {
+    fontFamily: typography.fonts.heading,
+    fontSize: typography.sizes.xl,
+    textAlign: 'center',
+    marginBottom: spacing.sm,
+  },
+  subtitle: {
+    fontFamily: typography.fonts.body,
+    fontSize: typography.sizes.md,
+    textAlign: 'center',
+    lineHeight: 24,
+    marginBottom: spacing.xl,
+  },
+  stepsCard: {
+    width: '100%',
+    padding: spacing.lg,
+    borderRadius: borderRadius.lg,
+    borderWidth: 3,
+    gap: spacing.lg,
+  },
+  stepRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  stepNumber: {
+    width: 32,
+    height: 32,
+    borderRadius: 16,
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginRight: spacing.md,
+  },
+  stepNumberText: {
+    fontFamily: typography.fonts.heading,
+    fontSize: typography.sizes.md,
+  },
+  stepLabel: {
+    fontFamily: typography.fonts.bodyMedium,
+    fontSize: typography.sizes.md,
+  },
+  securityNote: {
+    fontFamily: typography.fonts.body,
+    fontSize: typography.sizes.sm,
+    textAlign: 'center',
+    marginTop: spacing.lg,
+    lineHeight: 20,
+  },
+});


### PR DESCRIPTION
## Summary
- **UC-050 (request_sent):** New screen at `/booking/request-sent/[bookingId]` that shows booking was sent, displays companion info, polls every 10s for status changes. Auto-navigates to payment on accept, declined screen on decline.
- **UC-051 (seeker_declined):** New screen at `/booking/declined/[bookingId]` showing decline message with companion info and actions to browse other companions or view bookings.
- **UC-087 (Stripe Connect):** New dedicated onboarding screen at `/stripe/connect` with step-by-step guide (verify identity, add bank, start payouts). Checks existing connect status and shows appropriate state.
- Updated booking form to navigate to request-sent screen instead of showing an alert after successful booking creation.

## Test plan
- [ ] Create a booking and verify navigation to request-sent screen
- [ ] Verify polling updates status every 10 seconds
- [ ] Accept booking from companion side and verify auto-navigation to payment
- [ ] Decline booking and verify navigation to declined screen
- [ ] On declined screen, verify "Browse Companions" navigates to browse
- [ ] Open `/stripe/connect` as companion without Stripe setup
- [ ] Verify "Set Up with Stripe" redirects to Stripe onboarding URL
- [ ] Open `/stripe/connect` with completed Stripe setup and verify connected state

Generated with [Claude Code](https://claude.com/claude-code)