### PR TITLE
fix: restore app-wide scrolling (bug #923)

### DIFF
--- a/app/app/+html.tsx
+++ b/app/app/+html.tsx
@@ -29,7 +29,7 @@ html, body {
 }
 
 body {
-  overflow: hidden;
+  overflow: auto;
   overscroll-behavior-y: none;
   -webkit-overflow-scrolling: touch;
 }
@@ -42,7 +42,7 @@ body {
 
 /* Expo Router wraps screens in nested divs. They must fill height
    but must NOT set overflow:hidden — that clips RN ScrollView content.
-   Only body has overflow:hidden to prevent double scrollbars. */
+   Body uses overflow:auto to allow native ScrollView scrolling. */
 #root > div {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- Changed `overflow: hidden` to `overflow: auto` on `<body>` in `+html.tsx`
- `overflow:hidden` was clipping React Native ScrollView content, breaking scroll on all pages (profiles, home, verification)
- `overscroll-behavior-y: none` remains to prevent double scrollbars

## Test plan
- [ ] Open staging, navigate to profile page -- verify scrolling works
- [ ] Check home feed scrolling
- [ ] Check verification pages scrolling
- [ ] Confirm no double scrollbar artifacts on desktop browser

Fixes #923