### PR TITLE
fix: remove fake statistics from welcome screen mockup

### DIFF
--- a/.ai/style-mockups/welcome-screen.html
+++ b/.ai/style-mockups/welcome-screen.html
@@ -220,33 +220,6 @@
       font-weight: 500;
     }
 
-    /* Stats row */
-    .stats-row {
-      display: flex;
-      gap: 28px;
-      padding-top: 24px;
-      border-top: 1px solid #F0EBF0;
-    }
-
-    .stat {
-      display: flex;
-      flex-direction: column;
-      gap: 4px;
-    }
-
-    .stat-number {
-      font-family: 'Fraunces', serif;
-      font-size: 24px;
-      font-weight: 500;
-      color: #2D2A32;
-    }
-
-    .stat-label {
-      font-size: 11px;
-      color: #9B959F;
-      text-transform: uppercase;
-      letter-spacing: 0.5px;
-    }
 
     /* Two CTA buttons for different roles */
     .actions {
@@ -382,20 +355,6 @@
           </div>
         </div>
 
-        <div class="stats-row">
-          <div class="stat">
-            <span class="stat-number">2K+</span>
-            <span class="stat-label">Companions</span>
-          </div>
-          <div class="stat">
-            <span class="stat-number">15K+</span>
-            <span class="stat-label">Bookings</span>
-          </div>
-          <div class="stat">
-            <span class="stat-number">4.9</span>
-            <span class="stat-label">Rating</span>
-          </div>
-        </div>
       </div>
 
       <div class="actions">


### PR DESCRIPTION
## Summary
- Removed fake "2K+ Companions", "15K+ Bookings", "4.9 Rating" stats from `.ai/style-mockups/welcome-screen.html`
- The React welcome screen (`app/app/(auth)/welcome.tsx`) never had these fake numbers
- The mockup was the only place with misleading stats; removed CSS + HTML (41 lines deleted)

Fixes bug #913

## Test plan
- [x] Verified no other source files contain fake stats (grep confirmed)
- [x] React welcome screen is clean -- no stats section exists
- [ ] Visual check on staging after deploy

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>