### PR TITLE
fix: welcome CTA cutoff and onboarding slide navigation

### DIFF
--- a/app/app/(auth)/welcome.tsx
+++ b/app/app/(auth)/welcome.tsx
@@ -4,7 +4,7 @@ import { router, useLocalSearchParams } from 'expo-router';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { LinearGradient } from 'expo-linear-gradient';
 import { Button } from '../../src/components/Button';
-import { Badge } from '../../src/components/Badge';
+// Badge removed -- "Premium dating marketplace" didn't match the color scheme
 import { Icon } from '../../src/components/Icon';
 import { colors, spacing, typography, borderRadius, PAGE_PADDING } from '../../src/constants/theme';
 
@@ -53,8 +53,6 @@ export default function WelcomeScreen() {
 
         {/* Hero */}
         <View style={styles.hero}>
-          <Badge text="Premium dating marketplace" variant="gradient" size="md" />
-
           <Text style={styles.headline}>
             Real dates.{'\n'}
             <Text style={styles.headlineHighlight}>Your terms.</Text>
@@ -257,9 +255,9 @@ const styles = StyleSheet.create({
 
   // Hero
   hero: {
-    flex: 1,
+    flexShrink: 1,
     justifyContent: 'center',
-    paddingVertical: spacing.xl,
+    paddingVertical: spacing.lg,
   },
   headline: {
     fontFamily: typography.fonts.heading,
@@ -329,8 +327,9 @@ const styles = StyleSheet.create({
 
   // Actions
   actions: {
-    marginTop: 'auto',
+    marginTop: spacing.lg,
     gap: spacing.md,
+    paddingBottom: spacing.md,
   },
   signinLink: {
     fontFamily: typography.fonts.body,

--- a/app/app/onboarding.tsx
+++ b/app/app/onboarding.tsx
@@ -48,26 +48,24 @@ const slides: SlideItem[] = [
 
 export default function OnboardingScreen() {
   const [currentIndex, setCurrentIndex] = useState(0);
-  const { setOnboardingSeen, user } = useAuthStore();
+  const { setOnboardingSeen } = useAuthStore();
 
   const handleNext = () => {
     if (currentIndex < slides.length - 1) {
-      setCurrentIndex(currentIndex + 1);
+      setCurrentIndex(prev => prev + 1);
     } else {
-      handleGetStarted();
+      completeOnboarding();
     }
   };
 
-  const handleGetStarted = () => {
+  const completeOnboarding = () => {
     setOnboardingSeen();
-    // User is already authenticated at this point, go to main app based on role
-    // In Expo Router, /male is equivalent to /male/index when index.tsx exists
-    const isCompanion = user?.role === 'companion';
-    router.replace(isCompanion ? '/female' : '/male');
+    // Navigate to auth welcome (login) page after onboarding
+    router.replace('/(auth)/welcome');
   };
 
   const handleSkip = () => {
-    handleGetStarted();
+    completeOnboarding();
   };
 
   const currentSlide = slides[currentIndex];


### PR DESCRIPTION
## Summary
- **BUG #854:** Remove yellow "Premium dating marketplace" badge (mismatched color scheme). Fix hero layout (`flex:1` → `flexShrink:1`) and actions spacing (`marginTop:auto` → fixed) so CTA buttons are always visible and reachable in ScrollView.
- **BUG #855:** Fix onboarding NEXT button to properly cycle slides using functional state update. Navigate directly to `/(auth)/welcome` after onboarding completion instead of role-based redirect through NavigationGuard.

## Test plan
- [ ] Open `/welcome` on mobile viewport -- verify all 3 CTA buttons visible without scrolling
- [ ] Open `/welcome` on short viewport -- verify page scrolls and buttons reachable
- [ ] Verify "Premium dating marketplace" badge is removed
- [ ] Open `/onboarding` -- tap NEXT, verify slides cycle 1→2→3→4
- [ ] On slide 4, tap NEXT -- verify redirect to welcome/login page
- [ ] Tap SKIP on any slide -- verify redirect to welcome/login page

🤖 Generated with [Claude Code](https://claude.com/claude-code)