### PR TITLE
fix: API timeout + hide rating with 0 reviews

### DIFF
--- a/app/app/(tabs)/male/browse.tsx
+++ b/app/app/(tabs)/male/browse.tsx
@@ -258,9 +258,17 @@ export default function BrowseScreen() {
                     </Text>
                   </View>
                   <View style={styles.ratingRow}>
-                    <Icon name="star" size={14} color={colors.accent} />
-                    <Text style={[styles.rating, { color: colors.text, marginLeft: 4 }]}>{Number(companion.rating).toFixed(1)}</Text>
-                    <Text style={[styles.reviews, { color: colors.textSecondary }]}>({companion.reviewCount} reviews)</Text>
+                    {companion.reviewCount > 0 ? (
+                      <>
+                        <Icon name="star" size={14} color={colors.accent} />
+                        <Text style={[styles.rating, { color: colors.text, marginLeft: 4 }]}>{Number(companion.rating).toFixed(1)}</Text>
+                        <Text style={[styles.reviews, { color: colors.textSecondary }]}>({companion.reviewCount} reviews)</Text>
+                      </>
+                    ) : (
+                      <View style={[styles.newBadge, { backgroundColor: colors.primary + '15' }]}>
+                        <Text style={[styles.newBadgeText, { color: colors.primary }]}>New</Text>
+                      </View>
+                    )}
                   </View>
                 </View>
                 <View style={[styles.rateBox, { backgroundColor: colors.primary + '15' }]}>
@@ -491,6 +499,15 @@ const styles = StyleSheet.create({
     fontFamily: typography.fonts.body,
     fontSize: typography.sizes.sm,
     marginLeft: spacing.xs,
+  },
+  newBadge: {
+    paddingHorizontal: spacing.sm,
+    paddingVertical: 2,
+    borderRadius: borderRadius.xs,
+  },
+  newBadgeText: {
+    fontFamily: typography.fonts.bodySemiBold,
+    fontSize: typography.sizes.xs,
   },
   rateBox: {
     alignItems: 'center',

--- a/app/app/profile/[id].tsx
+++ b/app/app/profile/[id].tsx
@@ -335,9 +335,17 @@ export default function ProfileViewScreen() {
 
             <View style={styles.statsRow}>
               <View style={styles.stat}>
-                <Icon name="star" size={16} color={colors.accent} />
-                <Text style={[styles.statValue, { color: colors.text }]}> {profile.rating}</Text>
-                <Text style={[styles.statLabel, { color: colors.textSecondary }]}>({profile.reviewCount} reviews)</Text>
+                {profile.reviewCount > 0 ? (
+                  <>
+                    <Icon name="star" size={16} color={colors.accent} />
+                    <Text style={[styles.statValue, { color: colors.text }]}> {profile.rating}</Text>
+                    <Text style={[styles.statLabel, { color: colors.textSecondary }]}>({profile.reviewCount} reviews)</Text>
+                  </>
+                ) : (
+                  <View style={[styles.newBadge, { backgroundColor: colors.primary + '15' }]}>
+                    <Text style={[styles.newBadgeText, { color: colors.primary }]}>New</Text>
+                  </View>
+                )}
               </View>
               <View style={[styles.rateBadge, { backgroundColor: colors.primary + '15' }]}>
                 <Text style={[styles.rateValue, { color: colors.primary }]}>${profile.hourlyRate ?? 0}</Text>
@@ -862,6 +870,15 @@ const styles = StyleSheet.create({
     fontFamily: typography.fonts.body,
     fontSize: typography.sizes.sm,
     marginLeft: spacing.xs,
+  },
+  newBadge: {
+    paddingHorizontal: spacing.sm,
+    paddingVertical: 2,
+    borderRadius: borderRadius.xs,
+  },
+  newBadgeText: {
+    fontFamily: typography.fonts.bodySemiBold,
+    fontSize: typography.sizes.sm,
   },
   rateBadge: {
     flexDirection: 'row',

--- a/app/src/services/api.ts
+++ b/app/src/services/api.ts
@@ -56,11 +56,26 @@ export async function apiRequest<T>(
     }
   }
 
-  const response = await fetch(`${API_BASE_URL}${endpoint}`, {
-    method,
-    headers,
-    body: body ? JSON.stringify(body) : undefined,
-  });
+  // 10-second timeout to prevent infinite loading states
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 10000);
+
+  let response: Response;
+  try {
+    response = await fetch(`${API_BASE_URL}${endpoint}`, {
+      method,
+      headers,
+      body: body ? JSON.stringify(body) : undefined,
+      signal: controller.signal,
+    });
+  } catch (err: any) {
+    clearTimeout(timeoutId);
+    if (err.name === 'AbortError') {
+      throw new ApiError('Request timed out. Please try again.', 408);
+    }
+    throw new ApiError('Network error. Please check your connection.', 0);
+  }
+  clearTimeout(timeoutId);
 
   const data = await response.json().catch(() => ({}));
 


### PR DESCRIPTION
## Summary
- **Bug #908**: Added 10-second `AbortController` timeout to all API requests in `apiRequest()`. On timeout/network error, throws clear error message that properly clears `isLoading` state and re-enables the Continue button.
- **Bug #921**: When `reviewCount === 0`, companion cards (browse) and profile pages now show a "New" badge instead of a misleading 5.0 star rating.

## Changed files
- `app/src/services/api.ts` -- AbortController timeout + network error handling
- `app/app/(tabs)/male/browse.tsx` -- conditional rating/New badge on companion cards
- `app/app/profile/[id].tsx` -- conditional rating/New badge on profile page

## Test plan
- [ ] Enter email on login screen, disconnect network -- verify spinner stops after 10s with error message
- [ ] Verify Continue button is re-enabled after timeout error
- [ ] Browse companions with 0 reviews -- verify "New" badge shown instead of 5.0 stars
- [ ] Browse companions with reviews -- verify rating still displays normally
- [ ] Open profile of companion with 0 reviews -- verify "New" badge

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>