### PR TITLE
fix: direct CTA navigation + auth redirect instead of 404

### DIFF
--- a/app/app/(auth)/welcome.tsx
+++ b/app/app/(auth)/welcome.tsx
@@ -82,7 +82,7 @@ export default function WelcomeScreen() {
           <Button
             title="Find Companions"
             label="Looking for a date?"
-            onPress={() => router.push({ pathname: '/(auth)/role-select', params: { role: 'seeker' } })}
+            onPress={() => router.push({ pathname: '/(auth)/register', params: { role: 'seeker' } })}
             variant="primary"
             fullWidth
             size="lg"
@@ -91,7 +91,7 @@ export default function WelcomeScreen() {
           <Button
             title="Become a Companion"
             label="Want to earn?"
-            onPress={() => router.push({ pathname: '/(auth)/role-select', params: { role: 'companion' } })}
+            onPress={() => router.push({ pathname: '/(auth)/register', params: { role: 'companion' } })}
             variant="secondary"
             fullWidth
             size="lg"

--- a/app/app/_layout.tsx
+++ b/app/app/_layout.tsx
@@ -14,7 +14,7 @@ import { colors } from '../src/constants/theme';
 import { StripeProvider } from '../src/components/StripeProvider';
 
 // Public routes accessible without authentication
-const PUBLIC_ROUTES = ['terms', 'privacy', 'onboarding', '(auth)', '+not-found'];
+const PUBLIC_ROUTES = ['terms', 'privacy', 'onboarding', '(auth)'];
 
 // Authenticated non-tab routes — accessible to all authenticated users (verified or not)
 const NON_TAB_AUTH_ROUTES = [
@@ -64,10 +64,10 @@ function NavigationGuard() {
     }
 
     if (!isAuthenticated) {
-      // Not logged in — redirect to auth
+      // Not logged in — redirect to auth with message
       const inAuthGroup = currentSegment === '(auth)';
       if (!inAuthGroup) {
-        router.replace('/(auth)/welcome');
+        router.replace({ pathname: '/(auth)/welcome', params: { redirect: '1' } });
       }
       return;
     }


### PR DESCRIPTION
## Summary
- **Bug 1:** Welcome CTAs ("Find Companions" / "Become a Companion") now navigate directly to `/register?role=seeker|companion`, skipping the intermediate role-select page
- **Bug 2:** Removed `+not-found` from PUBLIC_ROUTES so unauthenticated users hitting protected/unknown routes get redirected to welcome page with "Please sign in" banner instead of seeing 404

## Test plan
- [ ] Tap "Find Companions" on welcome → lands on register page with seeker role
- [ ] Tap "Become a Companion" on welcome → lands on register page with companion role
- [ ] Visit /browse while logged out → redirects to welcome with sign-in banner
- [ ] Visit /companion/123 while logged out → redirects to welcome with sign-in banner
- [ ] Visit /terms while logged out → still accessible (public route)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>