### PR TITLE
fix: add ParseUUIDPipe to all :id params (#951)

### DIFF
--- a/backend/daterabbit-api/src/admin/admin.controller.ts
+++ b/backend/daterabbit-api/src/admin/admin.controller.ts
@@ -11,6 +11,7 @@ import {
   UseGuards,
   Request,
   ParseIntPipe,
+  ParseUUIDPipe,
   DefaultValuePipe,
 } from '@nestjs/common';
 import { AdminGuard } from './admin.guard';
@@ -57,7 +58,7 @@ export class AdminController {
   }
 
   @Delete('reviews/:id')
-  deleteReview(@Param('id') id: string) {
+  deleteReview(@Param('id', ParseUUIDPipe) id: string) {
     return this.adminService.deleteReview(id);
   }
 
@@ -71,13 +72,13 @@ export class AdminController {
   }
 
   @Get('users/:id')
-  getUserById(@Param('id') id: string) {
+  getUserById(@Param('id', ParseUUIDPipe) id: string) {
     return this.adminService.getUserById(id);
   }
 
   @Patch('users/:id')
   updateUser(
-    @Param('id') id: string,
+    @Param('id', ParseUUIDPipe) id: string,
     @Body() body: { isActive?: boolean; isAdmin?: boolean },
   ) {
     return this.adminService.updateUser(id, body);
@@ -85,19 +86,19 @@ export class AdminController {
 
   // #697 - ban/unban
   @Post('users/:id/ban')
-  banUser(@Param('id') id: string) {
+  banUser(@Param('id', ParseUUIDPipe) id: string) {
     return this.adminService.banUser(id);
   }
 
   @Post('users/:id/unban')
-  unbanUser(@Param('id') id: string) {
+  unbanUser(@Param('id', ParseUUIDPipe) id: string) {
     return this.adminService.unbanUser(id);
   }
 
   // #698 - user bookings
   @Get('users/:userId/bookings')
   getUserBookings(
-    @Param('userId') userId: string,
+    @Param('userId', ParseUUIDPipe) userId: string,
     @Query('page', new DefaultValuePipe(1), ParseIntPipe) page: number,
     @Query('limit', new DefaultValuePipe(20), ParseIntPipe) limit: number,
   ) {
@@ -114,14 +115,14 @@ export class AdminController {
   }
 
   @Get('bookings/:id')
-  getBookingById(@Param('id') id: string) {
+  getBookingById(@Param('id', ParseUUIDPipe) id: string) {
     return this.adminService.getBookingById(id);
   }
 
   // #699 - cancel booking
   @Post('bookings/:id/cancel')
   cancelBooking(
-    @Param('id') id: string,
+    @Param('id', ParseUUIDPipe) id: string,
     @Body() body: { reason?: string },
   ) {
     return this.adminService.cancelBooking(id, body.reason);
@@ -137,13 +138,13 @@ export class AdminController {
   }
 
   @Put('verifications/:id/approve')
-  approveVerification(@Param('id') id: string) {
+  approveVerification(@Param('id', ParseUUIDPipe) id: string) {
     return this.adminService.approveVerification(id);
   }
 
   @Put('verifications/:id/reject')
   rejectVerification(
-    @Param('id') id: string,
+    @Param('id', ParseUUIDPipe) id: string,
     @Body() body: { reason?: string },
   ) {
     return this.adminService.rejectVerification(id, body.reason);

--- a/backend/daterabbit-api/src/bookings/bookings.controller.ts
+++ b/backend/daterabbit-api/src/bookings/bookings.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Post, Put, Body, Param, Query, UseGuards, Request, HttpException, HttpStatus } from '@nestjs/common';
+import { Controller, Get, Post, Put, Body, Param, Query, UseGuards, Request, HttpException, HttpStatus, ParseUUIDPipe } from '@nestjs/common';
 import { BookingsService } from './bookings.service';
 import { PaymentsService } from '../payments/payments.service';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
@@ -120,7 +120,7 @@ export class BookingsController {
    * Returns status, companion info, and elapsed time since request was sent.
    */
   @Get(':id/status')
-  async getBookingStatus(@Param('id') id: string, @Request() req) {
+  async getBookingStatus(@Param('id', ParseUUIDPipe) id: string, @Request() req) {
     const booking = await this.bookingsService.findById(id);
     if (!booking) {
       throw new HttpException('Booking not found', HttpStatus.NOT_FOUND);
@@ -148,7 +148,7 @@ export class BookingsController {
   }
 
   @Get(':id')
-  async getBooking(@Param('id') id: string, @Request() req) {
+  async getBooking(@Param('id', ParseUUIDPipe) id: string, @Request() req) {
     const booking = await this.bookingsService.findById(id);
     if (!booking) {
       throw new HttpException('Booking not found', HttpStatus.NOT_FOUND);
@@ -160,7 +160,7 @@ export class BookingsController {
   }
 
   @Put(':id/confirm')
-  async confirmBooking(@Param('id') id: string, @Request() req) {
+  async confirmBooking(@Param('id', ParseUUIDPipe) id: string, @Request() req) {
     const booking = await this.bookingsService.findById(id);
     if (!booking) {
       throw new HttpException('Booking not found', HttpStatus.NOT_FOUND);
@@ -179,7 +179,7 @@ export class BookingsController {
   }
 
   @Put(':id/cancel')
-  async cancelBooking(@Param('id') id: string, @Request() req, @Body() body: { reason?: string }) {
+  async cancelBooking(@Param('id', ParseUUIDPipe) id: string, @Request() req, @Body() body: { reason?: string }) {
     const booking = await this.bookingsService.findById(id);
     if (!booking) {
       throw new HttpException('Booking not found', HttpStatus.NOT_FOUND);
@@ -235,7 +235,7 @@ export class BookingsController {
   }
 
   @Put(':id/complete')
-  async completeBooking(@Param('id') id: string, @Request() req) {
+  async completeBooking(@Param('id', ParseUUIDPipe) id: string, @Request() req) {
     const updated = await this.bookingsService.complete(id, req.user.id);
     // Capture the Stripe hold (fire-and-forget)
     this.paymentsService.capturePayment(id).catch(err =>
@@ -245,25 +245,25 @@ export class BookingsController {
   }
 
   @Post(':id/checkin')
-  async seekerCheckin(@Param('id') id: string, @Request() req, @Body() body: { lat?: number; lon?: number }) {
+  async seekerCheckin(@Param('id', ParseUUIDPipe) id: string, @Request() req, @Body() body: { lat?: number; lon?: number }) {
     const booking = await this.bookingsService.seekerCheckin(id, req.user.id, body.lat, body.lon);
     return this.formatBooking(booking);
   }
 
   @Post(':id/companion-checkin')
-  async companionCheckin(@Param('id') id: string, @Request() req, @Body() body: { lat?: number; lon?: number }) {
+  async companionCheckin(@Param('id', ParseUUIDPipe) id: string, @Request() req, @Body() body: { lat?: number; lon?: number }) {
     const booking = await this.bookingsService.companionCheckin(id, req.user.id, body.lat, body.lon);
     return this.formatBooking(booking);
   }
 
   @Post(':id/sos')
-  async triggerSOS(@Param('id') id: string, @Request() req, @Body() body: { lat?: number; lon?: number }) {
+  async triggerSOS(@Param('id', ParseUUIDPipe) id: string, @Request() req, @Body() body: { lat?: number; lon?: number }) {
     const booking = await this.bookingsService.triggerSOS(id, req.user.id, body.lat, body.lon);
     return this.formatBooking(booking);
   }
 
   @Post(':id/end-early')
-  async endEarly(@Param('id') id: string, @Request() req) {
+  async endEarly(@Param('id', ParseUUIDPipe) id: string, @Request() req) {
     const booking = await this.bookingsService.endEarly(id, req.user.id);
     return this.formatBooking(booking);
   }
@@ -271,7 +271,7 @@ export class BookingsController {
   // --- Group 1: Safety check-in ---
 
   @Post(':id/safety-checkin')
-  async safetyCheckin(@Param('id') id: string, @Request() req) {
+  async safetyCheckin(@Param('id', ParseUUIDPipe) id: string, @Request() req) {
     const booking = await this.bookingsService.safetyCheckin(id, req.user.id);
     return this.formatBooking(booking);
   }
@@ -280,7 +280,7 @@ export class BookingsController {
 
   @Post(':id/photos')
   async uploadPhoto(
-    @Param('id') id: string,
+    @Param('id', ParseUUIDPipe) id: string,
     @Request() req,
     @Body() body: { url: string },
   ) {
@@ -291,20 +291,20 @@ export class BookingsController {
   }
 
   @Get(':id/photos')
-  async getPhotos(@Param('id') id: string, @Request() req) {
+  async getPhotos(@Param('id', ParseUUIDPipe) id: string, @Request() req) {
     return this.bookingsService.getPhotos(id, req.user.id);
   }
 
   // --- Group 1: Date plan ---
 
   @Get(':id/plan')
-  async getDatePlan(@Param('id') id: string, @Request() req) {
+  async getDatePlan(@Param('id', ParseUUIDPipe) id: string, @Request() req) {
     return this.bookingsService.getDatePlan(id, req.user.id);
   }
 
   @Put(':id/plan')
   async updateDatePlan(
-    @Param('id') id: string,
+    @Param('id', ParseUUIDPipe) id: string,
     @Request() req,
     @Body() body: { plan: Record<string, any> },
   ) {
@@ -319,7 +319,7 @@ export class BookingsController {
 
   @Post(':id/report-issue')
   async reportIssue(
-    @Param('id') id: string,
+    @Param('id', ParseUUIDPipe) id: string,
     @Request() req,
     @Body() body: { type: string; text: string },
   ) {
@@ -341,7 +341,7 @@ export class BookingsController {
 
   @Post(':id/extend-request')
   async extendRequest(
-    @Param('id') id: string,
+    @Param('id', ParseUUIDPipe) id: string,
     @Request() req,
     @Body() body: { hours: number },
   ) {
@@ -356,7 +356,7 @@ export class BookingsController {
 
   @Post(':id/verify-selfie')
   async submitSelfie(
-    @Param('id') id: string,
+    @Param('id', ParseUUIDPipe) id: string,
     @Request() req,
     @Body() body: { photoUrl: string },
   ) {
@@ -367,7 +367,7 @@ export class BookingsController {
   }
 
   @Get(':id/verify-selfie')
-  async getSelfieStatus(@Param('id') id: string, @Request() req) {
+  async getSelfieStatus(@Param('id', ParseUUIDPipe) id: string, @Request() req) {
     return this.bookingsService.getSelfieStatus(id, req.user.id);
   }
 
@@ -375,7 +375,7 @@ export class BookingsController {
 
   @Put(':id/extend-response')
   async extendResponse(
-    @Param('id') id: string,
+    @Param('id', ParseUUIDPipe) id: string,
     @Request() req,
     @Body() body: { approved: boolean },
   ) {

--- a/backend/daterabbit-api/src/calendar/calendar.controller.ts
+++ b/backend/daterabbit-api/src/calendar/calendar.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Post, Delete, Body, Param, UseGuards, Request } from '@nestjs/common';
+import { Controller, Get, Post, Delete, Body, Param, UseGuards, Request, ParseUUIDPipe } from '@nestjs/common';
 import { CalendarService } from './calendar.service';
 import { CreateBlockedDateDto } from './dto/create-blocked-date.dto';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
@@ -19,7 +19,7 @@ export class CalendarController {
   }
 
   @Delete('block/:id')
-  async removeBlock(@Param('id') id: string, @Request() req) {
+  async removeBlock(@Param('id', ParseUUIDPipe) id: string, @Request() req) {
     await this.calendarService.removeBlock(req.user.id, id);
     return { success: true };
   }

--- a/backend/daterabbit-api/src/companions/companions.controller.ts
+++ b/backend/daterabbit-api/src/companions/companions.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Query, Param, NotFoundException, UseGuards, Request } from '@nestjs/common';
+import { Controller, Get, Query, Param, NotFoundException, UseGuards, Request, ParseUUIDPipe } from '@nestjs/common';
 import { UsersService } from '../users/users.service';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 
@@ -70,13 +70,7 @@ export class CompanionsController {
   }
 
   @Get(':id')
-  async getCompanion(@Param('id') id: string) {
-    // Validate UUID format
-    const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-    if (!uuidRegex.test(id)) {
-      throw new NotFoundException('Companion not found');
-    }
-
+  async getCompanion(@Param('id', ParseUUIDPipe) id: string) {
     const user = await this.usersService.findById(id);
     if (!user || user.role !== 'companion') {
       throw new NotFoundException('Companion not found');

--- a/backend/daterabbit-api/src/messages/messages.controller.ts
+++ b/backend/daterabbit-api/src/messages/messages.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Post, Body, Param, Query, UseGuards, Request, HttpException, HttpStatus } from '@nestjs/common';
+import { Controller, Get, Post, Body, Param, Query, UseGuards, Request, HttpException, HttpStatus, ParseUUIDPipe } from '@nestjs/common';
 import { MessagesService } from './messages.service';
 import { UsersService } from '../users/users.service';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
@@ -56,7 +56,7 @@ export class MessagesController {
 
   @Get(':userId')
   async getMessages(
-    @Param('userId') otherUserId: string,
+    @Param('userId', ParseUUIDPipe) otherUserId: string,
     @Request() req,
     @Query('limit') limit?: string,
     @Query('offset') offset?: string,
@@ -86,7 +86,7 @@ export class MessagesController {
    */
   @Get(':userId/pre-chat')
   async getPreChatStatus(
-    @Param('userId') companionId: string,
+    @Param('userId', ParseUUIDPipe) companionId: string,
     @Request() req,
   ) {
     return this.messagesService.getPreChatStatus(req.user.id, companionId);
@@ -94,7 +94,7 @@ export class MessagesController {
 
   @Post(':userId')
   async sendMessage(
-    @Param('userId') receiverId: string,
+    @Param('userId', ParseUUIDPipe) receiverId: string,
     @Request() req,
     @Body() body: { content: string },
   ) {

--- a/backend/daterabbit-api/src/notifications/notifications.controller.ts
+++ b/backend/daterabbit-api/src/notifications/notifications.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Put, Param, Query, UseGuards, Request } from '@nestjs/common';
+import { Controller, Get, Put, Param, Query, UseGuards, Request, ParseUUIDPipe } from '@nestjs/common';
 import { NotificationsService } from './notifications.service';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 
@@ -37,7 +37,7 @@ export class NotificationsController {
   }
 
   @Put(':id/read')
-  async markAsRead(@Param('id') id: string, @Request() req) {
+  async markAsRead(@Param('id', ParseUUIDPipe) id: string, @Request() req) {
     await this.notificationsService.markAsRead(id, req.user.id);
     return { success: true };
   }

--- a/backend/daterabbit-api/src/payments/payments.controller.ts
+++ b/backend/daterabbit-api/src/payments/payments.controller.ts
@@ -11,6 +11,7 @@ import {
   Req,
   HttpException,
   HttpStatus,
+  ParseUUIDPipe,
 } from '@nestjs/common';
 import type { Request as ExpressRequest } from 'express';
 import { SkipThrottle } from '@nestjs/throttler';
@@ -41,7 +42,7 @@ export class PaymentsController {
   @UseGuards(JwtAuthGuard)
   async createPaymentIntent(
     @Request() req,
-    @Param('bookingId') bookingId: string,
+    @Param('bookingId', ParseUUIDPipe) bookingId: string,
   ) {
     return this.paymentsService.createPaymentIntent(req.user.id, bookingId);
   }


### PR DESCRIPTION
## Summary
- Added `ParseUUIDPipe` to all `:id` and `:userId` route params across 7 controllers (33 endpoints)
- Invalid UUIDs now return 400 Bad Request instead of 500 Internal Server Error
- Removed redundant manual UUID regex validation in companions controller

## Controllers modified
- `admin.controller.ts` (11 params)
- `bookings.controller.ts` (20 params)
- `calendar.controller.ts` (1 param)
- `companions.controller.ts` (1 param)
- `messages.controller.ts` (3 params)
- `notifications.controller.ts` (1 param)
- `payments.controller.ts` (1 param)

## Test plan
- [ ] `curl .../api/bookings/fake-id` returns 400, not 500
- [ ] `curl .../api/companions/fake-id` returns 400, not 500
- [ ] Valid UUID requests still work as before

Fixes #951