### PR TITLE
fix: search input focus outline yellow to brand

### DIFF
--- a/app/app/(tabs)/male/browse.tsx
+++ b/app/app/(tabs)/male/browse.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useMemo, useEffect, useCallback } from 'react';
-import { View, Text, StyleSheet, ScrollView, TouchableOpacity, TextInput, RefreshControl, ActivityIndicator } from 'react-native';
+import { View, Text, StyleSheet, ScrollView, TouchableOpacity, TextInput, RefreshControl, ActivityIndicator, Platform } from 'react-native';
 import { router } from 'expo-router';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import * as Location from 'expo-location';
@@ -437,8 +437,12 @@ const styles = StyleSheet.create({
     flex: 1,
     fontSize: typography.sizes.md,
     padding: 0,
-    outlineStyle: 'none',
-  } as any,
+    ...Platform.select({
+      web: {
+        outlineStyle: 'none',
+      } as any,
+    }),
+  },
   filtersScroll: {
     maxHeight: 56,
   },


### PR DESCRIPTION
## Summary
- Remove browser default yellow focus ring on search TextInput in browse screen
- Added `Platform.select({ web: { outlineStyle: 'none' } })` to `searchInput` style
- Follows the same pattern already used in `src/components/Input.tsx`

## Bug
#929 — Search input focus outline yellow instead of brand color

## Test plan
- [ ] Open browse screen on Expo Web
- [ ] Click/focus on the search input
- [ ] Verify no yellow outline appears

Generated with [Claude Code](https://claude.com/claude-code)