### PR TITLE
fix: remove __EXPO_ROUTER_key from URLs

### DIFF
--- a/app/app/(auth)/login.tsx
+++ b/app/app/(auth)/login.tsx
@@ -26,7 +26,7 @@ export default function LoginScreen() {
 
   useEffect(() => {
     if (authStep === 'otp') {
-      router.push({ pathname: '/(auth)/otp', params: { email: email.trim().toLowerCase(), ...(role ? { role } : {}) } });
+      router.push(`/(auth)/otp?email=${encodeURIComponent(email.trim().toLowerCase())}${role ? `&role=${role}` : ''}`);
     }
   }, [authStep]);
 

--- a/app/app/(auth)/role-select.tsx
+++ b/app/app/(auth)/role-select.tsx
@@ -10,10 +10,7 @@ export default function RoleSelectScreen() {
   const { colors } = useTheme();
 
   const handleSelectRole = (role: 'companion' | 'seeker') => {
-    router.push({
-      pathname: '/(auth)/register',
-      params: { role },
-    });
+    router.push(`/(auth)/register?role=${role}`);
   };
 
   return (

--- a/app/app/(auth)/welcome.tsx
+++ b/app/app/(auth)/welcome.tsx
@@ -73,7 +73,7 @@ export default function WelcomeScreen() {
           <Button
             title="Find Companions"
             label="Looking for a date?"
-            onPress={() => router.push({ pathname: '/(auth)/login', params: { role: 'seeker' } })}
+            onPress={() => router.push(`/(auth)/login?role=seeker`)}
             variant="primary"
             fullWidth
             size="lg"
@@ -82,7 +82,7 @@ export default function WelcomeScreen() {
           <Button
             title="Become a Companion"
             label="Want to earn?"
-            onPress={() => router.push({ pathname: '/(auth)/register', params: { role: 'companion' } })}
+            onPress={() => router.push(`/(auth)/register?role=companion`)}
             variant="secondary"
             fullWidth
             size="lg"

--- a/app/app/(tabs)/male/bookings.tsx
+++ b/app/app/(tabs)/male/bookings.tsx
@@ -226,10 +226,7 @@ function BookingCard({ booking, type, colors, onCancel, formatDate }: BookingCar
           )}
           <Button
             title="Message"
-            onPress={() => router.push({
-              pathname: `/chat/${booking.companion?.id || booking.companion_id}`,
-              params: { name: booking.companion?.name || companion.name }
-            })}
+            onPress={() => router.push(`/chat/${booking.companion?.id || booking.companion_id}?name=${encodeURIComponent(booking.companion?.name || companion.name)}`)}
             variant="outline"
             size="sm"
             style={{ flex: 1 }}

--- a/app/app/(tabs)/male/index.tsx
+++ b/app/app/(tabs)/male/index.tsx
@@ -328,7 +328,7 @@ function CompanionCardItem({ companion, colors }: { companion: CompanionListItem
   return (
     <TouchableOpacity
       activeOpacity={0.8}
-      onPress={() => router.push({ pathname: '/profile/[id]', params: { id: companion.id } })}
+      onPress={() => router.push(`/profile/${companion.id}`)}
     >
       <Card variant="elevated" shadow="sm" style={styles.companionCard}>
         <UserImage


### PR DESCRIPTION
## Summary
- Replace object-form `router.push({ pathname, params })` with template literal `router.push(`/path?param=value`)` across 5 files
- Prevents Expo Router from appending internal `__EXPO_ROUTER_key=undefined-XXX` to URLs on web
- Fixes bug #1022

## Files changed
- `app/(tabs)/male/index.tsx` — CompanionCardItem profile navigation
- `app/(tabs)/male/bookings.tsx` — Message button chat navigation
- `app/(auth)/welcome.tsx` — Seeker/companion role navigation
- `app/(auth)/role-select.tsx` — Role selection navigation
- `app/(auth)/login.tsx` — OTP navigation

## Test plan
- [ ] Navigate to a companion profile from home screen — URL should be clean `/profile/{id}`
- [ ] Navigate to booking — URL should be clean `/booking/{id}`
- [ ] Auth flow (login/register) — URLs should not contain `__EXPO_ROUTER_key`