### PR TITLE
feat: add 404 not-found page (BUG-838)

### DIFF
--- a/app/app/+not-found.tsx
+++ b/app/app/+not-found.tsx
@@ -1,0 +1,68 @@
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { useRouter } from 'expo-router';
+import { useTheme, spacing, typography, borderRadius, borderWidth, shadows } from '../src/constants/theme';
+
+export default function NotFoundScreen() {
+  const router = useRouter();
+  const { colors } = useTheme();
+
+  return (
+    <View style={[styles.container, { backgroundColor: colors.background }]}>
+      <Text style={styles.emoji}>🐰</Text>
+      <Text style={[styles.title, { color: colors.text }]}>Page Not Found</Text>
+      <Text style={[styles.subtitle, { color: colors.textMuted }]}>
+        Oops! This page doesn't exist.
+      </Text>
+      <TouchableOpacity
+        style={[
+          styles.button,
+          {
+            backgroundColor: colors.primary,
+            borderColor: colors.border,
+          },
+          shadows.sm,
+        ]}
+        onPress={() => router.replace('/')}
+        activeOpacity={0.8}
+      >
+        <Text style={[styles.buttonText, { color: colors.textInverse }]}>Go Home</Text>
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: spacing.xl,
+  },
+  emoji: {
+    fontSize: 64,
+    marginBottom: spacing.md,
+  },
+  title: {
+    fontSize: typography.sizes.xxl,
+    fontWeight: '700' as const,
+    marginBottom: spacing.xs,
+  },
+  subtitle: {
+    fontSize: typography.sizes.md,
+    textAlign: 'center',
+    marginBottom: spacing.xl,
+  },
+  button: {
+    paddingHorizontal: spacing.xl,
+    paddingVertical: spacing.md,
+    borderRadius: borderRadius.md,
+    borderWidth: borderWidth.thick,
+    minHeight: 48,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  buttonText: {
+    fontSize: typography.sizes.md,
+    fontWeight: '600' as const,
+  },
+});


### PR DESCRIPTION
## Summary
- Add `app/app/+not-found.tsx` — Expo Router catch-all 404 screen
- Unknown URLs now show a "Page Not Found" screen instead of silently redirecting to onboarding
- Uses project Neo-Brutalism theme (colors, spacing, shadows, borderWidth)

## Test plan
- [ ] Navigate to a non-existent route (e.g. `/asdf`) and verify 404 page appears
- [ ] Verify "Go Home" button redirects to root
- [ ] Confirm styling matches Neo-Brutalism theme

Generated with [Claude Code](https://claude.com/claude-code)