### PR TITLE
fix: photos break after toggling filter chip on Browse (#922)

### DIFF
--- a/app/app/(tabs)/male/browse.tsx
+++ b/app/app/(tabs)/male/browse.tsx
@@ -75,8 +75,13 @@ export default function BrowseScreen() {
     })();
   }, []);
 
+  // Track fetch generation to prevent stale responses from overwriting fresh data
+  const fetchGeneration = React.useRef(0);
+
   // Fetch companions when location or filters change
   const fetchCompanions = useCallback(async () => {
+    const generation = ++fetchGeneration.current;
+
     try {
       const sortByMap: Record<string, 'recommended' | 'price_low' | 'price_high' | 'rating' | 'distance' | 'new'> = {
         'recommended': 'recommended',
@@ -111,10 +116,16 @@ export default function BrowseScreen() {
         search: searchQuery.trim() || undefined,
       });
 
-      setCompanions(response.companions);
+      // Only update state if this is still the latest fetch (prevents stale overwrites)
+      if (generation === fetchGeneration.current) {
+        setCompanions(response.companions);
+      }
     } catch (err) {
-      console.error('Failed to fetch companions:', err);
-      setCompanions([]);
+      // Only handle error if this is still the latest fetch
+      if (generation === fetchGeneration.current) {
+        console.error('Failed to fetch companions:', err);
+        // Keep existing companions on error instead of wiping the list
+      }
     }
   }, [appliedFilters, activeFilter, userLocation, searchQuery]);
 
@@ -240,7 +251,7 @@ export default function BrowseScreen() {
           />
         ) : (
           filteredCompanions.map((companion) => (
-            <Card key={companion.id} style={styles.companionCard}>
+            <Card key={`${companion.id}-${activeFilter}`} style={styles.companionCard}>
               <View style={styles.cardHeader}>
                 <UserImage
                   name={companion.name}

--- a/app/src/components/UserImage.tsx
+++ b/app/src/components/UserImage.tsx
@@ -25,10 +25,12 @@ export function UserImage({
 }: UserImageProps) {
   const { colors, spacing } = useTheme();
   const [hasError, setHasError] = useState(false);
+  const [retryCount, setRetryCount] = useState(0);
 
   // Reset error state when URI changes (e.g., after filter toggle re-fetch)
   useEffect(() => {
     setHasError(false);
+    setRetryCount(0);
   }, [uri]);
 
   const actualBorderRadius = borderRadius ?? size / 2;
@@ -98,12 +100,20 @@ export function UserImage({
         </View>
       ) : (
         <Image
+          key={`${uri}-${retryCount}`}
           source={{ uri }}
           style={styles.image}
           placeholder={blurhash}
           contentFit="cover"
           transition={250}
-          onError={() => setHasError(true)}
+          onError={() => {
+            if (retryCount < 2) {
+              // Retry loading -- image may have failed due to aborted request during filter toggle
+              setRetryCount((c) => c + 1);
+            } else {
+              setHasError(true);
+            }
+          }}
         />
       )}
       {showVerified && (


### PR DESCRIPTION
## Summary
- Fixed race condition: rapid filter toggling caused stale API responses to overwrite fresh data (added fetch generation counter)
- Removed destructive error handling that wiped companions list on any fetch error
- Fixed permanent image error state in UserImage: added retry mechanism and filter-aware card keys to force remount

## Test plan
- [ ] Open Browse screen, verify photos load
- [ ] Toggle filter chips rapidly (All -> Nearby -> Top Rated -> All) -- photos should persist
- [ ] Toggle filters with slow/flaky network -- photos should not disappear
- [ ] Pull to refresh after filter toggle -- photos should reload

Closes #922

Generated with [Claude Code](https://claude.com/claude-code)