### PR TITLE
fix: chat name, filter button, Book Date navigation

### DIFF
--- a/app/app/(tabs)/female/requests.tsx
+++ b/app/app/(tabs)/female/requests.tsx
@@ -195,7 +195,7 @@ function RequestCard({ request, type, colors, onAccept, onDecline, formatDate }:
         <View style={styles.actions}>
           <Button
             title="Message"
-            onPress={() => router.push(`/chat/${request.seeker.id}`)}
+            onPress={() => router.push(`/chat/${request.seeker.id}?name=${encodeURIComponent(request.seeker.name)}`)}
             variant="outline"
             size="sm"
             style={{ flex: 1 }}

--- a/app/app/(tabs)/male/browse.tsx
+++ b/app/app/(tabs)/male/browse.tsx
@@ -405,6 +405,7 @@ const styles = StyleSheet.create({
     shadowOpacity: 1,
     shadowRadius: 0,
     elevation: 3,
+    zIndex: 2,
   },
   filterBadge: {
     position: 'absolute',

--- a/app/app/(tabs)/male/messages.tsx
+++ b/app/app/(tabs)/male/messages.tsx
@@ -43,7 +43,7 @@ export default function MessagesScreen() {
   };
 
   const handleOpenChat = (chat: Chat) => {
-    router.push(`/chat/${chat.otherUser.id}`);
+    router.push(`/chat/${chat.otherUser.id}?name=${encodeURIComponent(chat.otherUser.name)}`);
   };
 
   if (isLoading && chats.length === 0) {

--- a/app/app/profile/[id].tsx
+++ b/app/app/profile/[id].tsx
@@ -202,7 +202,7 @@ export default function ProfileViewScreen() {
   };
 
   const handleMessage = () => {
-    router.push(`/chat/${profile.id}`);
+    router.push(`/chat/${profile.id}?name=${encodeURIComponent(profile.name)}`);
   };
 
   const nextPhoto = () => {
@@ -994,6 +994,7 @@ const styles = StyleSheet.create({
     padding: spacing.lg,
     borderTopWidth: 1,
     gap: spacing.md,
+    zIndex: 10,
   },
   messageButton: {
     flex: 1,


### PR DESCRIPTION
## Summary
- **Bug #924:** Chat header showed "this person" — now passes companion name as query param from all navigation points (messages list, profile page, requests page)
- **Bug #925:** Filter button unclickable on Browse — added `zIndex: 2` so search box shadow doesn't intercept pointer events
- **Bug #926:** Book Date button did nothing on profile — added `zIndex: 10` to bottomBar so buttons are above ScrollView

## Files changed
- `app/app/(tabs)/male/messages.tsx` — pass name in chat navigation
- `app/app/(tabs)/female/requests.tsx` — pass name in chat navigation
- `app/app/(tabs)/male/browse.tsx` — zIndex on filter button
- `app/app/profile/[id].tsx` — pass name in chat nav + zIndex on bottomBar

## Test plan
- [ ] Open Messages tab, tap a conversation — header should show companion name
- [ ] Open a profile, tap Message — chat header should show name
- [ ] On Browse page, tap filter icon — modal should open
- [ ] On profile page, tap Book Date — should navigate to booking screen

Generated with [Claude Code](https://claude.com/claude-code)