### PR TITLE
fix: make filter button clickable on browse page (#925)

### DIFF
--- a/app/app/(tabs)/male/browse.tsx
+++ b/app/app/(tabs)/male/browse.tsx
@@ -403,12 +403,14 @@ const styles = StyleSheet.create({
     borderWidth: 2,
     borderColor: '#000000',
     gap: spacing.sm,
+    overflow: 'hidden',
     // Neo-Brutalism offset shadow
     shadowColor: '#000000',
     shadowOffset: { width: 3, height: 3 },
     shadowOpacity: 1,
     shadowRadius: 0,
     elevation: 3,
+    zIndex: 1,
   },
   filterButton: {
     width: 46,
@@ -424,7 +426,7 @@ const styles = StyleSheet.create({
     shadowOpacity: 1,
     shadowRadius: 0,
     elevation: 3,
-    zIndex: 2,
+    zIndex: 10,
   },
   filterBadge: {
     position: 'absolute',


### PR DESCRIPTION
## Summary
- Fix filter icon button unclickable on Browse page (bug #925)
- searchBox `elevation:3` gave implicit `zIndex:3` on RN Web, stacking above filterButton's `zIndex:2` and intercepting pointer events
- Set searchBox `zIndex:1`, bump filterButton `zIndex:10`, add `overflow:'hidden'` to searchBox

## Test plan
- [ ] Open Browse page on web
- [ ] Verify filter icon button is clickable
- [ ] Verify search box still works normally
- [ ] Verify filter modal opens on button press

Generated with [Claude Code](https://claude.com/claude-code)