### PR TITLE
fix: remove overflow:hidden to restore scroll, Safety link, Book Date

### DIFF
--- a/app/app/+html.tsx
+++ b/app/app/+html.tsx
@@ -26,27 +26,27 @@ html, body {
   height: 100%;
   margin: 0;
   padding: 0;
+}
+
+body {
   overflow: hidden;
+  overscroll-behavior-y: none;
+  -webkit-overflow-scrolling: touch;
 }
 
 #root {
   display: flex;
   flex-direction: column;
   height: 100%;
-  overflow: hidden;
 }
 
-body {
-  overscroll-behavior-y: none;
-  -webkit-overflow-scrolling: touch;
-}
-
-/* Ensure Expo Router screen containers fill height for ScrollView */
+/* Expo Router wraps screens in nested divs. They must fill height
+   but must NOT set overflow:hidden — that clips RN ScrollView content.
+   Only body has overflow:hidden to prevent double scrollbars. */
 #root > div {
   display: flex;
   flex-direction: column;
   flex: 1;
   height: 100%;
-  overflow: hidden;
 }
 `;


### PR DESCRIPTION
## Summary
- Removed `overflow: hidden` from `#root` and `#root > div` in `+html.tsx` -- only `body` keeps it
- This was the single root cause for all 3 bugs: scroll broken, Safety link unreachable, Book Date button hidden

## Root Cause Analysis
The CSS in `+html.tsx` applied `overflow: hidden` to `html`, `#root`, AND `#root > div`. This triple-clipping prevented React Native Web's `<ScrollView>` from scrolling. All pages already used `<ScrollView>` correctly -- the CSS was the sole culprit.

**BUG 1 (scroll broken):** `overflow: hidden` on parent divs clips ScrollView content below the fold.
**BUG 2 (Safety link):** Code was correct (TouchableOpacity + window.alert) but footer was below fold and unreachable due to broken scroll.
**BUG 3 (Book Date):** Code was correct (router.push to existing /booking/[id] route) but bottom bar was clipped by overflow:hidden on parent.

## Test plan
- [ ] Verify welcome page scrolls to show footer (Terms, Privacy, Safety links)
- [ ] Click Safety link -- should show alert
- [ ] Navigate to profile page -- Book Date button should be visible and functional
- [ ] Browse page scrolls through companion cards
- [ ] Home page scrolls through all sections

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>