### PR TITLE
fix: make verification optional (BUG #856)

### DIFF
--- a/app/app/(tabs)/female/index.tsx
+++ b/app/app/(tabs)/female/index.tsx
@@ -7,6 +7,7 @@ import { Card } from '../../../src/components/Card';
 import { Avatar } from '../../../src/components/Avatar';
 import { Badge } from '../../../src/components/Badge';
 import { Icon } from '../../../src/components/Icon';
+import { VerificationBanner } from '../../../src/components/VerificationBanner';
 import { colors, spacing, typography, borderRadius, shadows, PAGE_PADDING } from '../../../src/constants/theme';
 
 export default function FemaleDashboard() {
@@ -42,6 +43,9 @@ export default function FemaleDashboard() {
           verified={user?.isVerified}
         />
       </View>
+
+      {/* Verification reminder */}
+      <VerificationBanner />
 
       {/* Stats Grid */}
       <View style={styles.statsGrid}>

--- a/app/app/(tabs)/male/browse.tsx
+++ b/app/app/(tabs)/male/browse.tsx
@@ -11,6 +11,7 @@ import { EmptyState } from '../../../src/components/EmptyState';
 import { FilterModal, FilterOptions } from '../../../src/components/FilterModal';
 import { useTheme, spacing, typography, borderRadius } from '../../../src/constants/theme';
 import { companionsApi, CompanionListItem } from '../../../src/services/api';
+import { useVerificationGate } from '../../../src/hooks/useVerificationGate';
 
 const quickFilters = ['All', 'Nearby', 'Top Rated', 'New'];
 
@@ -26,6 +27,7 @@ const defaultFilterOptions: FilterOptions = {
 export default function BrowseScreen() {
   const insets = useSafeAreaInsets();
   const { colors } = useTheme();
+  const { requireVerification } = useVerificationGate();
   const [activeFilter, setActiveFilter] = useState('All');
   const [searchQuery, setSearchQuery] = useState('');
   const [filterModalVisible, setFilterModalVisible] = useState(false);
@@ -289,7 +291,10 @@ export default function BrowseScreen() {
                 />
                 <Button
                   title="Book Date"
-                  onPress={() => router.push(`/booking/${companion.id}`)}
+                  onPress={() => {
+                    if (requireVerification()) return;
+                    router.push(`/booking/${companion.id}`);
+                  }}
                   size="md"
                   style={styles.actionButton}
                   testID={`browse-book-date-${companion.id}`}

--- a/app/app/(tabs)/male/index.tsx
+++ b/app/app/(tabs)/male/index.tsx
@@ -21,6 +21,7 @@ import { UserImage } from '../../../src/components/UserImage';
 import { Badge } from '../../../src/components/Badge';
 import { Icon } from '../../../src/components/Icon';
 import { EmptyState } from '../../../src/components/EmptyState';
+import { VerificationBanner } from '../../../src/components/VerificationBanner';
 import { useTheme, spacing, typography, borderRadius, PAGE_PADDING } from '../../../src/constants/theme';
 import { bookingsApi, companionsApi, Booking, CompanionListItem } from '../../../src/services/api';
 
@@ -135,6 +136,9 @@ export default function MaleDashboard() {
           verified={user?.isVerified}
         />
       </View>
+
+      {/* Verification reminder */}
+      <VerificationBanner />
 
       {/* Search */}
       <TouchableOpacity

--- a/app/app/_layout.tsx
+++ b/app/app/_layout.tsx
@@ -16,17 +16,21 @@ import { StripeProvider } from '../src/components/StripeProvider';
 // Public routes accessible without authentication
 const PUBLIC_ROUTES = ['terms', 'privacy', 'onboarding', '(auth)', '+not-found'];
 
-// Authenticated non-tab routes — accessible to fully verified users outside (tabs)
+// Authenticated non-tab routes — accessible to all authenticated users (verified or not)
 const NON_TAB_AUTH_ROUTES = [
-  'booking',
   'chat',
   'profile',
   'reviews',
-  'payment',
-  'stripe',
   'favorites',
   'settings',
   'date',
+];
+
+// Routes that REQUIRE verification — unverified users get redirected to verification prompt
+const VERIFICATION_REQUIRED_ROUTES = [
+  'booking',
+  'payment',
+  'stripe',
 ];
 
 function NavigationGuard() {
@@ -43,17 +47,9 @@ function NavigationGuard() {
     if (PUBLIC_ROUTES.includes(currentSegment)) {
       // Only redirect from onboarding/auth if already authenticated
       if (currentSegment === '(auth)' && isAuthenticated) {
-        // Authenticated user on auth page — redirect to app
-        if (needsVerification) {
-          if (isSeeker) {
-            router.replace('/(seeker-verify)/intro');
-          } else {
-            router.replace('/(comp-onboard)/step1');
-          }
-        } else {
-          const isCompanion = user?.role === 'companion';
-          router.replace(isCompanion ? '/(tabs)/female' : '/(tabs)/male');
-        }
+        // Authenticated user on auth page — redirect to main app
+        const isCompanion = user?.role === 'companion';
+        router.replace(isCompanion ? '/(tabs)/female' : '/(tabs)/male');
       }
       // terms, privacy — always accessible, never redirect
       return;
@@ -77,17 +73,31 @@ function NavigationGuard() {
     }
 
     if (needsVerification) {
-      // Authenticated but not yet verified — send to verification flow
-      if (isSeeker) {
-        const inSeekerVerify = currentSegment === '(seeker-verify)';
-        if (!inSeekerVerify) {
+      // Unverified users CAN still be in verification flow
+      const inSeekerVerify = currentSegment === '(seeker-verify)';
+      const inCompOnboard = currentSegment === '(comp-onboard)';
+
+      // If user is already in a verification flow, let them stay
+      if (inSeekerVerify || inCompOnboard) {
+        return;
+      }
+
+      // Block verification-required routes — redirect to verification prompt
+      if (VERIFICATION_REQUIRED_ROUTES.includes(currentSegment)) {
+        if (isSeeker) {
           router.replace('/(seeker-verify)/intro');
-        }
-      } else {
-        const inCompOnboard = currentSegment === '(comp-onboard)';
-        if (!inCompOnboard) {
+        } else {
           router.replace('/(comp-onboard)/step1');
         }
+        return;
+      }
+
+      // Allow unverified users to browse tabs and non-tab auth routes
+      const inTabsGroup = currentSegment === '(tabs)';
+      const inNonTabAuthRoute = NON_TAB_AUTH_ROUTES.includes(currentSegment);
+      if (!inTabsGroup && !inNonTabAuthRoute) {
+        const isCompanion = user?.role === 'companion';
+        router.replace(isCompanion ? '/(tabs)/female' : '/(tabs)/male');
       }
       return;
     }
@@ -95,7 +105,8 @@ function NavigationGuard() {
     // Fully authenticated and verified
     const inTabsGroup = currentSegment === '(tabs)';
     const inNonTabAuthRoute = NON_TAB_AUTH_ROUTES.includes(currentSegment);
-    if (!inTabsGroup && !inNonTabAuthRoute) {
+    const inVerificationRequiredRoute = VERIFICATION_REQUIRED_ROUTES.includes(currentSegment);
+    if (!inTabsGroup && !inNonTabAuthRoute && !inVerificationRequiredRoute) {
       const isCompanion = user?.role === 'companion';
       router.replace(isCompanion ? '/(tabs)/female' : '/(tabs)/male');
     }

--- a/app/app/booking/[id].tsx
+++ b/app/app/booking/[id].tsx
@@ -18,6 +18,7 @@ import { useTheme, spacing, typography, borderRadius } from '../../src/constants
 import { useBookingsStore } from '../../src/store/bookingsStore';
 import { companionsApi, CompanionDetail } from '../../src/services/api';
 import { showAlert } from '../../src/utils/alert';
+import { useVerificationGate } from '../../src/hooks/useVerificationGate';
 
 // Activity IDs aligned with backend ActivityType enum
 const activities = [
@@ -68,6 +69,7 @@ export default function BookingScreen() {
   const { colors } = useTheme();
 
   const { createBooking } = useBookingsStore();
+  const { requireVerification } = useVerificationGate();
 
   const availableDates = generateDates();
 
@@ -99,6 +101,8 @@ export default function BookingScreen() {
   const isValid = selectedActivity && selectedDate && selectedTime && location.length > 0;
 
   const handleSubmit = async () => {
+    if (requireVerification()) return;
+
     if (!isValid || !companion) {
       showAlert('Missing Information', 'Please fill in all required fields.');
       return;

--- a/app/app/profile/[id].tsx
+++ b/app/app/profile/[id].tsx
@@ -22,6 +22,7 @@ import { Icon } from '../../src/components/Icon';
 import { UserImage } from '../../src/components/UserImage';
 import { useTheme, spacing, typography, borderRadius, colors } from '../../src/constants/theme';
 import { useFavoritesStore } from '../../src/store/favoritesStore';
+import { useVerificationGate } from '../../src/hooks/useVerificationGate';
 import { usersApi, companionsApi, CompanionDetail } from '../../src/services/api';
 
 // Max width for photo container — prevents giant hero on wide screens
@@ -68,8 +69,9 @@ export default function ProfileViewScreen() {
   const insets = useSafeAreaInsets();
   const { colors } = useTheme();
   const { width: windowWidth } = useWindowDimensions();
+  const { requireVerification } = useVerificationGate();
   const photoWidth = Platform.OS === 'web' ? Math.min(windowWidth, MAX_PHOTO_WIDTH) : windowWidth;
-  
+
   const [profile, setProfile] = useState<ProfileData>(defaultProfile);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -195,6 +197,7 @@ export default function ProfileViewScreen() {
   };
 
   const handleBookDate = () => {
+    if (requireVerification()) return;
     router.push(`/booking/${profile.id}`);
   };
 

--- a/app/src/components/VerificationBanner.tsx
+++ b/app/src/components/VerificationBanner.tsx
@@ -1,0 +1,105 @@
+import React from 'react';
+import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
+import { useRouter } from 'expo-router';
+import { Icon } from './Icon';
+import { colors, spacing, typography, borderRadius, borderWidth } from '../constants/theme';
+import { useAuthStore } from '../store/authStore';
+
+interface VerificationBannerProps {
+  /** Compact mode shows a smaller single-line banner */
+  compact?: boolean;
+}
+
+/**
+ * Banner reminding unverified users to complete verification.
+ * Renders nothing if the user is already verified.
+ */
+export function VerificationBanner({ compact = false }: VerificationBannerProps) {
+  const { user } = useAuthStore();
+  const router = useRouter();
+
+  const isVerified = user?.verificationStatus === 'approved';
+  const isPending = user?.verificationStatus === 'pending';
+
+  if (isVerified) return null;
+
+  const handlePress = () => {
+    if (user?.role === 'seeker') {
+      router.push('/(seeker-verify)/intro');
+    } else {
+      router.push('/(comp-onboard)/step1');
+    }
+  };
+
+  if (isPending) {
+    return (
+      <View style={[styles.banner, styles.pendingBanner, compact && styles.compact]}>
+        <Icon name="clock" size={compact ? 16 : 20} color={colors.badge.warning.text} />
+        <Text style={[styles.text, styles.pendingText, compact && styles.compactText]}>
+          Verification under review
+        </Text>
+      </View>
+    );
+  }
+
+  return (
+    <TouchableOpacity
+      style={[styles.banner, styles.warningBanner, compact && styles.compact]}
+      onPress={handlePress}
+      activeOpacity={0.8}
+    >
+      <View style={styles.content}>
+        <Icon name="shield-alert" size={compact ? 16 : 20} color={colors.warning} />
+        <Text style={[styles.text, compact && styles.compactText]}>
+          {compact
+            ? 'Verify to unlock booking'
+            : 'Complete verification to unlock booking and payments'}
+        </Text>
+      </View>
+      <Icon name="chevron-right" size={16} color={colors.textSecondary} />
+    </TouchableOpacity>
+  );
+}
+
+const styles = StyleSheet.create({
+  banner: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingVertical: spacing.sm + 2,
+    paddingHorizontal: spacing.md,
+    marginHorizontal: spacing.md,
+    marginVertical: spacing.sm,
+    borderRadius: borderRadius.md,
+    borderWidth: borderWidth.thin,
+    borderColor: colors.black,
+  },
+  compact: {
+    paddingVertical: spacing.sm,
+    marginVertical: spacing.xs,
+  },
+  warningBanner: {
+    backgroundColor: colors.warningLight,
+  },
+  pendingBanner: {
+    backgroundColor: colors.badge.warning.bg,
+  },
+  content: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    flex: 1,
+    gap: spacing.sm,
+  },
+  text: {
+    fontFamily: typography.fonts.bodyMedium,
+    fontSize: typography.sizes.sm,
+    color: colors.textPrimary,
+    flex: 1,
+  },
+  compactText: {
+    fontSize: typography.sizes.xs,
+  },
+  pendingText: {
+    marginLeft: spacing.sm,
+  },
+});

--- a/app/src/hooks/useVerificationGate.ts
+++ b/app/src/hooks/useVerificationGate.ts
@@ -1,0 +1,55 @@
+import { useRouter } from 'expo-router';
+import { useAuthStore } from '../store/authStore';
+import { showAlert, showConfirm } from '../utils/alert';
+
+/**
+ * Hook that checks verification status before allowing an action.
+ * Returns { isVerified, requireVerification }.
+ *
+ * Usage:
+ *   const { requireVerification } = useVerificationGate();
+ *   const handleBook = () => {
+ *     if (requireVerification()) return; // blocked, user prompted
+ *     // proceed with booking...
+ *   };
+ */
+export function useVerificationGate() {
+  const { user } = useAuthStore();
+  const router = useRouter();
+
+  const isVerified = user?.verificationStatus === 'approved';
+  const isPending = user?.verificationStatus === 'pending';
+
+  /**
+   * Call before a gated action. Returns true if action should be blocked.
+   * Shows an alert and optionally redirects to verification flow.
+   */
+  const requireVerification = (): boolean => {
+    if (isVerified) return false;
+
+    if (isPending) {
+      showAlert(
+        'Verification Pending',
+        'Your verification is being reviewed. You will be able to book once approved.',
+      );
+      return true;
+    }
+
+    showConfirm(
+      'Verification Required',
+      'Complete identity verification to book dates and make payments.',
+      () => {
+        if (user?.role === 'seeker') {
+          router.push('/(seeker-verify)/intro');
+        } else {
+          router.push('/(comp-onboard)/step1');
+        }
+      },
+      'Verify Now',
+      'Later',
+    );
+    return true;
+  };
+
+  return { isVerified, isPending, requireVerification };
+}


### PR DESCRIPTION
## Summary
- **NavigationGuard** no longer blocks unverified users from the entire app. Only `booking`, `payment`, and `stripe` routes require verification.
- Unverified users can browse profiles, view messages, access favorites, settings, and chat.
- **VerificationBanner** component added to both male and female dashboards — shows a warning with link to start verification (or "under review" for pending users).
- **useVerificationGate** hook gates booking actions: "Book Date" buttons on browse, profile, and booking screens show a confirm dialog prompting verification.

## Test plan
- [ ] Register new account, skip verification — confirm app loads dashboard (not verification screen)
- [ ] Verify banner appears on dashboard with "Verify to unlock booking" message
- [ ] Tap "Book Date" on browse/profile — confirm verification prompt appears
- [ ] Complete verification — confirm banner disappears and booking works normally
- [ ] Pending verification status shows "Verification under review" banner

Fixes BUG #856