### PR TITLE
fix: strip HTML from user-editable fields (XSS #950)

### DIFF
--- a/backend/daterabbit-api/src/reviews/dto/create-review.dto.ts
+++ b/backend/daterabbit-api/src/reviews/dto/create-review.dto.ts
@@ -1,4 +1,8 @@
 import { IsInt, IsOptional, IsString, Max, MaxLength, Min } from 'class-validator';
+import { Transform } from 'class-transformer';
+
+const stripHtml = (value: string) =>
+  typeof value === 'string' ? value.replace(/<[^>]*>/g, '') : value;
 
 export class CreateReviewDto {
   @IsInt()
@@ -9,5 +13,6 @@ export class CreateReviewDto {
   @IsOptional()
   @IsString()
   @MaxLength(2000)
+  @Transform(({ value }) => stripHtml(value))
   comment?: string;
 }

--- a/backend/daterabbit-api/src/users/dto/update-user.dto.ts
+++ b/backend/daterabbit-api/src/users/dto/update-user.dto.ts
@@ -11,7 +11,10 @@ import {
   Min,
   ValidateNested,
 } from 'class-validator';
-import { Type } from 'class-transformer';
+import { Transform, Type } from 'class-transformer';
+
+const stripHtml = (value: string) =>
+  typeof value === 'string' ? value.replace(/<[^>]*>/g, '') : value;
 
 export class PhotoDto {
   @IsUUID()
@@ -32,6 +35,7 @@ export class UpdateUserDto {
   @IsOptional()
   @IsString()
   @MaxLength(100)
+  @Transform(({ value }) => stripHtml(value))
   name?: string;
 
   @IsOptional()
@@ -44,11 +48,13 @@ export class UpdateUserDto {
   @IsOptional()
   @IsString()
   @MaxLength(200)
+  @Transform(({ value }) => stripHtml(value))
   location?: string;
 
   @IsOptional()
   @IsString()
   @MaxLength(2000)
+  @Transform(({ value }) => stripHtml(value))
   bio?: string;
 
   @IsOptional()


### PR DESCRIPTION
## Summary
- Add `@Transform` with `stripHtml` to `name`, `bio`, `location` in `UpdateUserDto`
- Add `@Transform` with `stripHtml` to `comment` in `CreateReviewDto`
- Prevents stored XSS by stripping all HTML tags before validation

## Test plan
- [ ] PUT /api/users/me with `{"name":"<script>alert(1)</script>"}` should return name as `alert(1)`
- [ ] POST review with HTML in comment should have tags stripped

Generated with [Claude Code](https://claude.com/claude-code)