### PR TITLE
fix: scroll not working on home and profile pages (web)

### DIFF
--- a/app/app/(tabs)/male/index.tsx
+++ b/app/app/(tabs)/male/index.tsx
@@ -379,6 +379,7 @@ function ActivityCard({ icon, label, colors }: { icon: string; label: string; co
 const styles = StyleSheet.create({
   container: {
     flex: 1,
+    ...(Platform.OS === 'web' ? { overflow: 'auto' as any } : {}),
   },
   content: {
     paddingHorizontal: PAGE_PADDING,

--- a/app/app/(tabs)/male/profile.tsx
+++ b/app/app/(tabs)/male/profile.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo } from 'react';
-import { View, Text, StyleSheet, ScrollView, TouchableOpacity } from 'react-native';
+import { View, Text, StyleSheet, ScrollView, TouchableOpacity, Platform } from 'react-native';
 import { router } from 'expo-router';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useAuthStore } from '../../../src/store/authStore';
@@ -177,6 +177,7 @@ function MenuItem({ icon, label, value, onPress, colors }: { icon: string; label
 const styles = StyleSheet.create({
   container: {
     flex: 1,
+    ...(Platform.OS === 'web' ? { overflow: 'auto' as any } : {}),
   },
   content: {
     padding: spacing.lg,


### PR DESCRIPTION
## Summary
- Added `overflow: 'auto'` (web-only) to ScrollView container style on male home (`index.tsx`) and profile (`profile.tsx`) screens
- Root cause: Expo Router Stack/Tabs layout with `height: 100%` creates a fixed container, and RN ScrollView with `flex: 1` doesn't enable native scrolling on web without explicit overflow

## Fixes
- Bug #971: Home page does not scroll
- Bug #972: Profile page does not scroll

## Test plan
- [ ] Open `/male` on mobile viewport (393x659) — verify Featured Companions and Browse by Activity are scrollable
- [ ] Open `/male/profile` on mobile viewport — verify all sections (Account, Preferences, Support, Sign Out) are reachable via scroll
- [ ] Verify pull-to-refresh still works on home page