### PR TITLE
fix: show companion name in chat header instead of 'this person'

### DIFF
--- a/app/app/(tabs)/male/bookings.tsx
+++ b/app/app/(tabs)/male/bookings.tsx
@@ -228,7 +228,7 @@ function BookingCard({ booking, type, colors, onCancel, formatDate }: BookingCar
             title="Message"
             onPress={() => router.push({
               pathname: `/chat/${booking.companion?.id || booking.companion_id}`,
-              params: { name: booking.companion?.name }
+              params: { name: booking.companion?.name || companion.name }
             })}
             variant="outline"
             size="sm"

--- a/app/app/chat/[id].tsx
+++ b/app/app/chat/[id].tsx
@@ -27,21 +27,23 @@ export default function ChatScreen() {
   const [messageText, setMessageText] = useState('');
 
   const { user } = useAuthStore();
-  const { messages, sendMessage, getMessages, fetchMessages, chats } = useMessagesStore();
+  const { messages, sendMessage, getMessages, fetchMessages, fetchChats, chats } = useMessagesStore();
 
   // id param is the otherUser's id
   const otherUserId = id || '';
   const chatMessages = getMessages(otherUserId);
   const chat = chats.find(c => c.otherUser.id === otherUserId);
 
-  // Resolve companion name: prefer URL param, fall back to chat data, then a safe default
-  const companionName = name || chat?.otherUser?.name || 'this person';
+  // Resolve companion name: prefer URL param, fall back to chat data
+  const companionName = name || chat?.otherUser?.name || '';
 
   // Poll messages every 5 seconds while screen is focused
   useFocusEffect(
     useCallback(() => {
       // Initial fetch (with loading spinner)
       fetchMessages(otherUserId);
+      // Ensure chats are loaded so companion name resolves from store
+      if (!chat) fetchChats(true);
 
       // Poll every 5s silently (no loading spinner)
       const interval = setInterval(() => {


### PR DESCRIPTION
## Summary
- Chat header showed "this person" instead of companion name when navigating from bookings or when chat data wasn't loaded yet
- Added `fetchChats` call on mount when chat not in store, so companion name resolves from backend
- Changed fallback from "this person" to empty string to avoid misleading text
- Bookings navigation now passes `companion.name` as fallback

## Bug
#924

## Test plan
- [ ] Navigate to chat from bookings screen — header shows companion name
- [ ] Navigate to chat from messages list — header shows companion name
- [ ] Navigate to chat from profile — header shows companion name