### PR TITLE
fix: constrain FilterModal width to 430px

### DIFF
--- a/app/src/components/FilterModal.tsx
+++ b/app/src/components/FilterModal.tsx
@@ -295,6 +295,9 @@ export function FilterModal({
 const styles = StyleSheet.create({
   container: {
     flex: 1,
+    maxWidth: 430,
+    width: '100%',
+    alignSelf: 'center',
     backgroundColor: colors.background,
   },
   header: {


### PR DESCRIPTION
## Summary
- FilterModal uses React Native Modal which renders as a portal outside the root layout hierarchy
- This bypasses the existing maxWidth: 430 constraint in _layout.tsx
- Added maxWidth: 430, width: '100%', alignSelf: 'center' to the modal container

## Test plan
- [ ] Open filter modal on desktop browser -- should not exceed 430px width
- [ ] Verify sliders, chips, radio buttons stay within bounds
- [ ] Test on mobile viewport -- no visual change expected

Generated with [Claude Code](https://claude.com/claude-code)