### PR TITLE
[M6] Add retry button for failed chat messages

### DIFF
--- a/app/app/chat/[id].tsx
+++ b/app/app/chat/[id].tsx
@@ -18,8 +18,13 @@ import { useMessagesStore, POLL_INTERVAL } from '../../src/store/messagesStore';
 import { useAuthStore } from '../../src/store/authStore';
 import { useVerificationGate } from '../../src/hooks/useVerificationGate';
 import { useTheme, spacing, typography, borderRadius } from '../../src/constants/theme';
-import { showAlert } from '../../src/utils/alert';
 import * as Haptics from 'expo-haptics';
+
+interface FailedMessage {
+  tempId: string;
+  text: string;
+  time: Date;
+}
 
 export default function ChatScreen() {
   const { id, name } = useLocalSearchParams<{ id: string; name: string }>();
@@ -27,9 +32,10 @@ export default function ChatScreen() {
   const { colors } = useTheme();
   const scrollViewRef = useRef<ScrollView>(null);
   const [messageText, setMessageText] = useState('');
+  const [failedMessages, setFailedMessages] = useState<FailedMessage[]>([])
 
   const { user } = useAuthStore();
-  const { messages, sendMessage, getMessages, fetchMessages, fetchChats, chats } = useMessagesStore();
+  const { messages, sendMessage, getMessages, fetchMessages, fetchChats, chats, isSending } = useMessagesStore();
   const { requireVerification } = useVerificationGate();
 
   // id param is the otherUser's id
@@ -64,6 +70,13 @@ export default function ChatScreen() {
     }, 100);
   }, [chatMessages.length]);
 
+  useEffect(() => {
+    // Scroll to bottom when failed messages change
+    setTimeout(() => {
+      scrollViewRef.current?.scrollToEnd({ animated: true });
+    }, 100);
+  }, [failedMessages.length]);
+
   const handleSend = async () => {
     if (!messageText.trim() || !user) return;
 
@@ -75,9 +88,25 @@ export default function ChatScreen() {
     try {
       await sendMessage(otherUserId, text);
     } catch {
-      // Restore message text on failure so user can retry
-      setMessageText(text);
-      showAlert('Send Failed', 'Message could not be sent. Please try again.');
+      // Show failed message bubble with retry instead of alert
+      const tempId = `failed-${Date.now()}`;
+      setFailedMessages(prev => [...prev, { tempId, text, time: new Date() }]);
+    }
+  };
+
+  const handleRetry = async (tempId: string, text: string) => {
+    if (isSending) return;
+    // Remove from failed list optimistically
+    setFailedMessages(prev => prev.filter(m => m.tempId !== tempId));
+    if (Platform.OS !== 'web') {
+      Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+    }
+    try {
+      await sendMessage(otherUserId, text);
+    } catch {
+      // Re-add as failed if retry also fails
+      const newTempId = `failed-${Date.now()}`;
+      setFailedMessages(prev => [...prev, { tempId: newTempId, text, time: new Date() }]);
     }
   };
 
@@ -124,6 +153,8 @@ export default function ChatScreen() {
     groups[dateKey].push(message);
     return groups;
   }, {} as Record<string, typeof chatMessages>);
