### PR TITLE
fix: ensure 404 page renders on web (BUG-838)

### DIFF
--- a/app/app/_layout.tsx
+++ b/app/app/_layout.tsx
@@ -14,7 +14,7 @@ import { colors } from '../src/constants/theme';
 import { StripeProvider } from '../src/components/StripeProvider';
 
 // Public routes accessible without authentication
-const PUBLIC_ROUTES = ['terms', 'privacy', 'onboarding', '(auth)'];
+const PUBLIC_ROUTES = ['terms', 'privacy', 'onboarding', '(auth)', '+not-found'];
 
 // Authenticated non-tab routes — accessible to fully verified users outside (tabs)
 const NON_TAB_AUTH_ROUTES = [
@@ -163,6 +163,7 @@ export default function RootLayout() {
         <Stack.Screen name="settings/delete-account" />
         <Stack.Screen name="settings/payment-methods" />
         <Stack.Screen name="date" />
+        <Stack.Screen name="+not-found" />
       </Stack>
       <NavigationGuard />
     </StripeProvider>


### PR DESCRIPTION
## Summary
- Add `+not-found` to `PUBLIC_ROUTES` in NavigationGuard so unknown URLs are not redirected to onboarding/auth
- Register `+not-found` as a `Stack.Screen` so Expo Router matches and renders the 404 component

## Root cause
The `NavigationGuard` component in `_layout.tsx` checks the current route segment against known route lists. Unknown URLs (which should show 404) were not in any list, so the guard redirected them to onboarding or auth depending on user state.

## Test plan
- [ ] Open `https://daterabbit.smartlaunchhub.com/nonexistent-page` -- should show 404 page with bunny emoji
- [ ] Verify normal routes (onboarding, auth, tabs) still work as before

Generated with [Claude Code](https://claude.com/claude-code)