### PR TITLE
fix: welcome page scroll on web (#909)

### DIFF
--- a/app/app/(auth)/welcome.tsx
+++ b/app/app/(auth)/welcome.tsx
@@ -146,9 +146,10 @@ const styles = StyleSheet.create({
   },
   content: {
     paddingHorizontal: PAGE_PADDING,
-    flexGrow: 1,
-    // justifyContent: 'center' breaks scrolling on web — when content
-    // exceeds viewport, the top gets clipped. Use paddingTop instead.
+    // flexGrow: 1 breaks scrolling on web — the container stretches to
+    // fill the viewport and ScrollView thinks content fits, so it won't
+    // scroll. Only use flexGrow on native where it works correctly.
+    ...(Platform.OS === 'web' ? {} : { flexGrow: 1 }),
     paddingTop: spacing.xl,
   },
 


### PR DESCRIPTION
## Summary
- Remove `flexGrow: 1` from ScrollView `contentContainerStyle` on web platform
- On web, `flexGrow: 1` stretches the content container to viewport height, which prevents ScrollView from scrolling when content overflows
- Native retains `flexGrow: 1` for proper centering behavior

## Test plan
- [ ] Open welcome page on web — verify FIND COMPANIONS and BECOME A COMPANION cards are fully visible
- [ ] Scroll down on small viewports — page should scroll to show all CTAs and footer
- [ ] Verify native (iOS/Android) layout unchanged

Fixes #909

Generated with [Claude Code](https://claude.com/claude-code)