### PR TITLE
fix: web scroll broken on all screens

### DIFF
--- a/app/app/_layout.tsx
+++ b/app/app/_layout.tsx
@@ -147,8 +147,7 @@ export default function RootLayout() {
               minWidth: 320,
               marginLeft: 'auto',
               marginRight: 'auto',
-              height: '100%',
-              overflow: 'auto',
+              flex: 1,
             } as any : {}),
           }
         }}


### PR DESCRIPTION
## Summary
- Root cause: `contentStyle` in root `_layout.tsx` had `height: '100%'` on web, creating a fixed-height container that prevented all ScrollViews from scrolling
- Fix: replaced `height: '100%'` with `flex: 1` and removed redundant `overflow: 'auto'` from Stack contentStyle
- Individual screen ScrollViews already have `overflow: 'auto'` from PR #148, which remains correct

## Why `height: '100%'` breaks scroll
On web, `height: '100%'` makes the Stack content container exactly viewport-sized. ScrollView inside it sees "I fit perfectly" and doesn't activate scrolling. `flex: 1` instead lets the container participate in flexbox layout properly, allowing ScrollView children to scroll naturally.

## Test plan
- [ ] Open any tab screen (Home, Profile, Browse) on web
- [ ] Verify vertical scroll works on all screens
- [ ] Verify mobile max-width (430px) constraint still applied
- [ ] Verify native app not affected (change is web-only)

Generated with [Claude Code](https://claude.com/claude-code)