### PR TITLE
fix: remove non-functional EN button from welcome page

### DIFF
--- a/app/app/(auth)/welcome.tsx
+++ b/app/app/(auth)/welcome.tsx
@@ -40,9 +40,6 @@ export default function WelcomeScreen() {
             </LinearGradient>
             <Text style={styles.logoText}>DateRabbit</Text>
           </View>
-          <View style={styles.langBtn}>
-            <Text style={styles.langBtnText}>EN</Text>
-          </View>
         </View>
 
         {showRedirectMessage && (
@@ -225,17 +222,6 @@ const styles = StyleSheet.create({
     fontFamily: typography.fonts.heading,
     fontSize: 18,
     color: colors.text,
-  },
-  langBtn: {
-    backgroundColor: colors.surface,
-    paddingVertical: spacing.sm,
-    paddingHorizontal: spacing.md,
-    borderRadius: borderRadius.full,
-  },
-  langBtnText: {
-    fontFamily: typography.fonts.bodyMedium,
-    fontSize: typography.sizes.xs,
-    color: colors.textMuted,
   },
 
   // Redirect banner


### PR DESCRIPTION
## Summary
- Removed the EN language selector button from the Welcome page header
- No i18n infrastructure exists, so the button did nothing when clicked (bug #912)
- Removed associated styles (langBtn, langBtnText)

## Test plan
- [ ] Open welcome page, verify EN button is gone
- [ ] Verify header still shows DateRabbit logo correctly

Generated with [Claude Code](https://claude.com/claude-code)