### PR TITLE
fix: add /male/home route redirect to resolve 404

### DIFF
--- a/app/app/(tabs)/_layout.tsx
+++ b/app/app/(tabs)/_layout.tsx
@@ -86,6 +86,10 @@ export default function TabsLayout() {
         options={isCompanion ? { href: null } : undefined}
       />
       <Tabs.Screen
+        name="male/home"
+        options={{ href: null }}
+      />
+      <Tabs.Screen
         name="male/browse"
         options={isCompanion ? { href: null } : undefined}
       />

--- a/app/app/(tabs)/male/home.tsx
+++ b/app/app/(tabs)/male/home.tsx
@@ -1,0 +1,5 @@
+import { Redirect } from 'expo-router';
+
+export default function MaleHome() {
+  return <Redirect href="/(tabs)/male" />;
+}


### PR DESCRIPTION
## Summary
- Added `app/(tabs)/male/home.tsx` with a `<Redirect>` to `/male` index
- Registered `male/home` route in tabs `_layout.tsx` (hidden from tab bar with `href: null`)
- Fixes bug #930: `/male/home` returning 404

## Test plan
- [ ] Navigate to `/male/home` -- should redirect to male dashboard
- [ ] Verify other `/male/*` routes still work (browse, bookings, messages, profile)
- [ ] Verify tab bar still shows correct active state on Home tab