### PR TITLE
fix: New filter shows only genuinely new companions (#927)

### DIFF
--- a/backend/daterabbit-api/src/users/users.service.ts
+++ b/backend/daterabbit-api/src/users/users.service.ts
@@ -120,10 +120,11 @@ export class UsersService {
         query.orderBy('user.rating', 'DESC');
         break;
       case 'new': {
-        // Show companions who joined in the last 30 days, newest first
+        // "New" = recently joined AND few reviews (genuinely new to the platform)
         const thirtyDaysAgo = new Date();
         thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
         query.andWhere('user.createdAt >= :thirtyDaysAgo', { thirtyDaysAgo });
+        query.andWhere('user.reviewCount < :newReviewThreshold', { newReviewThreshold: 5 });
         query.orderBy('user.createdAt', 'DESC');
         break;
       }


### PR DESCRIPTION
## Summary
- Bug #927: "New" filter on Browse page showed same results as "All" — companions with 26+ reviews appeared under "New"
- Root cause: backend only checked `createdAt >= 30 days ago`, which matched all companions (all seeded/created recently)
- Fix: added `reviewCount < 5` threshold so established companions are excluded from "New" results

## Test plan
- [ ] Open Browse page, click "New" filter — should show only companions with < 5 reviews
- [ ] Click "All" filter — should show all companions including those with 26+ reviews
- [ ] Verify "New" results are sorted by newest first

Generated with [Claude Code](https://claude.com/claude-code)