### PR TITLE
fix: enable scroll on verification page to reach Get Started button

### DIFF
--- a/app/app/(seeker-verify)/intro.tsx
+++ b/app/app/(seeker-verify)/intro.tsx
@@ -121,6 +121,7 @@ const styles = StyleSheet.create({
   },
   scrollContent: {
     paddingHorizontal: PAGE_PADDING,
+    flexGrow: 1,
   },
   heroContainer: {
     alignItems: 'center',

--- a/app/app/_layout.tsx
+++ b/app/app/_layout.tsx
@@ -148,7 +148,7 @@ export default function RootLayout() {
               marginLeft: 'auto',
               marginRight: 'auto',
               height: '100%',
-              overflow: 'hidden',
+              overflow: 'auto',
             } as any : {}),
           }
         }}


### PR DESCRIPTION
## Summary
- Changed `overflow: 'hidden'` to `overflow: 'auto'` in `_layout.tsx` web contentStyle — this was clipping ScrollView content on all web pages
- Added `flexGrow: 1` to seeker-verify intro.tsx scrollContent so content fills available space

## Root Cause
The Stack contentStyle in `_layout.tsx` applied `overflow: 'hidden'` on web platform, which prevented the inner ScrollView from scrolling. The "Get Started" button at the bottom of the verification intro page was unreachable.

## Test plan
- [ ] Open verification intro page on web — scroll should work, "Get Started" button visible
- [ ] Verify other pages (browse, profile, settings) still scroll correctly
- [ ] Check mobile viewport (375px) scrolling works