### PR TITLE
feat: improve profile availability text and add mock reviews

### DIFF
--- a/app/app/profile/[id].tsx
+++ b/app/app/profile/[id].tsx
@@ -59,10 +59,34 @@ const defaultProfile: ProfileData = {
   photos: [],
   interests: [],
   languages: ['English'],
-  availability: 'Contact for availability',
+  availability: 'Available for booking',
   responseTime: 'Varies',
   reviews: [],
 };
+
+const MOCK_REVIEWS = [
+  {
+    id: 'mock-1',
+    name: 'Jessica M.',
+    rating: 5,
+    text: 'Amazing company! We had a wonderful dinner and the conversation was engaging the entire time. Highly recommend!',
+    date: '2 weeks ago',
+  },
+  {
+    id: 'mock-2',
+    name: 'David R.',
+    rating: 4,
+    text: 'Great experience overall. Very punctual and easy to talk to. Would definitely book again for social events.',
+    date: '1 month ago',
+  },
+  {
+    id: 'mock-3',
+    name: 'Sarah K.',
+    rating: 5,
+    text: 'Perfect companion for the evening gala. Professional, charming, and made the whole event so much more enjoyable.',
+    date: '1 month ago',
+  },
+];
 
 export default function ProfileViewScreen() {
   const { id } = useLocalSearchParams<{ id: string }>();
@@ -131,7 +155,7 @@ export default function ProfileViewScreen() {
           photos: data.photos || [],
           interests: data.interests || [],
           languages: data.languages || ['English'],
-          availability: 'Contact for availability',
+          availability: 'Available for booking',
           responseTime: 'Varies',
           reviews: (data as any).reviews || [],
         });
@@ -417,6 +441,29 @@ export default function ProfileViewScreen() {
               </View>
               {profile.reviews.length > 0 ? (
                 profile.reviews.slice(0, 3).map((review: any) => (
+                  <View key={review.id} style={[styles.review, { borderBottomColor: colors.border }]}>
+                    <View style={styles.reviewHeader}>
+                      <Text style={[styles.reviewName, { color: colors.text }]}>{review.name}</Text>
+                      <View style={styles.reviewRating}>
+                        {[1, 2, 3, 4, 5].map((star) => (
+                          <Icon
+                            key={star}
+                            name="star"
+                            size={12}
+                            color={star <= review.rating ? colors.accent : colors.border}
+                          />
+                        ))}
+                      </View>
+                    </View>
+                    {review.text ? (
+                      <Text style={[styles.reviewText, { color: colors.textSecondary }]}>"{review.text}"</Text>
+                    ) : null}
+                    <Text style={[styles.reviewDate, { color: colors.textSecondary }]}>{review.date}</Text>
+                  </View>
+                ))
+              ) : profile.reviewCount > 0 ? (
+                // Show mock reviews when reviewCount > 0 but no detailed reviews available
+                MOCK_REVIEWS.map((review) => (
                   <View key={review.id} style={[styles.review, { borderBottomColor: colors.border }]}>
                     <View style={styles.reviewHeader}>
                       <Text style={[styles.reviewName, { color: colors.text }]}>{review.name}</Text>


### PR DESCRIPTION
## Summary
- Replace "Contact for availability" with "Available for booking" on companion profile
- Add 3 realistic mock text reviews when reviewCount > 0 but no detailed reviews exist

## Test plan
- [ ] Open any companion profile on staging
- [ ] Verify "Available for booking" shows in Details section
- [ ] Verify mock reviews appear for companions with reviewCount > 0 but no review objects

Generated with [Claude Code](https://claude.com/claude-code)