### PR TITLE
fix: move Stripe publishable key from code to env var

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,6 +24,8 @@ jobs:
           node-version: '20'
 
       - name: Build frontend (Expo web)
+        env:
+          EXPO_PUBLIC_STRIPE_PUBLISHABLE_KEY: ${{ secrets.STRIPE_PUBLISHABLE_KEY }}
         run: |
           cd app
           npm ci --legacy-peer-deps
@@ -254,6 +256,8 @@ jobs:
           node-version: '20'
 
       - name: Build frontend (Expo web)
+        env:
+          EXPO_PUBLIC_STRIPE_PUBLISHABLE_KEY: ${{ secrets.STRIPE_PUBLISHABLE_KEY }}
         run: |
           cd app
           npm ci --legacy-peer-deps

--- a/app/src/components/StripePaymentForm.tsx
+++ b/app/src/components/StripePaymentForm.tsx
@@ -39,7 +39,8 @@ function WebPaymentForm({ clientSecret, amount, onSuccess, onError }: StripePaym
 
   const publishableKey =
     Constants.expoConfig?.extra?.stripePublishableKey ||
-    'pk_test_51T5TlyPIXSgCWIzOHEKqYS4Pqjt8VNkMlPx2aZ6MIqJQf1UWTEJvEdcSfrLj9z3qRzG49fQrF0FxEGqaNLNpSIX00Hb8bFncl';
+    process.env.EXPO_PUBLIC_STRIPE_PUBLISHABLE_KEY ||
+    '';
 
   const stripePromise = loadStripe(publishableKey);
 

--- a/app/src/components/StripeProviderWeb.tsx
+++ b/app/src/components/StripeProviderWeb.tsx
@@ -5,7 +5,8 @@ import Constants from 'expo-constants';
 
 const publishableKey =
   Constants.expoConfig?.extra?.stripePublishableKey ||
-  'pk_test_51T5TlyPIXSgCWIzOHEKqYS4Pqjt8VNkMlPx2aZ6MIqJQf1UWTEJvEdcSfrLj9z3qRzG49fQrF0FxEGqaNLNpSIX00Hb8bFncl';
+  process.env.EXPO_PUBLIC_STRIPE_PUBLISHABLE_KEY ||
+  '';
 
 const stripePromise = loadStripe(publishableKey);
 


### PR DESCRIPTION
## Summary
- Remove hardcoded `pk_test_*` Stripe key from `StripePaymentForm.tsx` and `StripeProviderWeb.tsx`
- Use `EXPO_PUBLIC_STRIPE_PUBLISHABLE_KEY` env var (baked at build time)
- Add env injection in both staging and production CI workflows
- `STRIPE_PUBLISHABLE_KEY` added to GitHub Secrets

## PRE_PROD blocker
Resolves blocker #2 from Launch Prep audit (secrets in code).

## Test plan
- [ ] CI build succeeds with env var injection
- [ ] Stripe payment form still loads publishable key correctly on staging

Generated with [Claude Code](https://claude.com/claude-code)