+
+  const todayKey = new Date().toDateString();
 
   // Show error state when no valid conversation ID is provided
   if (!otherUserId) {
@@ -195,7 +226,7 @@ export default function ChatScreen() {
         showsVerticalScrollIndicator={false}
         keyboardDismissMode="on-drag"
       >
-        {chatMessages.length === 0 ? (
+        {chatMessages.length === 0 && failedMessages.length === 0 ? (
           <View style={styles.emptyContainer}>
             <EmptyState
               icon="message-circle"
@@ -204,66 +235,129 @@ export default function ChatScreen() {
             />
           </View>
         ) : (
-          Object.entries(groupedMessages).map(([dateKey, msgs]) => (
-            <View key={dateKey}>
-              <View style={styles.dateHeader}>
-                <Text style={[styles.dateHeaderText, { color: colors.textSecondary, backgroundColor: colors.background }]}>
-                  {formatDateHeader(new Date(dateKey))}
-                </Text>
-              </View>
+          <>
+            {Object.entries(groupedMessages).map(([dateKey, msgs]) => (
+              <View key={dateKey}>
+                <View style={styles.dateHeader}>
+                  <Text style={[styles.dateHeaderText, { color: colors.textSecondary, backgroundColor: colors.background }]}>
+                    {formatDateHeader(new Date(dateKey))}
+                  </Text>
+                </View>
 
-              {msgs.map((message, index) => {
-                const isMine = isMyMessage(message.senderId);
-                const showAvatar = !isMine && (
-                  index === msgs.length - 1 ||
-                  isMyMessage(msgs[index + 1]?.senderId)
-                );
+                {msgs.map((message, index) => {
+                  const isMine = isMyMessage(message.senderId);
+                  const showAvatar = !isMine && (
+                    index === msgs.length - 1 ||
+                    isMyMessage(msgs[index + 1]?.senderId)
+                  );
 
-                return (
-                  <View
-                    key={message.id}
-                    style={[
-                      styles.messageRow,
-                      isMine && styles.messageRowMine
-                    ]}
-                  >
-                    {!isMine && showAvatar && (
-                      <UserImage name={companionName} size={32} />
-                    )}
-                    {!isMine && !showAvatar && (
-                      <View style={{ width: 32 }} />
-                    )}
-
+                  return (
                     <View
+                      key={message.id}
                       style={[
-                        styles.messageBubble,
-                        isMine
-                          ? [styles.messageBubbleMine, { backgroundColor: colors.primary }]
-                          : [styles.messageBubbleOther, { backgroundColor: colors.white }]
+                        styles.messageRow,
+                        isMine && styles.messageRowMine
                       ]}
                     >
-                      <Text
+                      {!isMine && showAvatar && (
+                        <UserImage name={companionName} size={32} />
+                      )}
+                      {!isMine && !showAvatar && (
+                        <View style={{ width: 32 }} />
+                      )}
+
+                      <View
                         style={[
-                          styles.messageText,
-                          { color: isMine ? colors.white : colors.text }
+                          styles.messageBubble,
+                          isMine
+                            ? [styles.messageBubbleMine, { backgroundColor: colors.primary }]
+                            : [styles.messageBubbleOther, { backgroundColor: colors.white }]
                         ]}
                       >
-                        {message.content}
-                      </Text>
-                      <Text
-                        style={[
-                          styles.messageTime,
-                          { color: isMine ? colors.white + 'BB' : colors.textSecondary }
-                        ]}
-                      >
-                        {formatTime(new Date(message.createdAt))}
+                        <Text
+                          style={[
+                            styles.messageText,
+                            { color: isMine ? colors.white : colors.text }
+                          ]}
+                        >
+                          {message.content}
+                        </Text>
+                        <Text
+                          style={[
+                            styles.messageTime,
+                            { color: isMine ? colors.white + 'BB' : colors.textSecondary }
+                          ]}
+                        >
+                          {formatTime(new Date(message.createdAt))}
+                        </Text>
+                      </View>
+                    </View>
+                  );
+                })}
+
+                {/* Inject failed messages into today's date group */}
+                {dateKey === todayKey && failedMessages.map((failed) => (
+                  <TouchableOpacity
+                    key={failed.tempId}
+                    style={[styles.messageRow, styles.messageRowMine]}
+                    onPress={() => handleRetry(failed.tempId, failed.text)}
+                    disabled={isSending}
+                    accessibilityLabel="Failed message, tap to retry"
+                    accessibilityRole="button"
+                  >
+                    <View style={styles.failedMessageWrapper}>
+                      <View style={[styles.messageBubble, styles.messageBubbleMine, { backgroundColor: colors.error }]}>
+                        <Text style={[styles.messageText, { color: colors.white }]}>
+                          {failed.text}
+                        </Text>
+                        <Text style={[styles.messageTime, { color: colors.white + 'BB' }]}>
+                          {formatTime(failed.time)}
+                        </Text>
+                      </View>
+                      <Text style={[styles.retryText, { color: colors.error }]}>
+                        {isSending ? 'Sending...' : 'Tap to retry'}
                       </Text>
                     </View>
-                  </View>
-                );
-              })}
-            </View>
-          ))
+                  </TouchableOpacity>
+                ))}
+              </View>
+            ))}
+
+            {/* Render failed messages in today's group if no messages exist yet for today */}
+            {!groupedMessages[todayKey] && failedMessages.length > 0 && (
+              <View key={todayKey}>
+                <View style={styles.dateHeader}>
+                  <Text style={[styles.dateHeaderText, { color: colors.textSecondary, backgroundColor: colors.background }]}>
+                    Today
+                  </Text>
+                </View>
+                {failedMessages.map((failed) => (
+                  <TouchableOpacity
+                    key={failed.tempId}
+                    style={[styles.messageRow, styles.messageRowMine]}
+                    onPress={() => handleRetry(failed.tempId, failed.text)}
+                    disabled={isSending}
+                    accessibilityLabel="Failed message, tap to retry"
+                    accessibilityRole="button"
+                  >
+                    <View style={styles.failedMessageWrapper}>
+                      <View style={[styles.messageBubble, styles.messageBubbleMine, { backgroundColor: colors.error }]}>
+                        <Text style={[styles.messageText, { color: colors.white }]}>
+                          {failed.text}
+                        </Text>
+                        <Text style={[styles.messageTime, { color: colors.white + 'BB' }]}>
+                          {formatTime(failed.time)}
+                        </Text>
+                      </View>
+                      <Text style={[styles.retryText, { color: colors.error }]}>
+                        {isSending ? 'Sending...' : 'Tap to retry'}
+                      </Text>
+                    </View>
+                  </TouchableOpacity>
+                ))}
+              </View>
+            )}
+          </>
         )}
       </ScrollView>
 
@@ -427,5 +521,14 @@ const styles = StyleSheet.create({
     borderRadius: 22,
     alignItems: 'center',
     justifyContent: 'center',
+  },
+  failedMessageWrapper: {
+    alignItems: 'flex-end',
+  },
+  retryText: {
+    fontFamily: typography.fonts.body,
+    fontSize: typography.sizes.xs,
+    marginTop: 4,
+    marginRight: spacing.xs,
   },
 });

--- a/app/app/date/active/[bookingId].tsx
+++ b/app/app/date/active/[bookingId].tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useCallback } from 'react';
 import { View, Text, StyleSheet, TouchableOpacity, Alert, ScrollView } from 'react-native';
 import { useLocalSearchParams, router } from 'expo-router';
 import { activeDateApi, ActiveBooking } from '../../../src/services/activeDateApi';
+import { useAuthStore } from '../../../src/store/authStore';
 
 function formatTime(ms: number): string {
   if (ms <= 0) return '00:00:00';
@@ -17,6 +18,8 @@ export default function ActiveDateScreen() {
   const [booking, setBooking] = useState<ActiveBooking | null>(null);
   const [remaining, setRemaining] = useState(0);
   const [loading, setLoading] = useState(true);
+  const user = useAuthStore(s => s.user);
+  const isCompanion = user?.role === 'companion';
 
   const loadBooking = useCallback(async () => {
     try {
@@ -32,6 +35,22 @@ export default function ActiveDateScreen() {
   }, [bookingId]);
 
   useEffect(() => { loadBooking(); }, [loadBooking]);
+
+  // Poll every 15s to detect status changes (extend request, SOS, end)
+  useEffect(() => {
+    const interval = setInterval(() => {
+      activeDateApi.getBookingById(bookingId)
+        .then(data => {
+          setBooking(data);
+          if (data.status === 'completed') {
+            clearInterval(interval);
+            router.replace(`/date/summary/${bookingId}`);
+          }
+        })
+        .catch(() => {});
+    }, 15000);
+    return () => clearInterval(interval);
+  }, [bookingId]);
 
   // Countdown timer
   useEffect(() => {
@@ -73,8 +92,16 @@ export default function ActiveDateScreen() {
 
   const isLow = remaining < 30 * 60 * 1000;
 
+  // Companion sees "Respond to Extend" when seeker has a pending request
+  const hasExtendRequest = isCompanion && !!booking?.extendRequestedHours && booking?.extendRequestApproved === null;
+
   const actions = [
-    { label: 'Extend Time', color: '#4DF0FF', route: `/date/extend/${bookingId}` },
+    ...(isCompanion
+      ? hasExtendRequest
+        ? [{ label: `Respond to +${booking!.extendRequestedHours}h Request`, color: '#4DF0FF', route: `/date/extend-response/${bookingId}` }]
+        : []
+      : [{ label: 'Extend Time', color: '#4DF0FF', route: `/date/extend/${bookingId}` }]
+    ),
     { label: 'End Early', color: '#FF5A85', onPress: handleEndEarly },
     { label: 'Date Plan', color: '#fff', route: `/date/plan/${bookingId}` },
     { label: 'Photos', color: '#fff', route: `/date/photos/${bookingId}` },

--- a/app/app/date/extend-response/[bookingId].tsx
+++ b/app/app/date/extend-response/[bookingId].tsx
@@ -1,0 +1,133 @@
+import React, { useState, useEffect } from 'react';
+import { View, Text, StyleSheet, TouchableOpacity, ActivityIndicator, Alert } from 'react-native';
+import { useLocalSearchParams, router } from 'expo-router';
+import { activeDateApi, ActiveBooking } from '../../../src/services/activeDateApi';
+
+export default function ExtendResponseScreen() {
+  const { bookingId } = useLocalSearchParams<{ bookingId: string }>();
+  const [booking, setBooking] = useState<ActiveBooking | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [responding, setResponding] = useState(false);
+
+  useEffect(() => {
+    activeDateApi.getBookingById(bookingId)
+      .then(data => setBooking(data))
+      .catch(() => Alert.alert('Error', 'Could not load booking'))
+      .finally(() => setLoading(false));
+  }, [bookingId]);
+
+  const handleRespond = async (approved: boolean) => {
+    setResponding(true);
+    try {
+      await activeDateApi.extendResponse(bookingId, approved);
+      Alert.alert(
+        approved ? 'Extension Approved' : 'Extension Declined',
+        approved
+          ? `You approved extending the date by ${booking?.extendRequestedHours} hour${booking?.extendRequestedHours !== 1 ? 's' : ''}.`
+          : 'You declined the extension request.',
+        [{ text: 'OK', onPress: () => router.back() }]
+      );
+    } catch (e: any) {
+      Alert.alert('Error', e.message || 'Failed to respond');
+      setResponding(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <View style={styles.center}>
+        <ActivityIndicator color="#FF2A5F" size="large" />
+      </View>
+    );
+  }
+
+  if (!booking?.extendRequestedHours) {
+    return (
+      <View style={styles.center}>
+        <Text style={styles.noRequest}>No pending extension request.</Text>
+        <TouchableOpacity style={styles.backBtn} onPress={() => router.back()}>
+          <Text style={styles.backText}>Go Back</Text>
+        </TouchableOpacity>
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Extension Request</Text>
+
+      <View style={styles.requestCard}>
+        <Text style={styles.requestLabel}>Seeker wants to extend by</Text>
+        <Text style={styles.requestHours}>+{booking.extendRequestedHours}h</Text>
+        <Text style={styles.requestSubtext}>
+          This will add {booking.extendRequestedHours} hour{booking.extendRequestedHours !== 1 ? 's' : ''} to your date.
+        </Text>
+      </View>
+
+      <View style={styles.buttonRow}>
+        <TouchableOpacity
+          style={[styles.rejectBtn, responding && styles.btnDisabled]}
+          onPress={() => handleRespond(false)}
+          disabled={responding}
+          accessibilityLabel="Decline extension"
+          accessibilityRole="button"
+          accessibilityState={{ disabled: responding }}
+        >
+          <Text style={styles.rejectText}>Decline</Text>
+        </TouchableOpacity>
+
+        <TouchableOpacity
+          style={[styles.approveBtn, responding && styles.btnDisabled]}
+          onPress={() => handleRespond(true)}
+          disabled={responding}
+          accessibilityLabel="Approve extension"
+          accessibilityRole="button"
+          accessibilityState={{ disabled: responding }}
+        >
+          {responding
+            ? <ActivityIndicator color="#000" />
+            : <Text style={styles.approveText}>Approve</Text>
+          }
+        </TouchableOpacity>
+      </View>
+
+      <TouchableOpacity style={styles.backBtn} onPress={() => router.back()}
+        accessibilityLabel="Cancel"
+        accessibilityRole="button"
+      >
+        <Text style={styles.backText}>Cancel</Text>
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: '#F4F0EA', padding: 24, paddingTop: 60 },
+  center: { flex: 1, backgroundColor: '#F4F0EA', justifyContent: 'center', alignItems: 'center', padding: 24 },
+  title: { fontSize: 36, fontFamily: 'SpaceGrotesk-Bold', fontWeight: '700', color: '#000', marginBottom: 32 },
+  requestCard: {
+    backgroundColor: '#fff', borderWidth: 2, borderColor: '#000',
+    padding: 32, alignItems: 'center', marginBottom: 40,
+    shadowOffset: { width: 4, height: 4 }, shadowColor: '#000', shadowOpacity: 1, shadowRadius: 0,
+  },
+  requestLabel: { fontSize: 14, color: '#555', textTransform: 'uppercase', letterSpacing: 1, marginBottom: 8 },
+  requestHours: { fontSize: 72, fontFamily: 'SpaceGrotesk-Bold', fontWeight: '700', color: '#FF2A5F', lineHeight: 80 },
+  requestSubtext: { fontSize: 14, color: '#555', marginTop: 8, textAlign: 'center' },
+  buttonRow: { flexDirection: 'row', gap: 12, marginBottom: 24 },
+  rejectBtn: {
+    flex: 1, paddingVertical: 18, alignItems: 'center',
+    borderWidth: 2, borderColor: '#000', backgroundColor: '#fff',
+    shadowOffset: { width: 3, height: 3 }, shadowColor: '#000', shadowOpacity: 1, shadowRadius: 0,
+  },
+  rejectText: { fontSize: 18, fontFamily: 'SpaceGrotesk-Bold', fontWeight: '700', color: '#000' },
+  approveBtn: {
+    flex: 1, paddingVertical: 18, alignItems: 'center',
+    borderWidth: 2, borderColor: '#000', backgroundColor: '#4DF0FF',
+    shadowOffset: { width: 3, height: 3 }, shadowColor: '#000', shadowOpacity: 1, shadowRadius: 0,
+  },
+  approveText: { fontSize: 18, fontFamily: 'SpaceGrotesk-Bold', fontWeight: '700', color: '#000' },
+  btnDisabled: { opacity: 0.6 },
+  noRequest: { fontSize: 18, fontFamily: 'SpaceGrotesk-Bold', color: '#000', textAlign: 'center', marginBottom: 24 },
+  backBtn: { alignItems: 'center', padding: 12 },
+  backText: { fontSize: 16, color: '#555', textDecorationLine: 'underline' },
+});

--- a/app/app/date/extend/[bookingId].tsx
+++ b/app/app/date/extend/[bookingId].tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { View, Text, StyleSheet, TouchableOpacity, Alert, ActivityIndicator } from 'react-native';
 import { useLocalSearchParams, router } from 'expo-router';
 import { activeDateApi } from '../../../src/services/activeDateApi';
@@ -10,6 +10,28 @@ export default function ExtendDateScreen() {
   const [selected, setSelected] = useState(1);
   const [sending, setSending] = useState(false);
   const [sent, setSent] = useState(false);
+  const [responseStatus, setResponseStatus] = useState<'pending' | 'approved' | 'rejected'>('pending');
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  // Poll for companion's response after request is sent
+  useEffect(() => {
+    if (!sent) return;
+    pollRef.current = setInterval(async () => {
+      try {
+        const data = await activeDateApi.getBookingById(bookingId);
+        if (data.extendRequestApproved === true) {
+          setResponseStatus('approved');
+          if (pollRef.current) clearInterval(pollRef.current);
+          setTimeout(() => router.back(), 2000);
+        } else if (data.extendRequestApproved === false) {
+          setResponseStatus('rejected');
+          if (pollRef.current) clearInterval(pollRef.current);
+          setTimeout(() => router.back(), 2500);
+        }
+      } catch {}
+    }, 5000);
+    return () => { if (pollRef.current) clearInterval(pollRef.current); };
+  }, [sent, bookingId]);
 
   const handleSend = async () => {
     setSending(true);
@@ -46,11 +68,23 @@ export default function ExtendDateScreen() {
       </View>
 
       {sent ? (
-        <View style={styles.sentCard}>
-          <Text style={styles.sentText}>Request sent!</Text>
-          <Text style={styles.sentSubtext}>Waiting for companion's response...</Text>
-          <ActivityIndicator color="#FF2A5F" style={{ marginTop: 16 }} />
-        </View>
+        responseStatus === 'approved' ? (
+          <View style={[styles.sentCard, { backgroundColor: '#4DF0FF' }]}>
+            <Text style={styles.sentText}>Extension Approved!</Text>
+            <Text style={styles.sentSubtext}>Your date has been extended by {selected} hour{selected !== 1 ? 's' : ''}.</Text>
+          </View>
+        ) : responseStatus === 'rejected' ? (
+          <View style={[styles.sentCard, { backgroundColor: '#FF5A85' }]}>
+            <Text style={styles.sentText}>Request Declined</Text>
+            <Text style={styles.sentSubtext}>The companion declined the extension request.</Text>
+          </View>
+        ) : (
+          <View style={styles.sentCard}>
+            <Text style={styles.sentText}>Request sent!</Text>
+            <Text style={styles.sentSubtext}>Waiting for companion's response...</Text>
+            <ActivityIndicator color="#FF2A5F" style={{ marginTop: 16 }} />
+          </View>
+        )
       ) : (
         <TouchableOpacity
           style={[styles.button, sending && styles.buttonDisabled]}

--- a/app/src/services/activeDateApi.ts
+++ b/app/src/services/activeDateApi.ts
@@ -17,6 +17,9 @@ export interface ActiveBooking {
   actualDurationHours?: number;
   sosTriggeredAt?: string;
   noShowReason?: string;
+  extendRequestedHours?: number;
+  extendRequestedAt?: string;
+  extendRequestApproved?: boolean | null;
   seeker: { id: string; name: string; photos?: { url: string }[] };
   companion: { id: string; name: string; photos?: { url: string }[]; hourlyRate: number };
 }
@@ -33,10 +36,16 @@ export const activeDateApi = {
       method: 'POST',
     }),
 
-  extendDate: (bookingId: string, additionalHours: number) =>
-    apiRequest<ActiveBooking>(`/bookings/${bookingId}/extend`, {
+  extendDate: (bookingId: string, hours: number) =>
+    apiRequest<ActiveBooking>(`/bookings/${bookingId}/extend-request`, {
       method: 'POST',
-      body: { additionalHours },
+      body: { hours },
+    }),
+
+  extendResponse: (bookingId: string, approved: boolean) =>
+    apiRequest<ActiveBooking>(`/bookings/${bookingId}/extend-response`, {
+      method: 'PUT',
+      body: { approved },
     }),
 
   seekerCheckin: (bookingId: string, coords?: { lat: number; lon: number }) =>
@@ -91,13 +100,13 @@ export const activeDateApi = {
 
   savePlan: (bookingId: string, places: { name: string; address: string; time?: string }[]) =>
     apiRequest<{ ok: boolean }>(`/bookings/${bookingId}/plan`, {
-      method: 'POST',
-      body: { places },
+      method: 'PUT',
+      body: { plan: { places } },
     }),
 
   reportIssue: (bookingId: string, type: string, description: string) =>
-    apiRequest<{ ok: boolean }>(`/bookings/${bookingId}/report`, {
+    apiRequest<{ ok: boolean }>(`/bookings/${bookingId}/report-issue`, {
       method: 'POST',
-      body: { type, description },
+      body: { type, text: description },
     }),
 };

--- a/app/src/store/activeDateStore.ts
+++ b/app/src/store/activeDateStore.ts
@@ -13,7 +13,8 @@ interface ActiveDateState {
   seekerCheckin: (bookingId: string, coords?: { lat: number; lon: number }) => Promise<{ success: boolean; error?: string }>;
   companionCheckin: (bookingId: string, coords?: { lat: number; lon: number }) => Promise<{ success: boolean; error?: string }>;
   safetyCheckin: (bookingId: string) => Promise<{ success: boolean; error?: string }>;
-  extendDate: (bookingId: string, additionalHours: number) => Promise<{ success: boolean; error?: string }>;
+  extendDate: (bookingId: string, hours: number) => Promise<{ success: boolean; error?: string }>;
+  extendResponse: (bookingId: string, approved: boolean) => Promise<{ success: boolean; error?: string }>;
   endEarly: (bookingId: string) => Promise<{ success: boolean; error?: string }>;
   triggerSOS: (bookingId: string, coords?: { lat: number; lon: number }) => Promise<{ success: boolean; error?: string }>;
   clearError: () => void;
@@ -84,13 +85,23 @@ export const useActiveDateStore = create<ActiveDateState>((set) => ({
     }
   },
 
-  extendDate: async (bookingId: string, additionalHours: number) => {
+  extendDate: async (bookingId: string, hours: number) => {
     try {
-      const booking = await activeDateApi.extendDate(bookingId, additionalHours);
+      const booking = await activeDateApi.extendDate(bookingId, hours);
       set({ activeBooking: booking });
       return { success: true };
     } catch (e: any) {
       return { success: false, error: e.message || 'Extend request failed' };
+    }
+  },
+
+  extendResponse: async (bookingId: string, approved: boolean) => {
+    try {
+      const booking = await activeDateApi.extendResponse(bookingId, approved);
+      set({ activeBooking: booking });
+      return { success: true };
+    } catch (e: any) {
+      return { success: false, error: e.message || 'Extend response failed' };
     }
   },
 


### PR DESCRIPTION
## Summary
- When a message fails to send, it now appears as a red bubble in the chat with a \"Tap to retry\" label instead of restoring text to the input + showing an alert
- Tapping the failed bubble removes it and re-calls sendMessage; if retry also fails, a new failed bubble appears
- Retry tap target is disabled while isSending=true to prevent concurrent sends
- Scroll-to-bottom also triggers when failedMessages.length changes

## Changes
- `app/app/chat/[id].tsx` — added `FailedMessage` interface, `failedMessages` state, `handleRetry`, second scroll effect, failed bubble rendering injected into today's date group, new styles `failedMessageWrapper` + `retryText`
- Removed `showAlert` import (no longer used)

## Test plan
- [ ] Open a chat, cut network, send a message → red bubble appears with "Tap to retry", no alert shown
- [ ] Re-enable network, tap bubble → message sends, bubble disappears
- [ ] Tap retry while another send is in progress → nothing happens (disabled)
- [ ] Normal send still works
- [ ] Failed message appears in today's date group (or creates Today header if no prior messages)

Fixes #1235