### PR TITLE
fix: limit public API fields + New filter shows recent companions

### DIFF
--- a/app/src/services/api.ts
+++ b/app/src/services/api.ts
@@ -194,6 +194,7 @@ export interface CompanionListItem {
   isVerified: boolean;
   primaryPhoto?: string;
   distance?: number;
+  shortBio?: string;
 }
 
 export interface CompanionDetail extends CompanionListItem {

--- a/backend/daterabbit-api/src/companions/companions.controller.ts
+++ b/backend/daterabbit-api/src/companions/companions.controller.ts
@@ -59,7 +59,7 @@ export class CompanionsController {
         name: c.name,
         age: c.age,
         location: c.location,
-        bio: c.bio,
+        shortBio: c.bio ? c.bio.substring(0, 100) : null,
         primaryPhoto: c.photos?.[0]?.url || null,
         hourlyRate: c.hourlyRate != null ? Number(c.hourlyRate) : 0,
         rating: c.rating ? Number(c.rating) : 5.0,

--- a/backend/daterabbit-api/src/users/users.service.ts
+++ b/backend/daterabbit-api/src/users/users.service.ts
@@ -119,10 +119,14 @@ export class UsersService {
       case 'rating':
         query.orderBy('user.rating', 'DESC');
         break;
-      case 'new':
-        // Show newest companions first (recently joined)
+      case 'new': {
+        // Show companions who joined in the last 30 days, newest first
+        const thirtyDaysAgo = new Date();
+        thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
+        query.andWhere('user.createdAt >= :thirtyDaysAgo', { thirtyDaysAgo });
         query.orderBy('user.createdAt', 'DESC');
         break;
+      }
       default:
         query.orderBy('user.createdAt', 'DESC');
     }


### PR DESCRIPTION
## Summary
- **Bug 1:** `GET /api/companions` was returning full `bio` field publicly. Now returns `shortBio` (first 100 chars) instead. Sensitive fields (email, otpCode, stripeAccountId) were already excluded by the manual field mapping.
- **Bug 2:** "New" filter chip on Browse screen now correctly filters to companions who joined in the last 30 days (via `createdAt >= 30 days ago`), sorted newest first.
- Updated `CompanionListItem` frontend interface to include `shortBio` field.

## Test plan
- [ ] Verify `GET /api/companions` returns `shortBio` (max 100 chars) instead of full `bio`
- [ ] Verify `GET /api/companions?sortBy=new` only returns companions created in last 30 days
- [ ] Verify "New" filter chip on Browse screen shows recent companions
- [ ] Verify companion detail endpoint still returns full `bio`

Generated with [Claude Code](https://claude.com/claude-code)