### PR TITLE
fix: welcome page scroll + Book Date button clicks

### DIFF
--- a/app/app/(auth)/welcome.tsx
+++ b/app/app/(auth)/welcome.tsx
@@ -147,7 +147,9 @@ const styles = StyleSheet.create({
   content: {
     paddingHorizontal: PAGE_PADDING,
     flexGrow: 1,
-    justifyContent: 'center',
+    // justifyContent: 'center' breaks scrolling on web — when content
+    // exceeds viewport, the top gets clipped. Use paddingTop instead.
+    paddingTop: spacing.xl,
   },
 
   // Decorative blobs

--- a/app/src/components/Card.tsx
+++ b/app/src/components/Card.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View, StyleSheet, StyleProp, ViewStyle, Pressable } from 'react-native';
+import { View, StyleSheet, StyleProp, ViewStyle, Pressable, Platform } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 import { colors, borderRadius, spacing, shadows, borderWidth } from '../constants/theme';
 
@@ -89,7 +89,10 @@ const styles = StyleSheet.create({
     borderRadius: borderRadius.sm,
     borderWidth: borderWidth.normal,
     borderColor: colors.black,
-    overflow: 'hidden',
+    // overflow:'hidden' on web creates a stacking context that can block
+    // pointer events on nested TouchableOpacity/Pressable children (buttons).
+    // On native it's needed for borderRadius clipping of images.
+    ...(Platform.OS === 'web' ? {} : { overflow: 'hidden' as const }),
   },
   outlined: {
     borderWidth: borderWidth.normal,


### PR DESCRIPTION
## Summary
- **Welcome page scroll**: removed `justifyContent: 'center'` from ScrollView `contentContainerStyle` — on web, CSS `justify-content: center` with flexGrow causes top content to be clipped above the scroll area when content exceeds viewport. Replaced with `paddingTop` for visual spacing.
- **Book Date / View Profile buttons**: removed `overflow: 'hidden'` from Card component on web — it creates a stacking context that blocks pointer events on nested TouchableOpacity/Pressable children. Kept on native where it's needed for borderRadius clipping.

## Test plan
- [ ] Open welcome page on web, verify content scrolls when viewport is shorter than content
- [ ] Open browse page, click "View Profile" button on a companion card — should navigate to profile
- [ ] Open browse page, click "Book Date" button — should navigate to booking screen
- [ ] Verify Card border-radius still clips content properly on native (iOS/Android)

Generated with [Claude Code](https://claude.com/claude-code)