### PR TITLE
fix: add Browse Companions CTA to Messages empty state (#977)

### DIFF
--- a/app/app/(tabs)/male/messages.tsx
+++ b/app/app/(tabs)/male/messages.tsx
@@ -66,6 +66,8 @@ export default function MessagesScreen() {
             icon="message-circle"
             title="No messages yet"
             description="Start booking dates to begin conversations with companions"
+            actionLabel="Browse Companions"
+            onAction={() => router.push('/(tabs)/male/browse')}
           />
         ) : (
           chats.map((chat) => (


### PR DESCRIPTION
## Summary
- Messages empty state now shows a "Browse Companions" button, matching Bookings empty state behavior
- Uses existing `EmptyState` component props (`actionLabel` + `onAction`)
- Navigates to Browse tab on tap

## Test plan
- [ ] Open Messages tab with no conversations — verify "Browse Companions" button appears
- [ ] Tap button — verify navigation to Browse screen

Generated with [Claude Code](https://claude.com/claude-code)