### PR TITLE
fix: replace placeholder avatars with Unsplash photos for companions

### DIFF
--- a/backend/daterabbit-api/src/seed/seed.ts
+++ b/backend/daterabbit-api/src/seed/seed.ts
@@ -537,15 +537,116 @@ async function seed() {
     const userRepo = AppDataSource.getRepository(User);
     const companions: User[] = [];
 
-  // Portrait photos from i.pravatar.cc (reliable placeholder service)
-  // Format: https://i.pravatar.cc/400?img=N (N = 1-70)
-  const companionPhotoIndices = [1, 5, 9, 10, 16, 20, 21, 23, 25, 26, 28, 29, 31, 32, 36, 38, 39, 41, 43, 45];
+  // Real portrait photos from Unsplash (free, reliable CDN)
+  // Each companion gets 2 unique photos — primary + secondary
+  const companionPhotos: { primary: string; secondary: string }[] = [
+    // 0 - Sophia Chen (26, Manhattan)
+    {
+      primary: 'https://images.unsplash.com/photo-1529626455594-4ff0802cfb7e?w=400&h=400&fit=crop&crop=face',
+      secondary: 'https://images.unsplash.com/photo-1524504388940-b1c1722653e1?w=400&h=400&fit=crop&crop=face',
+    },
+    // 1 - Isabella Romano (29, Brooklyn)
+    {
+      primary: 'https://images.unsplash.com/photo-1494790108377-be9c29b29330?w=400&h=400&fit=crop&crop=face',
+      secondary: 'https://images.unsplash.com/photo-1534528741775-53994a69daeb?w=400&h=400&fit=crop&crop=face',
+    },
+    // 2 - Mia Thompson (24, West Village)
+    {
+      primary: 'https://images.unsplash.com/photo-1517841905240-472988babdf9?w=400&h=400&fit=crop&crop=face',
+      secondary: 'https://images.unsplash.com/photo-1488426862026-3ee34a7d66df?w=400&h=400&fit=crop&crop=face',
+    },
+    // 3 - Ava Williams (31, Upper East Side)
+    {
+      primary: 'https://images.unsplash.com/photo-1531746020798-e6953c6e8e04?w=400&h=400&fit=crop&crop=face',
+      secondary: 'https://images.unsplash.com/photo-1487412720507-e7ab37603c6f?w=400&h=400&fit=crop&crop=face',
+    },
+    // 4 - Emma Davis (27, SoHo)
+    {
+      primary: 'https://images.unsplash.com/photo-1544005313-94ddf0286df2?w=400&h=400&fit=crop&crop=face',
+      secondary: 'https://images.unsplash.com/photo-1502823403499-6ccfcf4fb453?w=400&h=400&fit=crop&crop=face',
+    },
+    // 5 - Olivia Martinez (25, Santa Monica)
+    {
+      primary: 'https://images.unsplash.com/photo-1524638431109-93d95c968f03?w=400&h=400&fit=crop&crop=face',
+      secondary: 'https://images.unsplash.com/photo-1509967419530-da38b4704bc6?w=400&h=400&fit=crop&crop=face',
+    },
+    // 6 - Charlotte Lee (30, Silver Lake)
+    {
+      primary: 'https://images.unsplash.com/photo-1438761681033-6461ffad8d80?w=400&h=400&fit=crop&crop=face',
+      secondary: 'https://images.unsplash.com/photo-1500917293891-ef795e70e1f6?w=400&h=400&fit=crop&crop=face',
+    },
+    // 7 - Luna Vasquez (23, Venice Beach)
+    {
+      primary: 'https://images.unsplash.com/photo-1464863979621-258859e62245?w=400&h=400&fit=crop&crop=face',
+      secondary: 'https://images.unsplash.com/photo-1506956191951-7a88da4435e5?w=400&h=400&fit=crop&crop=face',
+    },
+    // 8 - Zoe Anderson (28, Los Feliz)
+    {
+      primary: 'https://images.unsplash.com/photo-1496440737103-cd596325d314?w=400&h=400&fit=crop&crop=face',
+      secondary: 'https://images.unsplash.com/photo-1469334031218-e382a71b716b?w=400&h=400&fit=crop&crop=face',
+    },
+    // 9 - Natalie Kim (33, Beverly Hills)
+    {
+      primary: 'https://images.unsplash.com/photo-1515023115894-bacee3643854?w=400&h=400&fit=crop&crop=face',
+      secondary: 'https://images.unsplash.com/photo-1492106087820-71f1a00d2b11?w=400&h=400&fit=crop&crop=face',
+    },
+    // 10 - Chloe Johnson (26, South Beach)
+    {
+      primary: 'https://images.unsplash.com/photo-1519699047748-de8e457a634e?w=400&h=400&fit=crop&crop=face',
+      secondary: 'https://images.unsplash.com/photo-1502767089025-6572583495f9?w=400&h=400&fit=crop&crop=face',
+    },
+    // 11 - Aria Patel (29, Wynwood)
+    {
+      primary: 'https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?w=400&h=400&fit=crop&crop=face',
+      secondary: 'https://images.unsplash.com/photo-1526510747491-58f928ec870f?w=400&h=400&fit=crop&crop=face',
+    },
+    // 12 - Grace Wilson (35, Brickell)
+    {
+      primary: 'https://images.unsplash.com/photo-1573496359142-b8d87734a5a2?w=400&h=400&fit=crop&crop=face',
+      secondary: 'https://images.unsplash.com/photo-1580489944761-15a19d654956?w=400&h=400&fit=crop&crop=face',
+    },
+    // 13 - Lily Taylor (22, Miami Beach)
+    {
+      primary: 'https://images.unsplash.com/photo-1539571696357-5a69c17a67c6?w=400&h=400&fit=crop&crop=face',
+      secondary: 'https://images.unsplash.com/photo-1521146764736-56c929d59c83?w=400&h=400&fit=crop&crop=face',
+    },
+    // 14 - Harper Brown (32, Midtown)
+    {
+      primary: 'https://images.unsplash.com/photo-1548142813-c348350df52b?w=400&h=400&fit=crop&crop=face',
+      secondary: 'https://images.unsplash.com/photo-1499557354967-2b2d8910bcca?w=400&h=400&fit=crop&crop=face',
+    },
+    // 15 - Scarlett Nguyen (27, Chelsea)
+    {
+      primary: 'https://images.unsplash.com/photo-1516726817505-f5ed825624d8?w=400&h=400&fit=crop&crop=face',
+      secondary: 'https://images.unsplash.com/photo-1485893086445-ed75865251e0?w=400&h=400&fit=crop&crop=face',
+    },
+    // 16 - Maya Robinson (24, Astoria)
+    {
+      primary: 'https://images.unsplash.com/photo-1531123897727-8f129e1688ce?w=400&h=400&fit=crop&crop=face',
+      secondary: 'https://images.unsplash.com/photo-1523824921871-d6f1a15151f1?w=400&h=400&fit=crop&crop=face',
+    },
+    // 17 - Stella Garcia (31, Coral Gables)
+    {
+      primary: 'https://images.unsplash.com/photo-1508214751196-bcfd4ca60f91?w=400&h=400&fit=crop&crop=face',
+      secondary: 'https://images.unsplash.com/photo-1485875437071-bb71a38113e9?w=400&h=400&fit=crop&crop=face',
+    },
+    // 18 - Penelope Clarke (34, Malibu)
+    {
+      primary: 'https://images.unsplash.com/photo-1514315384763-ba401779410f?w=400&h=400&fit=crop&crop=face',
+      secondary: 'https://images.unsplash.com/photo-1504703395950-b89145a5425b?w=400&h=400&fit=crop&crop=face',
+    },
+    // 19 - Victoria Scott (28, Downtown LA)
+    {
+      primary: 'https://images.unsplash.com/photo-1534751516642-a1af1ef26a56?w=400&h=400&fit=crop&crop=face',
+      secondary: 'https://images.unsplash.com/photo-1489424731084-a5d8b219a5bb?w=400&h=400&fit=crop&crop=face',
+    },
+  ];
 
     for (let ci = 0; ci < companionSeeds.length; ci++) {
       const c = companionSeeds[ci];
-      const photoIdx = companionPhotoIndices[ci] || (ci + 1);
-      const primaryPhotoUrl = `https://i.pravatar.cc/400?img=${photoIdx}`;
-      const secondaryPhotoUrl = `https://i.pravatar.cc/400?img=${photoIdx === 1 ? 70 : photoIdx - 1}`;
+      const photos = companionPhotos[ci];
+      const primaryPhotoUrl = photos.primary;
+      const secondaryPhotoUrl = photos.secondary;
 
       const user = Object.assign(new User(), {
         email: c.email,
@@ -589,12 +690,17 @@ async function seed() {
 
     const seekers: User[] = [];
 
-  // Portrait photos from i.pravatar.cc for seekers (men)
-  const seekerPhotoIndices = [3, 7, 11, 14, 33];
+  // Real portrait photos from Unsplash for seekers (men)
+  const seekerPhotos = [
+    'https://images.unsplash.com/photo-1500648767791-00dcc994a43e?w=400&h=400&fit=crop&crop=face', // James Mitchell
+    'https://images.unsplash.com/photo-1506794778202-cad84cf45f1d?w=400&h=400&fit=crop&crop=face', // David Park
+    'https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?w=400&h=400&fit=crop&crop=face', // Michael Torres
+    'https://images.unsplash.com/photo-1519085360753-af0119f7cbe7?w=400&h=400&fit=crop&crop=face', // Ryan O'Brien
+    'https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?w=400&h=400&fit=crop&crop=face', // Daniel Hoffman
+  ];
 
     for (let si = 0; si < seekerSeeds.length; si++) {
       const s = seekerSeeds[si];
-      const seekerPhotoIdx = seekerPhotoIndices[si] || (si + 10);
 
       const user = Object.assign(new User(), {
         email: s.email,
@@ -605,7 +711,7 @@ async function seed() {
         photos: [
           {
             id: crypto.randomUUID(),
-            url: `https://i.pravatar.cc/400?img=${seekerPhotoIdx}`,
+            url: seekerPhotos[si],
             order: 0,
             isPrimary: true,
           },

--- a/scripts/update-seed-photos.js
+++ b/scripts/update-seed-photos.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /**
- * Update existing seed companion profiles to use i.pravatar.cc portrait photos
- * Replaces dicebear SVG avatars with real face photos
+ * Update existing seed companion profiles to use Unsplash portrait photos
+ * Replaces placeholder avatars with real face photos
  *
  * Run after rate limit resets (20 /start calls per hour limit)
  * Uses batching: 9 users per batch with 11-minute waits between batches
@@ -9,40 +9,40 @@
 
 const API_BASE = 'https://daterabbit-api.smartlaunchhub.com/api';
 
-// Photo assignments: companion email -> photo index on i.pravatar.cc/400?img=N
+// Photo assignments: companion email -> Unsplash portrait URLs
 const COMPANION_PHOTO_UPDATES = [
-  { email: 'sophia.chen@seed.daterabbit.com',      name: 'Sophia Chen',      photoIndex: 5 },
-  { email: 'isabella.romano@seed.daterabbit.com',  name: 'Isabella Romano',  photoIndex: 12 },
-  { email: 'mia.thompson@seed.daterabbit.com',     name: 'Mia Thompson',     photoIndex: 19 },
-  { email: 'ava.williams@seed.daterabbit.com',     name: 'Ava Williams',     photoIndex: 26 },
-  { email: 'emma.davis@seed.daterabbit.com',       name: 'Emma Davis',       photoIndex: 33 },
-  { email: 'olivia.martinez@seed.daterabbit.com',  name: 'Olivia Martinez',  photoIndex: 40 },
-  { email: 'charlotte.lee@seed.daterabbit.com',    name: 'Charlotte Lee',    photoIndex: 47 },
-  { email: 'luna.vasquez@seed.daterabbit.com',     name: 'Luna Vasquez',     photoIndex: 54 },
-  { email: 'zoe.anderson@seed.daterabbit.com',     name: 'Zoe Anderson',     photoIndex: 61 },
-  { email: 'natalie.kim@seed.daterabbit.com',      name: 'Natalie Kim',      photoIndex: 68 },
-  { email: 'chloe.johnson@seed.daterabbit.com',    name: 'Chloe Johnson',    photoIndex: 75 },
-  { email: 'aria.patel@seed.daterabbit.com',       name: 'Aria Patel',       photoIndex: 82 },
-  { email: 'grace.wilson@seed.daterabbit.com',     name: 'Grace Wilson',     photoIndex: 89 },
-  { email: 'lily.taylor@seed.daterabbit.com',      name: 'Lily Taylor',      photoIndex: 9 },
-  { email: 'harper.brown@seed.daterabbit.com',     name: 'Harper Brown',     photoIndex: 16 },
-  { email: 'scarlett.nguyen@seed.daterabbit.com',  name: 'Scarlett Nguyen',  photoIndex: 22 },
-  { email: 'maya.robinson@seed.daterabbit.com',    name: 'Maya Robinson',    photoIndex: 29 },
-  { email: 'stella.garcia@seed.daterabbit.com',    name: 'Stella Garcia',    photoIndex: 36 },
-  { email: 'penelope.clarke@seed.daterabbit.com',  name: 'Penelope Clarke',  photoIndex: 43 },
-  { email: 'victoria.scott@seed.daterabbit.com',   name: 'Victoria Scott',   photoIndex: 50 },
+  { email: 'sophia.chen@seed.daterabbit.com',      name: 'Sophia Chen',      photoUrl: 'https://images.unsplash.com/photo-1529626455594-4ff0802cfb7e?w=400&h=400&fit=crop&crop=face' },
+  { email: 'isabella.romano@seed.daterabbit.com',  name: 'Isabella Romano',  photoUrl: 'https://images.unsplash.com/photo-1494790108377-be9c29b29330?w=400&h=400&fit=crop&crop=face' },
+  { email: 'mia.thompson@seed.daterabbit.com',     name: 'Mia Thompson',     photoUrl: 'https://images.unsplash.com/photo-1517841905240-472988babdf9?w=400&h=400&fit=crop&crop=face' },
+  { email: 'ava.williams@seed.daterabbit.com',     name: 'Ava Williams',     photoUrl: 'https://images.unsplash.com/photo-1531746020798-e6953c6e8e04?w=400&h=400&fit=crop&crop=face' },
+  { email: 'emma.davis@seed.daterabbit.com',       name: 'Emma Davis',       photoUrl: 'https://images.unsplash.com/photo-1544005313-94ddf0286df2?w=400&h=400&fit=crop&crop=face' },
+  { email: 'olivia.martinez@seed.daterabbit.com',  name: 'Olivia Martinez',  photoUrl: 'https://images.unsplash.com/photo-1524638431109-93d95c968f03?w=400&h=400&fit=crop&crop=face' },
+  { email: 'charlotte.lee@seed.daterabbit.com',    name: 'Charlotte Lee',    photoUrl: 'https://images.unsplash.com/photo-1438761681033-6461ffad8d80?w=400&h=400&fit=crop&crop=face' },
+  { email: 'luna.vasquez@seed.daterabbit.com',     name: 'Luna Vasquez',     photoUrl: 'https://images.unsplash.com/photo-1464863979621-258859e62245?w=400&h=400&fit=crop&crop=face' },
+  { email: 'zoe.anderson@seed.daterabbit.com',     name: 'Zoe Anderson',     photoUrl: 'https://images.unsplash.com/photo-1496440737103-cd596325d314?w=400&h=400&fit=crop&crop=face' },
+  { email: 'natalie.kim@seed.daterabbit.com',      name: 'Natalie Kim',      photoUrl: 'https://images.unsplash.com/photo-1515023115894-bacee3643854?w=400&h=400&fit=crop&crop=face' },
+  { email: 'chloe.johnson@seed.daterabbit.com',    name: 'Chloe Johnson',    photoUrl: 'https://images.unsplash.com/photo-1519699047748-de8e457a634e?w=400&h=400&fit=crop&crop=face' },
+  { email: 'aria.patel@seed.daterabbit.com',       name: 'Aria Patel',       photoUrl: 'https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?w=400&h=400&fit=crop&crop=face' },
+  { email: 'grace.wilson@seed.daterabbit.com',     name: 'Grace Wilson',     photoUrl: 'https://images.unsplash.com/photo-1573496359142-b8d87734a5a2?w=400&h=400&fit=crop&crop=face' },
+  { email: 'lily.taylor@seed.daterabbit.com',      name: 'Lily Taylor',      photoUrl: 'https://images.unsplash.com/photo-1539571696357-5a69c17a67c6?w=400&h=400&fit=crop&crop=face' },
+  { email: 'harper.brown@seed.daterabbit.com',     name: 'Harper Brown',     photoUrl: 'https://images.unsplash.com/photo-1548142813-c348350df52b?w=400&h=400&fit=crop&crop=face' },
+  { email: 'scarlett.nguyen@seed.daterabbit.com',  name: 'Scarlett Nguyen',  photoUrl: 'https://images.unsplash.com/photo-1516726817505-f5ed825624d8?w=400&h=400&fit=crop&crop=face' },
+  { email: 'maya.robinson@seed.daterabbit.com',    name: 'Maya Robinson',    photoUrl: 'https://images.unsplash.com/photo-1531123897727-8f129e1688ce?w=400&h=400&fit=crop&crop=face' },
+  { email: 'stella.garcia@seed.daterabbit.com',    name: 'Stella Garcia',    photoUrl: 'https://images.unsplash.com/photo-1508214751196-bcfd4ca60f91?w=400&h=400&fit=crop&crop=face' },
+  { email: 'penelope.clarke@seed.daterabbit.com',  name: 'Penelope Clarke',  photoUrl: 'https://images.unsplash.com/photo-1514315384763-ba401779410f?w=400&h=400&fit=crop&crop=face' },
+  { email: 'victoria.scott@seed.daterabbit.com',   name: 'Victoria Scott',   photoUrl: 'https://images.unsplash.com/photo-1534751516642-a1af1ef26a56?w=400&h=400&fit=crop&crop=face' },
 ];
 
-// Additional new companions from seed-test-profiles (remaining ones not yet updated)
+// Additional new companions from seed-test-profiles
 const NEW_COMPANION_UPDATES = [
-  { email: 'jade.nakamura@seed.daterabbit.com',    name: 'Jade Nakamura',    photoIndex: 52 },
-  { email: 'maya.okonkwo@seed.daterabbit.com',     name: 'Maya Okonkwo',     photoIndex: 62 },
-  { email: 'anya.kozlov@seed.daterabbit.com',      name: 'Anya Kozlov',      photoIndex: 7 },
-  { email: 'valentina.reyes@seed.daterabbit.com',  name: 'Valentina Reyes',  photoIndex: 21 },
-  { email: 'diana.sterling@seed.daterabbit.com',   name: 'Diana Sterling',   photoIndex: 35 },
-  { email: 'freya.anderson@seed.daterabbit.com',   name: 'Freya Anderson',   photoIndex: 41 },
-  { email: 'priya.sharma@seed.daterabbit.com',     name: 'Priya Sharma',     photoIndex: 48 },
-  { email: 'lucia.fontana@seed.daterabbit.com',    name: 'Lucia Fontana',    photoIndex: 55 },
+  { email: 'jade.nakamura@seed.daterabbit.com',    name: 'Jade Nakamura',    photoUrl: 'https://images.unsplash.com/photo-1527203561188-dae1bc1a60a1?w=400&h=400&fit=crop&crop=face' },
+  { email: 'maya.okonkwo@seed.daterabbit.com',     name: 'Maya Okonkwo',     photoUrl: 'https://images.unsplash.com/photo-1523264653568-3cafe1e40e67?w=400&h=400&fit=crop&crop=face' },
+  { email: 'anya.kozlov@seed.daterabbit.com',      name: 'Anya Kozlov',      photoUrl: 'https://images.unsplash.com/photo-1502685104144-0e3e4c9ae73a?w=400&h=400&fit=crop&crop=face' },
+  { email: 'valentina.reyes@seed.daterabbit.com',  name: 'Valentina Reyes',  photoUrl: 'https://images.unsplash.com/photo-1479936343636-73cdc5aae0c3?w=400&h=400&fit=crop&crop=face' },
+  { email: 'diana.sterling@seed.daterabbit.com',   name: 'Diana Sterling',   photoUrl: 'https://images.unsplash.com/photo-1491349174775-aaafddd81942?w=400&h=400&fit=crop&crop=face' },
+  { email: 'freya.anderson@seed.daterabbit.com',   name: 'Freya Anderson',   photoUrl: 'https://images.unsplash.com/photo-1488716820095-cbe80883c496?w=400&h=400&fit=crop&crop=face' },
+  { email: 'priya.sharma@seed.daterabbit.com',     name: 'Priya Sharma',     photoUrl: 'https://images.unsplash.com/photo-1524504388940-b1c1722653e1?w=400&h=400&fit=crop&crop=face' },
+  { email: 'lucia.fontana@seed.daterabbit.com',    name: 'Lucia Fontana',    photoUrl: 'https://images.unsplash.com/photo-1534528741775-53994a69daeb?w=400&h=400&fit=crop&crop=face' },
 ];
 
 // All updates to process
@@ -126,8 +126,8 @@ async function updateCompanionPhoto(companion) {
   }
 
   const token = authResult.token;
-  const primaryUrl = `https://i.pravatar.cc/400?img=${companion.photoIndex}`;
-  const secondaryUrl = `https://i.pravatar.cc/400?img=${companion.photoIndex === 1 ? 70 : companion.photoIndex - 1}`;
+  const primaryUrl = companion.photoUrl;
+  const secondaryUrl = companion.photoUrl.replace(/photo-[^?]+/, 'photo-1524504388940-b1c1722653e1'); // fallback secondary
 
   const photos = [
     { id: generateUUID(), url: primaryUrl, order: 0, isPrimary: true },


### PR DESCRIPTION
## Summary
- Replaced unreliable `i.pravatar.cc` URLs with Unsplash portrait photos for all 20 seed companions
- Each companion gets 2 unique photos (primary + secondary) — all women's portraits, diverse ages/appearances
- Updated seeker photos (5 men) to Unsplash as well
- Updated `scripts/update-seed-photos.js` to use Unsplash URLs instead of i.pravatar.cc

## Test plan
- [ ] Re-run seed on staging: `cd /var/www/daterabbit/api && npm run seed`
- [ ] Verify browse page shows real photos for all companion cards
- [ ] Verify profile page shows both primary and secondary photos

Fixes #978