### PR TITLE
fix: replace randomuser.me with i.pravatar.cc in seed data

### DIFF
--- a/backend/daterabbit-api/src/seed/seed.ts
+++ b/backend/daterabbit-api/src/seed/seed.ts
@@ -537,15 +537,15 @@ async function seed() {
     const userRepo = AppDataSource.getRepository(User);
     const companions: User[] = [];
 
-  // Real portrait photos from randomuser.me (women, indices 1-99)
-  // These are stable URLs that return real-looking face photos
-  const companionPhotoIndices = [5, 12, 19, 26, 33, 40, 47, 54, 61, 68, 75, 82, 89, 9, 16, 22, 29, 36, 43, 50];
+  // Portrait photos from i.pravatar.cc (reliable placeholder service)
+  // Format: https://i.pravatar.cc/400?img=N (N = 1-70)
+  const companionPhotoIndices = [1, 5, 9, 10, 16, 20, 21, 23, 25, 26, 28, 29, 31, 32, 36, 38, 39, 41, 43, 45];
 
     for (let ci = 0; ci < companionSeeds.length; ci++) {
       const c = companionSeeds[ci];
       const photoIdx = companionPhotoIndices[ci] || (ci + 1);
-      const primaryPhotoUrl = `https://randomuser.me/api/portraits/women/${photoIdx}.jpg`;
-      const secondaryPhotoUrl = `https://randomuser.me/api/portraits/women/${photoIdx === 1 ? 99 : photoIdx - 1}.jpg`;
+      const primaryPhotoUrl = `https://i.pravatar.cc/400?img=${photoIdx}`;
+      const secondaryPhotoUrl = `https://i.pravatar.cc/400?img=${photoIdx === 1 ? 70 : photoIdx - 1}`;
 
       const user = Object.assign(new User(), {
         email: c.email,
@@ -589,8 +589,8 @@ async function seed() {
 
     const seekers: User[] = [];
 
-  // Real portrait photos from randomuser.me for seekers (men)
-  const seekerPhotoIndices = [15, 28, 42, 57, 71];
+  // Portrait photos from i.pravatar.cc for seekers (men)
+  const seekerPhotoIndices = [3, 7, 11, 14, 33];
 
     for (let si = 0; si < seekerSeeds.length; si++) {
       const s = seekerSeeds[si];
@@ -605,7 +605,7 @@ async function seed() {
         photos: [
           {
             id: crypto.randomUUID(),
-            url: `https://randomuser.me/api/portraits/men/${seekerPhotoIdx}.jpg`,
+            url: `https://i.pravatar.cc/400?img=${seekerPhotoIdx}`,
             order: 0,
             isPrimary: true,
           },

--- a/scripts/fix-last-3.js
+++ b/scripts/fix-last-3.js
@@ -42,13 +42,13 @@ async function updateProfile(email, name, photoIndex) {
   const photos = [
     {
       id: generateUUID(),
-      url: 'https://randomuser.me/api/portraits/women/' + photoIndex + '.jpg',
+      url: 'https://i.pravatar.cc/400?img=' + photoIndex,
       order: 0,
       isPrimary: true,
     },
     {
       id: generateUUID(),
-      url: 'https://randomuser.me/api/portraits/women/' + (photoIndex - 1) + '.jpg',
+      url: 'https://i.pravatar.cc/400?img=' + (photoIndex - 1),
       order: 1,
       isPrimary: false,
     },
@@ -73,14 +73,14 @@ async function main() {
   const res = await apiRequest('GET', '/companions?limit=100');
   if (res.data && res.data.companions) {
     const withReal = res.data.companions.filter(
-      (c) => c.primaryPhoto && c.primaryPhoto.includes('randomuser.me'),
+      (c) => c.primaryPhoto && c.primaryPhoto.includes('i.pravatar.cc'),
     );
     const withDicebear = res.data.companions.filter(
       (c) => c.primaryPhoto && c.primaryPhoto.includes('dicebear'),
     );
     const noPhoto = res.data.companions.filter((c) => !c.primaryPhoto);
     console.log('\nFinal state (' + res.data.total + ' total companions):');
-    console.log('  With real photos (randomuser.me): ' + withReal.length);
+    console.log('  With real photos (i.pravatar.cc): ' + withReal.length);
     console.log('  With dicebear avatars:            ' + withDicebear.length);
     console.log('  No photo:                         ' + noPhoto.length);
   }

--- a/scripts/seed-test-profiles.js
+++ b/scripts/seed-test-profiles.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /**
  * Seed script: Create realistic companion profiles with attractive photos
- * Uses randomuser.me for portrait photos
+ * Uses i.pravatar.cc for portrait photos
  * Target: https://daterabbit-api.smartlaunchhub.com/api
  *
  * In DEV_AUTH mode, OTP is always 000000 for any email
@@ -10,7 +10,7 @@
 const API_BASE = 'https://daterabbit-api.smartlaunchhub.com/api';
 
 // Realistic companion profiles to seed
-// Photos from randomuser.me (portrait indices 1-99 for women)
+// Photos from i.pravatar.cc (portrait indices 1-70)
 const COMPANIONS = [
   {
     email: 'isabella.romano@seed.daterabbit.com',
@@ -259,7 +259,7 @@ function generateUUID() {
 }
 
 function buildPhotos(photoIndex) {
-  const url = `https://randomuser.me/api/portraits/women/${photoIndex}.jpg`;
+  const url = `https://i.pravatar.cc/400?img=${photoIndex}`;
   return [
     {
       id: generateUUID(),

--- a/scripts/update-seed-photos.js
+++ b/scripts/update-seed-photos.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * Update existing seed companion profiles to use real randomuser.me portrait photos
+ * Update existing seed companion profiles to use i.pravatar.cc portrait photos
  * Replaces dicebear SVG avatars with real face photos
  *
  * Run after rate limit resets (20 /start calls per hour limit)
@@ -9,7 +9,7 @@
 
 const API_BASE = 'https://daterabbit-api.smartlaunchhub.com/api';
 
-// Photo assignments: companion email -> photo index on randomuser.me/api/portraits/women/N.jpg
+// Photo assignments: companion email -> photo index on i.pravatar.cc/400?img=N
 const COMPANION_PHOTO_UPDATES = [
   { email: 'sophia.chen@seed.daterabbit.com',      name: 'Sophia Chen',      photoIndex: 5 },
   { email: 'isabella.romano@seed.daterabbit.com',  name: 'Isabella Romano',  photoIndex: 12 },
@@ -126,8 +126,8 @@ async function updateCompanionPhoto(companion) {
   }
 
   const token = authResult.token;
-  const primaryUrl = `https://randomuser.me/api/portraits/women/${companion.photoIndex}.jpg`;
-  const secondaryUrl = `https://randomuser.me/api/portraits/women/${companion.photoIndex === 1 ? 99 : companion.photoIndex - 1}.jpg`;
+  const primaryUrl = `https://i.pravatar.cc/400?img=${companion.photoIndex}`;
+  const secondaryUrl = `https://i.pravatar.cc/400?img=${companion.photoIndex === 1 ? 70 : companion.photoIndex - 1}`;
 
   const photos = [
     { id: generateUUID(), url: primaryUrl, order: 0, isPrimary: true },


### PR DESCRIPTION
## Summary
- Replaced all `randomuser.me` placeholder photo URLs with `https://i.pravatar.cc/400?img=N` across seed data and scripts
- Updated 4 files: `seed.ts`, `fix-last-3.js`, `update-seed-photos.js`, `seed-test-profiles.js`
- i.pravatar.cc is a reliable service designed for placeholder avatars

Fixes BUG-915

## Test plan
- [ ] Re-seed database and verify companion photos load from i.pravatar.cc
- [ ] Check companion cards display photos correctly on staging

Generated with [Claude Code](https://claude.com/claude-code)