### PR TITLE
fix: XSS sanitization + OTP rate limiting

### DIFF
--- a/backend/daterabbit-api/src/auth/auth.service.ts
+++ b/backend/daterabbit-api/src/auth/auth.service.ts
@@ -1,19 +1,35 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, HttpException, HttpStatus } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { ConfigService } from '@nestjs/config';
 import * as crypto from 'crypto';
 import { UsersService } from '../users/users.service';
 import { User, UserRole } from '../users/entities/user.entity';
 import { EmailService } from '../email/email.service';
+import { sanitizeText } from '../common/sanitize';
 
 @Injectable()
 export class AuthService {
+  // Per-email OTP attempt tracking to prevent brute force
+  private otpAttempts = new Map<string, { count: number; lockedUntil: number }>();
+  private readonly MAX_OTP_ATTEMPTS = 5;
+  private readonly LOCKOUT_MINUTES = 15;
+
   constructor(
     private usersService: UsersService,
     private jwtService: JwtService,
     private configService: ConfigService,
     private emailService: EmailService,
-  ) {}
+  ) {
+    // Cleanup stale entries every hour
+    setInterval(() => {
+      const now = Date.now();
+      for (const [email, data] of this.otpAttempts) {
+        if (data.lockedUntil < now && data.count === 0) {
+          this.otpAttempts.delete(email);
+        }
+      }
+    }, 60 * 60 * 1000);
+  }
 
   generateOtp(): string {
     // DEV mode: fixed code for quick testing
@@ -52,6 +68,16 @@ export class AuthService {
   }
 
   async verifyOtp(email: string, code: string): Promise<{ success: boolean; token?: string; user?: User; error?: string }> {
+    // Check per-email lockout
+    const attempts = this.otpAttempts.get(email);
+    if (attempts && attempts.lockedUntil > Date.now()) {
+      const minutesLeft = Math.ceil((attempts.lockedUntil - Date.now()) / 60000);
+      throw new HttpException(
+        `Too many attempts. Try again in ${minutesLeft} minutes`,
+        HttpStatus.TOO_MANY_REQUESTS,
+      );
+    }
+
     const user = await this.usersService.findByEmail(email);
 
     if (!user) {
@@ -69,12 +95,22 @@ export class AuthService {
     const isValid = user.otpCode.length === code.length &&
       crypto.timingSafeEqual(Buffer.from(user.otpCode), Buffer.from(code));
     if (!isValid) {
+      // Track failed attempt
+      const current = this.otpAttempts.get(email) || { count: 0, lockedUntil: 0 };
+      current.count++;
+      if (current.count >= this.MAX_OTP_ATTEMPTS) {
+        current.lockedUntil = Date.now() + this.LOCKOUT_MINUTES * 60 * 1000;
+        current.count = 0;
+      }
+      this.otpAttempts.set(email, current);
+
       // Invalidate OTP after failed attempt to prevent brute-force
       await this.usersService.clearOtp(user.id);
       return { success: false, error: 'Invalid OTP' };
     }
 
-    // Clear OTP
+    // Successful verification -- clear attempts and OTP
+    this.otpAttempts.delete(email);
     await this.usersService.clearOtp(user.id);
 
     // Generate JWT
@@ -93,18 +129,26 @@ export class AuthService {
     bio?: string;
     hourlyRate?: number;
   }): Promise<{ success: boolean; token?: string; user?: User; error?: string }> {
+    // Sanitize user-facing text fields
+    const sanitizedData = {
+      ...data,
+      name: sanitizeText(data.name),
+      bio: data.bio ? sanitizeText(data.bio) : data.bio,
+      location: data.location ? sanitizeText(data.location) : data.location,
+    };
+
     let user = await this.usersService.findByEmail(data.email);
 
     if (user) {
       // Update existing user
-      const updated = await this.usersService.update(user.id, data);
+      const updated = await this.usersService.update(user.id, sanitizedData);
       if (!updated) {
         return { success: false, error: 'Failed to update user' };
       }
       user = updated;
     } else {
       // Create new user
-      user = await this.usersService.create(data);
+      user = await this.usersService.create(sanitizedData);
     }
 
     const token = this.jwtService.sign({ id: user.id, email: user.email });

--- a/backend/daterabbit-api/src/bookings/bookings.service.ts
+++ b/backend/daterabbit-api/src/bookings/bookings.service.ts
@@ -6,6 +6,7 @@ import { DatePhoto } from './entities/date-photo.entity';
 import { SelfieVerification } from './entities/selfie-verification.entity';
 import { UsersService } from '../users/users.service';
 import { EmailService } from '../email/email.service';
+import { sanitizeText } from '../common/sanitize';
 
 @Injectable()
 export class BookingsService {
@@ -62,6 +63,8 @@ export class BookingsService {
 
     const booking = this.bookingsRepository.create({
       ...data,
+      notes: data.notes ? sanitizeText(data.notes) : data.notes,
+      location: data.location ? sanitizeText(data.location) : data.location,
       totalPrice,
       status: BookingStatus.PENDING,
     });
@@ -159,7 +162,7 @@ export class BookingsService {
   async updateStatus(id: string, status: BookingStatus, reason?: string): Promise<Booking | null> {
     const update: Partial<Booking> = { status };
     if (reason) {
-      update.cancellationReason = reason;
+      update.cancellationReason = sanitizeText(reason);
     }
     await this.bookingsRepository.update(id, update);
     return this.findById(id);
@@ -445,8 +448,8 @@ export class BookingsService {
       throw new HttpException('Unauthorized', HttpStatus.FORBIDDEN);
     }
     await this.bookingsRepository.update(bookingId, {
-      reportIssueType: issueType,
-      reportIssueText: issueText,
+      reportIssueType: sanitizeText(issueType),
+      reportIssueText: sanitizeText(issueText),
     });
     return this.findById(bookingId) as Promise<Booking>;
   }

--- a/backend/daterabbit-api/src/common/sanitize.ts
+++ b/backend/daterabbit-api/src/common/sanitize.ts
@@ -1,0 +1,9 @@
+// Strip HTML tags from user input to prevent XSS
+export function sanitizeText(input: string): string {
+  if (!input) return input;
+  return input
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#x27;');
+}

--- a/backend/daterabbit-api/src/messages/messages.service.ts
+++ b/backend/daterabbit-api/src/messages/messages.service.ts
@@ -3,6 +3,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Message, Conversation } from './entities/message.entity';
 import { BookingsService } from '../bookings/bookings.service';
+import { sanitizeText } from '../common/sanitize';
 
 // Max messages a seeker can send to a companion before booking
 const PRE_CHAT_LIMIT = 3;
@@ -44,7 +45,7 @@ export class MessagesService {
     const message = this.messagesRepository.create({
       senderId,
       receiverId,
-      content,
+      content: sanitizeText(content),
     });
 
     const saved = await this.messagesRepository.save(message);

--- a/backend/daterabbit-api/src/reviews/reviews.service.ts
+++ b/backend/daterabbit-api/src/reviews/reviews.service.ts
@@ -4,6 +4,7 @@ import { Repository } from 'typeorm';
 import { Review } from './entities/review.entity';
 import { Booking, BookingStatus } from '../bookings/entities/booking.entity';
 import { User } from '../users/entities/user.entity';
+import { sanitizeText } from '../common/sanitize';
 
 @Injectable()
 export class ReviewsService {
@@ -58,7 +59,7 @@ export class ReviewsService {
       revieweeId,
       bookingId,
       rating,
-      comment,
+      comment: comment ? sanitizeText(comment) : comment,
     });
 
     const saved = await this.reviewsRepo.save(review);

--- a/backend/daterabbit-api/src/users/users.service.ts
+++ b/backend/daterabbit-api/src/users/users.service.ts
@@ -5,6 +5,7 @@ import { User, UserRole } from './entities/user.entity';
 import { BlockedUser } from './entities/blocked-user.entity';
 import { UserReport } from './entities/user-report.entity';
 import { Favorite } from './entities/favorite.entity';
+import { sanitizeText } from '../common/sanitize';
 
 @Injectable()
 export class UsersService {
@@ -152,7 +153,7 @@ export class UsersService {
     const blocked = this.blockedUsersRepository.create({
       blockerId,
       blockedId,
-      reason,
+      reason: reason ? sanitizeText(reason) : reason,
     });
     await this.blockedUsersRepository.save(blocked);
   }
@@ -194,8 +195,8 @@ export class UsersService {
     const report = this.userReportsRepository.create({
       reporterId,
       reportedId,
-      reason,
-      description,
+      reason: sanitizeText(reason),
+      description: description ? sanitizeText(description) : description,
     });
     return this.userReportsRepository.save(report);
   }


### PR DESCRIPTION
## Summary
- **BUG #836 (P3):** Added `sanitizeText()` utility that escapes HTML entities (`<`, `>`, `"`, `'`) to prevent stored XSS. Applied to all user-facing text fields: booking notes/location/cancellationReason/issueText, auth register name/bio/location, message content, review comment, user report reason/description, block reason.
- **BUG #835 (P2):** Added per-email OTP attempt tracking with lockout after 5 failed attempts (15 min cooldown). Includes hourly cleanup of stale entries to prevent memory leaks.

## Test plan
- [ ] POST /bookings with `<script>alert(1)</script>` in notes -- should be escaped in DB
- [ ] Register with HTML in name/bio -- should be escaped
- [ ] Send message with HTML tags -- should be escaped
- [ ] Submit 5 wrong OTPs for same email -- should get 429 Too Many Requests
- [ ] After lockout, correct OTP should also be rejected until cooldown expires
- [ ] After cooldown, auth should work normally again

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>