### PR TITLE
fix: remove double verification gate from Book Date button (#926)

### DIFF
--- a/app/app/(tabs)/male/browse.tsx
+++ b/app/app/(tabs)/male/browse.tsx
@@ -12,7 +12,7 @@ import { FilterModal, FilterOptions } from '../../../src/components/FilterModal'
 import { useTheme, spacing, typography, borderRadius } from '../../../src/constants/theme';
 import { companionsApi, CompanionListItem } from '../../../src/services/api';
 import { showAlert } from '../../../src/utils/alert';
-import { useVerificationGate } from '../../../src/hooks/useVerificationGate';
+
 import { useAuthStore } from '../../../src/store/authStore';
 
 const quickFilters = ['All', 'Nearby', 'Top Rated', 'New'];
@@ -29,7 +29,6 @@ const defaultFilterOptions: FilterOptions = {
 export default function BrowseScreen() {
   const insets = useSafeAreaInsets();
   const { colors } = useTheme();
-  const { requireVerification } = useVerificationGate();
   const { isAuthenticated } = useAuthStore();
   const [activeFilter, setActiveFilter] = useState('All');
   const [searchQuery, setSearchQuery] = useState('');
@@ -308,7 +307,6 @@ export default function BrowseScreen() {
                       router.push('/(auth)/welcome');
                       return;
                     }
-                    if (requireVerification()) return;
                     router.push(`/booking/${companion.id}`);
                   }}
                   size="md"

--- a/app/app/_layout.tsx
+++ b/app/app/_layout.tsx
@@ -24,11 +24,11 @@ const NON_TAB_AUTH_ROUTES = [
   'favorites',
   'settings',
   'date',
+  'booking',
 ];
 
 // Routes that REQUIRE verification — unverified users get redirected to verification prompt
 const VERIFICATION_REQUIRED_ROUTES = [
-  'booking',
   'payment',
   'stripe',
 ];

--- a/app/app/profile/[id].tsx
+++ b/app/app/profile/[id].tsx
@@ -22,7 +22,6 @@ import { Icon } from '../../src/components/Icon';
 import { UserImage } from '../../src/components/UserImage';
 import { useTheme, spacing, typography, borderRadius, colors } from '../../src/constants/theme';
 import { useFavoritesStore } from '../../src/store/favoritesStore';
-import { useVerificationGate } from '../../src/hooks/useVerificationGate';
 import { useAuthStore } from '../../src/store/authStore';
 import { usersApi, companionsApi, CompanionDetail } from '../../src/services/api';
 
@@ -70,7 +69,6 @@ export default function ProfileViewScreen() {
   const insets = useSafeAreaInsets();
   const { colors } = useTheme();
   const { width: windowWidth } = useWindowDimensions();
-  const { requireVerification } = useVerificationGate();
   const { isAuthenticated } = useAuthStore();
   const photoWidth = Platform.OS === 'web' ? Math.min(windowWidth, MAX_PHOTO_WIDTH) : windowWidth;
 
@@ -204,7 +202,6 @@ export default function ProfileViewScreen() {
       router.push('/(auth)/welcome');
       return;
     }
-    if (requireVerification()) return;
     router.push(`/booking/${profile.id}`);
   };
 


### PR DESCRIPTION
## Summary
- Removed `requireVerification()` gate from Book Date button onPress in browse.tsx and profile/[id].tsx
- Moved `booking` from `VERIFICATION_REQUIRED_ROUTES` to `NON_TAB_AUTH_ROUTES` in _layout.tsx
- Verification still enforced in booking screen's handleSubmit before creating the booking

## Root Cause
Triple verification gate: button handler + NavigationGuard + booking handleSubmit all checked verification. On web, the button showed a `window.confirm` dialog that was easy to miss, making it seem like "nothing happens."

## Test plan
- [ ] Unverified user can tap Book Date and see the booking form
- [ ] Unverified user gets verification prompt when submitting the booking
- [ ] Verified user can complete full booking flow