### PR TITLE
fix: show rating summary when review details unavailable (#1021)

### DIFF
--- a/app/app/profile/[id].tsx
+++ b/app/app/profile/[id].tsx
@@ -438,7 +438,14 @@ export default function ProfileViewScreen() {
                   </View>
                 ))
               ) : (
-                <Text style={[styles.bio, { color: colors.textSecondary }]}>No reviews yet. Be the first!</Text>
+                <View style={{ alignItems: 'center', paddingVertical: spacing.md }}>
+                  <View style={{ flexDirection: 'row', alignItems: 'center', marginBottom: spacing.xs }}>
+                    <Icon name="star" size={16} color={colors.accent} />
+                    <Text style={[styles.statValue, { color: colors.text, marginLeft: spacing.xs }]}>{profile.rating}</Text>
+                    <Text style={[styles.statLabel, { color: colors.textSecondary }]}> based on {profile.reviewCount} {profile.reviewCount === 1 ? 'review' : 'reviews'}</Text>
+                  </View>
+                  <Text style={[styles.bio, { color: colors.textSecondary, textAlign: 'center' }]}>Detailed reviews are not available yet</Text>
+                </View>
               )}
             </Card>
           ) : null}


### PR DESCRIPTION
## Summary
- When `reviewCount > 0` but no actual review objects exist in the array, the Reviews section showed "No reviews yet. Be the first!" which contradicts the displayed rating and count
- Now shows a rating summary ("4.8 based on 26 reviews") with "Detailed reviews are not available yet" message instead

## Test plan
- [ ] Open any companion profile that has reviewCount > 0 but empty reviews array
- [ ] Verify the Reviews section shows rating summary instead of "No reviews yet"
- [ ] Verify profiles with actual review objects still display them normally

Generated with [Claude Code](https://claude.com/claude-code)