### PR TITLE
fix: redirect unauthenticated users to login instead of 404

### DIFF
--- a/app/app/+not-found.tsx
+++ b/app/app/+not-found.tsx
@@ -1,10 +1,45 @@
-import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
-import { useRouter } from 'expo-router';
-import { useTheme, spacing, typography, borderRadius, borderWidth, shadows } from '../src/constants/theme';
+import { View, Text, StyleSheet, TouchableOpacity, ActivityIndicator } from 'react-native';
+import { useRouter, Redirect } from 'expo-router';
+import { useTheme, spacing, typography, borderRadius, borderWidth, shadows, colors as themeColors } from '../src/constants/theme';
+import { useAuthStore } from '../src/store/authStore';
+import { useEffect, useState } from 'react';
 
 export default function NotFoundScreen() {
   const router = useRouter();
   const { colors } = useTheme();
+  const { isAuthenticated, hasSeenOnboarding } = useAuthStore();
+  const [isHydrated, setIsHydrated] = useState(false);
+
+  useEffect(() => {
+    const unsubFinishHydration = useAuthStore.persist.onFinishHydration(() => {
+      setIsHydrated(true);
+    });
+
+    if (useAuthStore.persist.hasHydrated()) {
+      setIsHydrated(true);
+    }
+
+    return () => {
+      unsubFinishHydration();
+    };
+  }, []);
+
+  // Wait for auth store to hydrate before deciding
+  if (!isHydrated) {
+    return (
+      <View style={[styles.container, { backgroundColor: themeColors.background }]}>
+        <ActivityIndicator size="large" color={themeColors.primary} />
+      </View>
+    );
+  }
+
+  // Redirect unauthenticated users to login instead of showing 404
+  if (!isAuthenticated) {
+    if (!hasSeenOnboarding) {
+      return <Redirect href="/onboarding" />;
+    }
+    return <Redirect href="/(auth)/welcome?redirect=1" />;
+  }
 
   return (
     <View style={[styles.container, { backgroundColor: colors.background }]}>


### PR DESCRIPTION
## Summary
- Fixes bug #919: accessing unmatched routes (e.g. /browse, /home) when not logged in showed 404 instead of redirecting to login
- Modified `+not-found.tsx` to check auth state before rendering: unauthenticated users get redirected to `/(auth)/welcome`, users who haven't seen onboarding get redirected to `/onboarding`
- Authenticated users still see the normal 404 page for truly invalid routes

## Test plan
- [ ] Open `/browse` or `/home` in incognito — should redirect to login, not 404
- [ ] Open a truly invalid URL while logged in — should still show 404 page
- [ ] Verify normal auth flow still works (login, onboarding)

Generated with [Claude Code](https://claude.com/claude-code)