### PR TITLE
fix: home tab routing + remove search input browser outline

### DIFF
--- a/app/app/(tabs)/female/_layout.tsx
+++ b/app/app/(tabs)/female/_layout.tsx
@@ -1,0 +1,5 @@
+import { Slot } from 'expo-router';
+
+export default function FemaleLayout() {
+  return <Slot />;
+}

--- a/app/app/(tabs)/male/_layout.tsx
+++ b/app/app/(tabs)/male/_layout.tsx
@@ -1,0 +1,5 @@
+import { Slot } from 'expo-router';
+
+export default function MaleLayout() {
+  return <Slot />;
+}

--- a/app/app/(tabs)/male/browse.tsx
+++ b/app/app/(tabs)/male/browse.tsx
@@ -420,7 +420,8 @@ const styles = StyleSheet.create({
     flex: 1,
     fontSize: typography.sizes.md,
     padding: 0,
-  },
+    outlineStyle: 'none',
+  } as any,
   filtersScroll: {
     maxHeight: 56,
   },


### PR DESCRIPTION
## Summary
- **Bug 1:** Added `_layout.tsx` with `<Slot />` to `male/` and `female/` tab directories. Without these layout files, Expo Router cannot resolve nested tab routes, causing `/male` (home tab) to 404.
- **Bug 2:** Added `outlineStyle: 'none'` to the search `TextInput` in browse screen to remove the browser-default yellow/blue focus outline on web.

## Test plan
- [ ] Login as seeker, verify Home tab loads without 404
- [ ] Login as companion, verify Dashboard tab loads without 404
- [ ] On Browse screen, tap the search input and verify no browser-default outline appears

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>