### PR TITLE
fix: show 'New' instead of fake 5.0 rating when no reviews (bug #921)

### DIFF
--- a/app/app/(tabs)/female/index.tsx
+++ b/app/app/(tabs)/female/index.tsx
@@ -18,7 +18,7 @@ export default function FemaleDashboard() {
     pendingRequests: 3,
     upcomingDates: 2,
     thisWeekEarnings: 450,
-    rating: 4.9,
+    rating: (user?.reviewCount ?? 0) > 0 ? user?.rating ?? '-' : 'New',
   };
 
   return (

--- a/app/app/(tabs)/female/profile.tsx
+++ b/app/app/(tabs)/female/profile.tsx
@@ -37,9 +37,15 @@ export default function FemaleProfileScreen() {
             <Text style={[styles.profileName, { color: colors.text }]}>{user?.name}{user?.age ? `, ${user.age}` : ''}</Text>
             <Text style={[styles.profileLocation, { color: colors.textSecondary }]}>{user?.location}</Text>
             <View style={styles.ratingRow}>
-              <Icon name="star" size={14} color={colors.accent} />
-              <Text style={[styles.ratingValue, { color: colors.text }]}> {user?.rating}</Text>
-              <Text style={[styles.reviewCount, { color: colors.textSecondary }]}>({user?.reviewCount} reviews)</Text>
+              {(user?.reviewCount ?? 0) > 0 ? (
+                <>
+                  <Icon name="star" size={14} color={colors.accent} />
+                  <Text style={[styles.ratingValue, { color: colors.text }]}> {user?.rating}</Text>
+                  <Text style={[styles.reviewCount, { color: colors.textSecondary }]}>({user?.reviewCount} reviews)</Text>
+                </>
+              ) : (
+                <Text style={[styles.reviewCount, { color: colors.textSecondary }]}>No reviews yet</Text>
+              )}
             </View>
           </View>
         </View>

--- a/app/app/(tabs)/male/index.tsx
+++ b/app/app/(tabs)/male/index.tsx
@@ -341,10 +341,16 @@ function CompanionCardItem({ companion, colors }: { companion: CompanionListItem
           {companion.name}{companion.age ? `, ${companion.age}` : ''}
         </Text>
         <View style={styles.ratingRow}>
-          <Icon name="star" size={14} color={colors.warning} />
-          <Text style={[styles.companionRating, { color: colors.textSecondary }]}>
-            {Number(companion.rating).toFixed(1)}
-          </Text>
+          {companion.reviewCount > 0 ? (
+            <>
+              <Icon name="star" size={14} color={colors.warning} />
+              <Text style={[styles.companionRating, { color: colors.textSecondary }]}>
+                {Number(companion.rating).toFixed(1)}
+              </Text>
+            </>
+          ) : (
+            <Text style={[styles.newBadgeText, { color: colors.primary }]}>New</Text>
+          )}
         </View>
         <View style={[styles.rateTag, { backgroundColor: colors.secondary, borderColor: colors.border }]}>
           <Text style={[styles.companionRate, { color: colors.text }]}>${companion.hourlyRate}/hr</Text>
@@ -531,6 +537,10 @@ const styles = StyleSheet.create({
   companionRating: {
     fontFamily: typography.fonts.bodyMedium,
     fontSize: typography.sizes.sm,
+  },
+  newBadgeText: {
+    fontFamily: typography.fonts.bodySemiBold,
+    fontSize: typography.sizes.xs,
   },
   rateTag: {
     paddingHorizontal: spacing.md,

--- a/app/app/(tabs)/male/profile.tsx
+++ b/app/app/(tabs)/male/profile.tsx
@@ -64,9 +64,15 @@ export default function MaleProfileScreen() {
               </View>
             ) : null}
             <View style={styles.ratingRow}>
-              <Icon name="star" size={14} color={colors.accent} />
-              <Text style={[styles.ratingValue, { color: colors.text }]}> {user?.rating}</Text>
-              <Text style={[styles.reviewCount, { color: colors.textSecondary }]}>({user?.reviewCount} reviews)</Text>
+              {(user?.reviewCount ?? 0) > 0 ? (
+                <>
+                  <Icon name="star" size={14} color={colors.accent} />
+                  <Text style={[styles.ratingValue, { color: colors.text }]}> {user?.rating}</Text>
+                  <Text style={[styles.reviewCount, { color: colors.textSecondary }]}>({user?.reviewCount} reviews)</Text>
+                </>
+              ) : (
+                <Text style={[styles.reviewCount, { color: colors.textSecondary }]}>No reviews yet</Text>
+              )}
             </View>
           </View>
         </View>

--- a/app/app/favorites/index.tsx
+++ b/app/app/favorites/index.tsx
@@ -103,9 +103,17 @@ export default function FavoritesScreen() {
                       <Text style={[styles.cardLocation, { color: colors.textSecondary }]}> {companion.location || 'Location hidden'}</Text>
                     </View>
                     <View style={styles.ratingRow}>
-                      <Icon name="star" size={14} color={colors.accent} />
-                      <Text style={[styles.rating, { color: colors.text }]}> {companion.rating.toFixed(1)}</Text>
-                      <Text style={[styles.reviews, { color: colors.textSecondary }]}>({companion.reviewCount} reviews)</Text>
+                      {companion.reviewCount > 0 ? (
+                        <>
+                          <Icon name="star" size={14} color={colors.accent} />
+                          <Text style={[styles.rating, { color: colors.text }]}> {Number(companion.rating).toFixed(1)}</Text>
+                          <Text style={[styles.reviews, { color: colors.textSecondary }]}>({companion.reviewCount} reviews)</Text>
+                        </>
+                      ) : (
+                        <View style={[styles.newBadge, { backgroundColor: colors.primary + '15' }]}>
+                          <Text style={[styles.newBadgeText, { color: colors.primary }]}>New</Text>
+                        </View>
+                      )}
                     </View>
                   </View>
                   <TouchableOpacity
@@ -231,6 +239,15 @@ const styles = StyleSheet.create({
   reviews: {
     fontSize: typography.sizes.sm,
     marginLeft: spacing.xs,
+  },
+  newBadge: {
+    paddingHorizontal: spacing.sm,
+    paddingVertical: 2,
+    borderRadius: borderRadius.xs,
+  },
+  newBadgeText: {
+    fontFamily: typography.fonts.bodySemiBold,
+    fontSize: typography.sizes.xs,
   },
   heartButton: {
     padding: spacing.sm,

--- a/app/app/profile/[id].tsx
+++ b/app/app/profile/[id].tsx
@@ -51,7 +51,7 @@ const defaultProfile: ProfileData = {
   name: 'Profile',
   age: 25,
   location: 'New York',
-  rating: 4.5,
+  rating: 0,
   reviewCount: 0,
   hourlyRate: 100,
   bio: 'No bio available',

--- a/backend/daterabbit-api/src/companions/companions.controller.ts
+++ b/backend/daterabbit-api/src/companions/companions.controller.ts
@@ -62,7 +62,7 @@ export class CompanionsController {
         shortBio: c.bio ? c.bio.substring(0, 100) : null,
         primaryPhoto: c.photos?.[0]?.url || null,
         hourlyRate: c.hourlyRate != null ? Number(c.hourlyRate) : 0,
-        rating: c.rating ? Number(c.rating) : 5.0,
+        rating: c.rating ? Number(c.rating) : null,
         reviewCount: c.reviewCount || 0,
         isVerified: c.isVerified || false,
       })),
@@ -93,7 +93,7 @@ export class CompanionsController {
       bio: user.bio,
       photos: user.photos || [],
       hourlyRate: user.hourlyRate != null ? Number(user.hourlyRate) : 0,
-      rating: user.rating ? Number(user.rating) : 5.0,
+      rating: user.rating ? Number(user.rating) : null,
       reviewCount: user.reviewCount || 0,
       isVerified: user.isVerified || false,
     };

--- a/backend/daterabbit-api/src/reviews/reviews.service.ts
+++ b/backend/daterabbit-api/src/reviews/reviews.service.ts
@@ -100,7 +100,7 @@ export class ReviewsService {
       .getRawOne();
 
     await this.usersRepo.update(userId, {
-      rating: parseFloat(result.avg) || 5.0,
+      rating: parseFloat(result.avg) || 0,
       reviewCount: parseInt(result.count) || 0,
     });
   }

--- a/backend/daterabbit-api/src/users/entities/user.entity.ts
+++ b/backend/daterabbit-api/src/users/entities/user.entity.ts
@@ -49,7 +49,7 @@ export class User {
   @Column({ type: 'decimal', precision: 10, scale: 2, nullable: true })
   hourlyRate: number;
 
-  @Column({ type: 'decimal', precision: 2, scale: 1, default: 5.0 })
+  @Column({ type: 'decimal', precision: 2, scale: 1, default: 0, nullable: true })
   rating: number;
 
   @Column({ default: 0 })


### PR DESCRIPTION
## Summary
- Backend: removed default rating=5.0 from user entity, companions controller, and reviews service. New users get rating=null/0 instead of fake 5.0
- Frontend: all 6 pages now check `reviewCount > 0` before showing rating. Shows "New" badge or "No reviews yet" when no reviews exist
- Fixed hardcoded `rating: 4.9` in female dashboard to use actual user data

## Files changed (9)
- `backend/.../user.entity.ts` - DB default 5.0 → 0 (nullable)
- `backend/.../companions.controller.ts` - API fallback 5.0 → null (x2)
- `backend/.../reviews.service.ts` - recalc fallback 5.0 → 0
- `app/.../browse.tsx` - already correct (no change)
- `app/.../profile/[id].tsx` - default 4.5 → 0
- `app/.../favorites/index.tsx` - add reviewCount check + "New" badge
- `app/.../male/index.tsx` - add reviewCount check + "New" text
- `app/.../male/profile.tsx` - add reviewCount check + "No reviews yet"
- `app/.../female/profile.tsx` - add reviewCount check + "No reviews yet"
- `app/.../female/index.tsx` - use actual user rating instead of hardcoded 4.9

## Test plan
- [ ] Verify companions with 0 reviews show "New" badge on browse page
- [ ] Verify companions with 0 reviews show "New" on home featured cards
- [ ] Verify profile page shows "No reviews yet" for users with 0 reviews
- [ ] Verify favorites page shows "New" badge for companions with 0 reviews
- [ ] Verify companions WITH reviews still show correct rating and count
- [ ] Verify female dashboard shows actual rating from user data

Generated with [Claude Code](https://claude.com/claude-code)