### PR TITLE
fix: verification intro scroll on web (#928)

### DIFF
--- a/app/app/(seeker-verify)/intro.tsx
+++ b/app/app/(seeker-verify)/intro.tsx
@@ -4,6 +4,7 @@ import {
   Text,
   StyleSheet,
   ScrollView,
+  Platform,
 } from 'react-native';
 import { router } from 'expo-router';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -115,11 +116,13 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     backgroundColor: colors.background,
+    ...(Platform.OS === 'web' ? { height: '100vh' as any } : {}),
   },
   scrollView: {
     flex: 1,
   },
   scrollContent: {
+    flexGrow: 1,
     paddingHorizontal: PAGE_PADDING,
   },
   heroContainer: {


### PR DESCRIPTION
## Summary
- Add `Platform` import and `height: '100vh'` on web to the container so ScrollView gets a proper height constraint
- Add `flexGrow: 1` to `scrollContent` so content fills available space
- Fixes bug #928: "Get Started" button was unreachable because the intro page didn't scroll on web

## Test plan
- [ ] Open verification intro page on web (393x659 viewport)
- [ ] Verify the "Get Started" button is visible after scrolling down
- [ ] Verify native behavior is unchanged (no height override on iOS/Android)

Generated with [Claude Code](https://claude.com/claude-code)