### PR TITLE
fix: auth OTP email delivery + Brevo timeout

### DIFF
--- a/backend/daterabbit-api/src/auth/auth.service.ts
+++ b/backend/daterabbit-api/src/auth/auth.service.ts
@@ -62,7 +62,14 @@ export class AuthService {
       return { success: true, isNewUser };
     }
 
-    await this.emailService.sendOtp(email, otp);
+    const emailSent = await this.emailService.sendOtp(email, otp);
+
+    if (!emailSent) {
+      throw new HttpException(
+        'Failed to send verification email. Please try again later.',
+        HttpStatus.SERVICE_UNAVAILABLE,
+      );
+    }
 
     return { success: true, isNewUser };
   }

--- a/backend/daterabbit-api/src/email/email.service.ts
+++ b/backend/daterabbit-api/src/email/email.service.ts
@@ -27,6 +27,9 @@ export class EmailService {
     }
 
     try {
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), 10000); // 10s timeout
+
       const response = await fetch('https://api.brevo.com/v3/smtp/email', {
         method: 'POST',
         headers: {
@@ -40,7 +43,10 @@ export class EmailService {
           subject: options.subject,
           htmlContent: options.htmlContent,
         }),
+        signal: controller.signal,
       });
+
+      clearTimeout(timeout);
 
       if (response.ok) {
         this.logger.log(`Email sent to ${options.to}: ${options.subject}`);
@@ -51,7 +57,11 @@ export class EmailService {
         return false;
       }
     } catch (error) {
-      this.logger.error(`Failed to send email to ${options.to}: ${error}`);
+      if (error instanceof Error && error.name === 'AbortError') {
+        this.logger.error(`Brevo API timeout after 10s for ${options.to}`);
+      } else {
+        this.logger.error(`Failed to send email to ${options.to}: ${error}`);
+      }
       return false;
     }
   }


### PR DESCRIPTION
## Summary
- **Bug #906**: `send-otp` returned success even when Brevo email failed to send (disabled API key). Users waited for OTP that never arrived. Now throws 503 when email delivery fails.
- **Bug #907**: Sender email was `noreply@diagrams.love`. Updated server .env to `noreply@daterabbit.com` with `BREVO_SENDER_NAME=DateRabbit`.
- Added 10s AbortController timeout on Brevo API fetch to prevent network-level hangs.
- Replaced disabled Brevo API key on server.

## Root cause
The Brevo API key in server .env was disabled ("API Key is not enabled", 401). Email sending silently failed, `startAuth` still returned `{success: true}`, so users never received OTP codes.

## Test plan
- [x] Tested `send-otp` on staging -- returns 201, email delivered
- [x] Tested `verify-otp` on staging -- returns 201 with token in 0.08s
- [x] Verified full flow: send OTP -> retrieve from DB -> verify -> get JWT

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>