### PR TITLE
fix: OTP email error handling + allow retry (#906, #907)

### DIFF
--- a/backend/daterabbit-api/src/auth/auth.service.ts
+++ b/backend/daterabbit-api/src/auth/auth.service.ts
@@ -102,7 +102,7 @@ export class AuthService {
     const isValid = user.otpCode.length === code.length &&
       crypto.timingSafeEqual(Buffer.from(user.otpCode), Buffer.from(code));
     if (!isValid) {
-      // Track failed attempt
+      // Track failed attempt for rate limiting
       const current = this.otpAttempts.get(email) || { count: 0, lockedUntil: 0 };
       current.count++;
       if (current.count >= this.MAX_OTP_ATTEMPTS) {
@@ -111,8 +111,7 @@ export class AuthService {
       }
       this.otpAttempts.set(email, current);
 
-      // Invalidate OTP after failed attempt to prevent brute-force
-      await this.usersService.clearOtp(user.id);
+      // Don't clear OTP on failed attempt -- let users retry until 10-min TTL expires
       return { success: false, error: 'Invalid OTP' };
     }
 


### PR DESCRIPTION
## Summary
- **Bug #907:** `startAuth()` now checks `sendOtp()` return value and throws `HttpException(500)` if email send fails, instead of silently returning `{success: true}`
- **Bug #906:** Removed `clearOtp()` on failed verification attempt. OTP already has 10-min TTL, so users can retry until expiry instead of being locked out after one wrong code

## Test plan
- [ ] Verify OTP email send failure returns 500 error to frontend
- [ ] Verify wrong OTP code allows retry (not locked out after 1 attempt)
- [ ] Verify correct OTP still works and clears properly
- [ ] Verify OTP still expires after 10 minutes

Generated with [Claude Code](https://claude.com/claude-code)