### PR TITLE
fix: wire Book Date button to booking navigation

### DIFF
--- a/app/src/components/Button.tsx
+++ b/app/src/components/Button.tsx
@@ -135,7 +135,7 @@ export function Button({
           onPress={handlePress}
           disabled={disabled || loading}
           activeOpacity={0.85}
-          style={[styles.gradientWrapper, fullWidth && styles.fullWidth]}
+          style={[styles.gradientWrapper, fullWidth && styles.fullWidth, style]}
         >
           <LinearGradient
             colors={gradientColors}
@@ -156,7 +156,7 @@ export function Button({
         onPressIn={handlePressIn}
         onPressOut={handlePressOut}
         disabled={disabled || loading}
-        style={[styles.gradientWrapper, fullWidth && styles.fullWidth, animatedStyle]}
+        style={[styles.gradientWrapper, fullWidth && styles.fullWidth, style, animatedStyle]}
       >
         <LinearGradient
           colors={gradientColors}


### PR DESCRIPTION
## Summary
- Fixed "Book Date" button not responding to clicks (bug #926)
- Root cause: Button component's gradient variants (primary/pink) did not forward the `style` prop to the outer touchable wrapper, only to the inner LinearGradient
- When parent passed `flex: 1` via style, only the gradient expanded — the TouchableOpacity/AnimatedPressable wrapper stayed at content size, creating a zero/mismatched touch target
- Fix: forward `style` prop to the outer wrapper on both web (TouchableOpacity) and native (AnimatedPressable)

## Test plan
- [ ] Verify "Book Date" button navigates to booking screen on browse page
- [ ] Verify "Book Date" button navigates to booking screen on favorites page
- [ ] Verify "Book Date" button navigates to booking screen on profile page
- [ ] Verify "View Profile" button still works (outline variant, was unaffected)
- [ ] Test on web and mobile