### PR TITLE
feat: add calendar module with blocked dates CRUD (BUG-837)

### DIFF
--- a/backend/daterabbit-api/src/app.module.ts
+++ b/backend/daterabbit-api/src/app.module.ts
@@ -14,6 +14,7 @@ import { ReviewsModule } from './reviews/reviews.module';
 import { PaymentsModule } from './payments/payments.module';
 import { AdminModule } from './admin/admin.module';
 import { NotificationsModule } from './notifications/notifications.module';
+import { CalendarModule } from './calendar/calendar.module';
 
 @Module({
   imports: [
@@ -60,6 +61,7 @@ import { NotificationsModule } from './notifications/notifications.module';
     PaymentsModule,
     AdminModule,
     NotificationsModule,
+    CalendarModule,
   ],
   providers: [
     {

--- a/backend/daterabbit-api/src/calendar/calendar.controller.ts
+++ b/backend/daterabbit-api/src/calendar/calendar.controller.ts
@@ -1,0 +1,26 @@
+import { Controller, Get, Post, Delete, Body, Param, UseGuards, Request } from '@nestjs/common';
+import { CalendarService } from './calendar.service';
+import { CreateBlockedDateDto } from './dto/create-blocked-date.dto';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+
+@Controller('calendar')
+@UseGuards(JwtAuthGuard)
+export class CalendarController {
+  constructor(private calendarService: CalendarService) {}
+
+  @Post('block')
+  async blockDate(@Request() req, @Body() dto: CreateBlockedDateDto) {
+    return this.calendarService.blockDate(req.user.id, dto);
+  }
+
+  @Get('blocked')
+  async getBlockedDates(@Request() req) {
+    return this.calendarService.getBlockedDates(req.user.id);
+  }
+
+  @Delete('block/:id')
+  async removeBlock(@Param('id') id: string, @Request() req) {
+    await this.calendarService.removeBlock(req.user.id, id);
+    return { success: true };
+  }
+}

--- a/backend/daterabbit-api/src/calendar/calendar.module.ts
+++ b/backend/daterabbit-api/src/calendar/calendar.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { BlockedDate } from './entities/blocked-date.entity';
+import { CalendarService } from './calendar.service';
+import { CalendarController } from './calendar.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([BlockedDate])],
+  providers: [CalendarService],
+  controllers: [CalendarController],
+  exports: [CalendarService],
+})
+export class CalendarModule {}

--- a/backend/daterabbit-api/src/calendar/calendar.service.ts
+++ b/backend/daterabbit-api/src/calendar/calendar.service.ts
@@ -1,0 +1,61 @@
+import { Injectable, HttpException, HttpStatus } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { BlockedDate } from './entities/blocked-date.entity';
+import { CreateBlockedDateDto } from './dto/create-blocked-date.dto';
+import { sanitizeText } from '../common/sanitize';
+
+@Injectable()
+export class CalendarService {
+  constructor(
+    @InjectRepository(BlockedDate)
+    private blockedDateRepository: Repository<BlockedDate>,
+  ) {}
+
+  async blockDate(userId: string, dto: CreateBlockedDateDto): Promise<BlockedDate> {
+    // Validate startTime < endTime if both provided
+    if (dto.startTime && dto.endTime && dto.startTime >= dto.endTime) {
+      throw new HttpException('startTime must be before endTime', HttpStatus.BAD_REQUEST);
+    }
+
+    const blockedDate = this.blockedDateRepository.create({
+      userId,
+      date: dto.date,
+      startTime: dto.startTime || undefined,
+      endTime: dto.endTime || undefined,
+      reason: dto.reason ? sanitizeText(dto.reason) : undefined,
+    } as Partial<BlockedDate>);
+
+    return this.blockedDateRepository.save(blockedDate as BlockedDate);
+  }
+
+  async getBlockedDates(userId: string): Promise<BlockedDate[]> {
+    return this.blockedDateRepository.find({
+      where: { userId },
+      order: { date: 'ASC', startTime: 'ASC' },
+    });
+  }
+
+  async removeBlock(userId: string, blockId: string): Promise<void> {
+    const block = await this.blockedDateRepository.findOne({
+      where: { id: blockId },
+    });
+
+    if (!block) {
+      throw new HttpException('Blocked date not found', HttpStatus.NOT_FOUND);
+    }
+
+    if (block.userId !== userId) {
+      throw new HttpException('Cannot delete another user\'s blocked date', HttpStatus.FORBIDDEN);
+    }
+
+    await this.blockedDateRepository.remove(block);
+  }
+
+  async isDateBlocked(companionId: string, date: string): Promise<boolean> {
+    const count = await this.blockedDateRepository.count({
+      where: { userId: companionId, date },
+    });
+    return count > 0;
+  }
+}

--- a/backend/daterabbit-api/src/calendar/dto/create-blocked-date.dto.ts
+++ b/backend/daterabbit-api/src/calendar/dto/create-blocked-date.dto.ts
@@ -1,0 +1,22 @@
+import { IsString, IsOptional, Matches, IsNotEmpty } from 'class-validator';
+
+export class CreateBlockedDateDto {
+  @IsString()
+  @IsNotEmpty()
+  @Matches(/^\d{4}-\d{2}-\d{2}$/, { message: 'date must be in YYYY-MM-DD format' })
+  date: string;
+
+  @IsOptional()
+  @IsString()
+  @Matches(/^\d{2}:\d{2}$/, { message: 'startTime must be in HH:mm format' })
+  startTime?: string;
+
+  @IsOptional()
+  @IsString()
+  @Matches(/^\d{2}:\d{2}$/, { message: 'endTime must be in HH:mm format' })
+  endTime?: string;
+
+  @IsOptional()
+  @IsString()
+  reason?: string;
+}

--- a/backend/daterabbit-api/src/calendar/entities/blocked-date.entity.ts
+++ b/backend/daterabbit-api/src/calendar/entities/blocked-date.entity.ts
@@ -1,0 +1,37 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  ManyToOne,
+  JoinColumn,
+  CreateDateColumn,
+} from 'typeorm';
+import { User } from '../../users/entities/user.entity';
+
+@Entity('blocked_dates')
+export class BlockedDate {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  userId: string;
+
+  @ManyToOne(() => User)
+  @JoinColumn({ name: 'userId' })
+  user: User;
+
+  @Column({ type: 'date' })
+  date: string;
+
+  @Column({ nullable: true })
+  startTime: string; // HH:mm format, nullable = whole day blocked
+
+  @Column({ nullable: true })
+  endTime: string;
+
+  @Column({ nullable: true })
+  reason: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}


### PR DESCRIPTION
## Summary
- Add CalendarModule with BlockedDate entity, service, controller, and DTO
- Endpoints: POST /calendar/block, GET /calendar/blocked, DELETE /calendar/block/:id
- All endpoints require JWT auth; users can only manage their own blocked dates
- CalendarService.isDateBlocked() exported for future booking integration

## Test plan
- [ ] POST /calendar/block with valid date creates a blocked date
- [ ] GET /calendar/blocked returns user's blocked dates
- [ ] DELETE /calendar/block/:id removes own block, 403 for others
- [ ] Validation rejects invalid date/time formats

Generated with [Claude Code](https://claude.com/claude-code)