### PR TITLE
fix: favorites BROWSE COMPANIONS button navigation (#1041)

### DIFF
--- a/app/app/favorites/index.tsx
+++ b/app/app/favorites/index.tsx
@@ -85,7 +85,7 @@ export default function FavoritesScreen() {
             />
             <Button
               title="Browse Companions"
-              onPress={() => router.push('/(tabs)/male/browse')}
+              onPress={() => router.replace('/male/browse')}
               style={{ marginTop: spacing.lg }}
             />
           </View>


### PR DESCRIPTION
## Summary
- Fix favorites empty state CTA button not navigating
- Changed route from `/(tabs)/male/browse` to `/male/browse` — the `/(tabs)` group prefix doesn't resolve on web
- Used `router.replace` instead of `router.push` for cleaner navigation

## Test plan
- [ ] Open Favorites screen (empty state)
- [ ] Tap BROWSE COMPANIONS → should navigate to Browse page

🤖 Generated with [Claude Code](https://claude.com/claude-code)