### PR TITLE
fix: app-wide scroll + photos breaking on filter toggle

### DIFF
--- a/app/app/+html.tsx
+++ b/app/app/+html.tsx
@@ -1,0 +1,43 @@
+import { ScrollViewStyleReset } from 'expo-router/html';
+
+// This file is web-only and used to configure the root HTML for every
+// temporary web page during development.
+export default function Root({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <head>
+        <meta charSet="utf-8" />
+        <meta httpEquiv="X-UA-Compatible" content="IE=edge" />
+        <meta
+          name="viewport"
+          content="width=device-width, initial-scale=1, shrink-to-fit=no, maximum-scale=1"
+        />
+        {/* Reset default browser scroll styles so ScrollView works properly */}
+        <ScrollViewStyleReset />
+        <style dangerouslySetInnerHTML={{ __html: webStyles }} />
+      </head>
+      <body>{children}</body>
+    </html>
+  );
+}
+
+const webStyles = `
+html, body, #root {
+  height: 100%;
+  overflow: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+body {
+  margin: 0;
+  padding: 0;
+  overscroll-behavior-y: none;
+}
+
+/* Ensure Expo Router screen containers allow scrolling */
+#root > div {
+  display: flex;
+  flex-direction: column;
+  min-height: 100%;
+}
+`;

--- a/app/app/_layout.tsx
+++ b/app/app/_layout.tsx
@@ -147,7 +147,8 @@ export default function RootLayout() {
               minWidth: 320,
               marginLeft: 'auto',
               marginRight: 'auto',
-            } : {}),
+              height: '100%',
+            } as any : {}),
           }
         }}
       >

--- a/app/src/components/UserImage.tsx
+++ b/app/src/components/UserImage.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { View, StyleSheet, ViewStyle } from 'react-native';
 import { Image } from 'expo-image';
 import { Icon } from './Icon';
@@ -25,6 +25,11 @@ export function UserImage({
 }: UserImageProps) {
   const { colors, spacing } = useTheme();
   const [hasError, setHasError] = useState(false);
+
+  // Reset error state when URI changes (e.g., after filter toggle re-fetch)
+  useEffect(() => {
+    setHasError(false);
+  }, [uri]);
 
   const actualBorderRadius = borderRadius ?? size / 2;
 


### PR DESCRIPTION
## Summary
- **Bug #923:** Fixed app-wide scrolling broken on web — added `+html.tsx` with proper `html/body/#root { height: 100%; overflow: auto }` and `height: '100%'` to Stack `contentStyle` on web
- **Bug #922:** Fixed photos disappearing permanently after filter toggle — `UserImage` component's `hasError` state now resets via `useEffect` when `uri` prop changes

## Test plan
- [ ] Open Browse screen on web, verify page scrolls to see all companion cards
- [ ] Open Home screen, verify scrolling works
- [ ] On Browse, toggle filter chips (All/Nearby/Top Rated/New) — photos should remain visible
- [ ] Reload page after toggling filters — photos should still show