### PR TITLE
fix: Brevo sender email from diagrams.love to daterabbit.com

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -169,9 +169,9 @@ jobs:
           fi
           # Set sender email for Brevo
           if grep -q "^BREVO_SENDER_EMAIL=" "$ENV_FILE"; then
-            sed -i "s|^BREVO_SENDER_EMAIL=.*|BREVO_SENDER_EMAIL=noreply@diagrams.love|" "$ENV_FILE"
+            sed -i "s|^BREVO_SENDER_EMAIL=.*|BREVO_SENDER_EMAIL=noreply@daterabbit.com|" "$ENV_FILE"
           else
-            echo "BREVO_SENDER_EMAIL=noreply@diagrams.love" >> "$ENV_FILE"
+            echo "BREVO_SENDER_EMAIL=noreply@daterabbit.com" >> "$ENV_FILE"
           fi
           echo "Env vars updated from secrets"
 

--- a/backend/daterabbit-api/src/auth/auth.service.ts
+++ b/backend/daterabbit-api/src/auth/auth.service.ts
@@ -62,7 +62,14 @@ export class AuthService {
       return { success: true, isNewUser };
     }
 
-    await this.emailService.sendOtp(email, otp);
+    const emailSent = await this.emailService.sendOtp(email, otp);
+
+    if (!emailSent) {
+      throw new HttpException(
+        'Failed to send verification email. Please try again later.',
+        HttpStatus.SERVICE_UNAVAILABLE,
+      );
+    }
 
     return { success: true, isNewUser };
   }

--- a/backend/daterabbit-api/src/email/email.service.ts
+++ b/backend/daterabbit-api/src/email/email.service.ts
@@ -27,6 +27,9 @@ export class EmailService {
     }
 
     try {
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), 10000); // 10s timeout
+
       const response = await fetch('https://api.brevo.com/v3/smtp/email', {
         method: 'POST',
         headers: {
@@ -40,7 +43,10 @@ export class EmailService {
           subject: options.subject,
           htmlContent: options.htmlContent,
         }),
+        signal: controller.signal,
       });
+
+      clearTimeout(timeout);
 
       if (response.ok) {
         this.logger.log(`Email sent to ${options.to}: ${options.subject}`);
@@ -51,7 +57,11 @@ export class EmailService {
         return false;
       }
     } catch (error) {
-      this.logger.error(`Failed to send email to ${options.to}: ${error}`);
+      if (error instanceof Error && error.name === 'AbortError') {
+        this.logger.error(`Brevo API timeout after 10s for ${options.to}`);
+      } else {
+        this.logger.error(`Failed to send email to ${options.to}: ${error}`);
+      }
       return false;
     }
   }


### PR DESCRIPTION
## Summary
- CI workflow hardcoded `BREVO_SENDER_EMAIL=noreply@diagrams.love` -- changed to `noreply@daterabbit.com`
- Updated `BREVO_API_KEY` GitHub secret with working key (old one was disabled)

Fixes #907