### PR TITLE
fix: require JWT auth for companions endpoints (#916)

### DIFF
--- a/app/src/services/api.ts
+++ b/app/src/services/api.ts
@@ -219,7 +219,7 @@ export const companionsApi = {
         query.append(key, String(value));
       }
     });
-    return apiRequest<CompanionsResponse>(`/companions?${query}`, { auth: false });
+    return apiRequest<CompanionsResponse>(`/companions?${query}`);
   },
 
   getById: (id: string, latitude?: number, longitude?: number) => {
@@ -228,8 +228,7 @@ export const companionsApi = {
     if (longitude !== undefined) query.append('longitude', String(longitude));
     const queryStr = query.toString();
     return apiRequest<CompanionDetail>(
-      `/companions/${id}${queryStr ? `?${queryStr}` : ''}`,
-      { auth: false }
+      `/companions/${id}${queryStr ? `?${queryStr}` : ''}`
     );
   },
 };

--- a/backend/daterabbit-api/src/companions/companions.controller.ts
+++ b/backend/daterabbit-api/src/companions/companions.controller.ts
@@ -1,12 +1,12 @@
 import { Controller, Get, Query, Param, NotFoundException, UseGuards, Request } from '@nestjs/common';
 import { UsersService } from '../users/users.service';
-import { OptionalJwtAuthGuard } from '../auth/guards/optional-jwt-auth.guard';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 
+@UseGuards(JwtAuthGuard)
 @Controller('companions')
 export class CompanionsController {
   constructor(private usersService: UsersService) {}
 
-  @UseGuards(OptionalJwtAuthGuard)
   @Get()
   async searchCompanions(
     @Request() req,
@@ -31,11 +31,8 @@ export class CompanionsController {
         ? parseInt(offset)
         : 0;
 
-    // Exclude blocked users if the requester is authenticated
-    let excludeUserIds: string[] | undefined;
-    if (req.user?.id) {
-      excludeUserIds = await this.usersService.getBlockedUserIds(req.user.id);
-    }
+    // Exclude blocked users (req.user is guaranteed by JwtAuthGuard)
+    const excludeUserIds = await this.usersService.getBlockedUserIds(req.user.id);
 
     const { companions, total } = await this.usersService.getCompanions({
       priceMin: priceMin ? parseFloat(priceMin) : undefined,


### PR DESCRIPTION
## Summary
- Replace `OptionalJwtAuthGuard` with `JwtAuthGuard` on `CompanionsController` -- both `GET /api/companions` and `GET /api/companions/:id` now require authentication
- Update frontend `companionsApi.search()` and `companionsApi.getById()` to send auth token (removed `{ auth: false }`)
- Simplify blocked-users logic since `req.user` is now guaranteed

## Test plan
- [ ] Verify `GET /api/companions` returns 401 without token
- [ ] Verify `GET /api/companions/:id` returns 401 without token
- [ ] Verify both endpoints work normally with valid JWT
- [ ] Verify browse page loads companions when logged in

Generated with [Claude Code](https://claude.com/claude-code)