### PR TITLE
[#1211] Persist onboarding seen flag in AsyncStorage

### DIFF
--- a/app/app/_layout.tsx
+++ b/app/app/_layout.tsx
@@ -74,11 +74,16 @@ const VERIFICATION_REQUIRED_ROUTES = [
 ];
 
 function NavigationGuard() {
-  const { isAuthenticated, hasSeenOnboarding, user } = useAuthStore();
+  const { isAuthenticated, hasSeenOnboarding, _hasHydrated, user } = useAuthStore();
   const router = useRouter();
   const segments = useSegments();
 
   useEffect(() => {
+    // Wait for AsyncStorage hydration before making any routing decisions.
+    // Without this guard, NavigationGuard fires with the unhydrated initial state
+    // (hasSeenOnboarding=false) and immediately redirects returning users to onboarding.
+    if (!_hasHydrated) return;
+
     const currentSegment = segments[0];
     const needsVerification = isAuthenticated && user?.verificationStatus !== 'approved';
     const isSeeker = user?.role === 'seeker';
@@ -150,7 +155,7 @@ function NavigationGuard() {
       const isCompanion = user?.role === 'companion';
       router.replace(isCompanion ? '/(tabs)/female' : '/(tabs)/male');
     }
-  }, [isAuthenticated, hasSeenOnboarding, user, segments, router]);
+  }, [isAuthenticated, hasSeenOnboarding, _hasHydrated, user, segments, router]);
 
   return null;
 }

--- a/app/app/date/active/[bookingId].tsx
+++ b/app/app/date/active/[bookingId].tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useCallback } from 'react';
 import { View, Text, StyleSheet, TouchableOpacity, Alert, ScrollView } from 'react-native';
 import { useLocalSearchParams, router } from 'expo-router';
 import { activeDateApi, ActiveBooking } from '../../../src/services/activeDateApi';
+import { useAuthStore } from '../../../src/store/authStore';
 
 function formatTime(ms: number): string {
   if (ms <= 0) return '00:00:00';
@@ -17,6 +18,8 @@ export default function ActiveDateScreen() {
   const [booking, setBooking] = useState<ActiveBooking | null>(null);
   const [remaining, setRemaining] = useState(0);
   const [loading, setLoading] = useState(true);
+  const user = useAuthStore(s => s.user);
+  const isCompanion = user?.role === 'companion';
 
   const loadBooking = useCallback(async () => {
     try {
@@ -32,6 +35,22 @@ export default function ActiveDateScreen() {
   }, [bookingId]);
 
   useEffect(() => { loadBooking(); }, [loadBooking]);
+
+  // Poll every 15s to detect status changes (extend request, SOS, end)
+  useEffect(() => {
+    const interval = setInterval(() => {
+      activeDateApi.getBookingById(bookingId)
+        .then(data => {
+          setBooking(data);
+          if (data.status === 'completed') {
+            clearInterval(interval);
+            router.replace(`/date/summary/${bookingId}`);
+          }
+        })
+        .catch(() => {});
+    }, 15000);
+    return () => clearInterval(interval);
+  }, [bookingId]);
 
   // Countdown timer
   useEffect(() => {
@@ -73,8 +92,16 @@ export default function ActiveDateScreen() {
 
   const isLow = remaining < 30 * 60 * 1000;
 
+  // Companion sees "Respond to Extend" when seeker has a pending request
+  const hasExtendRequest = isCompanion && !!booking?.extendRequestedHours && booking?.extendRequestApproved === null;
+
   const actions = [
-    { label: 'Extend Time', color: '#4DF0FF', route: `/date/extend/${bookingId}` },
+    ...(isCompanion
+      ? hasExtendRequest
+        ? [{ label: `Respond to +${booking!.extendRequestedHours}h Request`, color: '#4DF0FF', route: `/date/extend-response/${bookingId}` }]
+        : []
+      : [{ label: 'Extend Time', color: '#4DF0FF', route: `/date/extend/${bookingId}` }]
+    ),
     { label: 'End Early', color: '#FF5A85', onPress: handleEndEarly },
     { label: 'Date Plan', color: '#fff', route: `/date/plan/${bookingId}` },
     { label: 'Photos', color: '#fff', route: `/date/photos/${bookingId}` },

--- a/app/app/date/extend-response/[bookingId].tsx
+++ b/app/app/date/extend-response/[bookingId].tsx
@@ -1,0 +1,133 @@
+import React, { useState, useEffect } from 'react';
+import { View, Text, StyleSheet, TouchableOpacity, ActivityIndicator, Alert } from 'react-native';
+import { useLocalSearchParams, router } from 'expo-router';
+import { activeDateApi, ActiveBooking } from '../../../src/services/activeDateApi';
+
+export default function ExtendResponseScreen() {
+  const { bookingId } = useLocalSearchParams<{ bookingId: string }>();
+  const [booking, setBooking] = useState<ActiveBooking | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [responding, setResponding] = useState(false);
+
+  useEffect(() => {
+    activeDateApi.getBookingById(bookingId)
+      .then(data => setBooking(data))
+      .catch(() => Alert.alert('Error', 'Could not load booking'))
+      .finally(() => setLoading(false));
+  }, [bookingId]);
+
+  const handleRespond = async (approved: boolean) => {
+    setResponding(true);
+    try {
+      await activeDateApi.extendResponse(bookingId, approved);
+      Alert.alert(
+        approved ? 'Extension Approved' : 'Extension Declined',
+        approved
+          ? `You approved extending the date by ${booking?.extendRequestedHours} hour${booking?.extendRequestedHours !== 1 ? 's' : ''}.`
+          : 'You declined the extension request.',
+        [{ text: 'OK', onPress: () => router.back() }]
+      );
+    } catch (e: any) {
+      Alert.alert('Error', e.message || 'Failed to respond');
+      setResponding(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <View style={styles.center}>
+        <ActivityIndicator color="#FF2A5F" size="large" />
+      </View>
+    );
+  }
+
+  if (!booking?.extendRequestedHours) {
+    return (
+      <View style={styles.center}>
+        <Text style={styles.noRequest}>No pending extension request.</Text>
+        <TouchableOpacity style={styles.backBtn} onPress={() => router.back()}>
+          <Text style={styles.backText}>Go Back</Text>
+        </TouchableOpacity>
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Extension Request</Text>
+
+      <View style={styles.requestCard}>
+        <Text style={styles.requestLabel}>Seeker wants to extend by</Text>
+        <Text style={styles.requestHours}>+{booking.extendRequestedHours}h</Text>
+        <Text style={styles.requestSubtext}>
+          This will add {booking.extendRequestedHours} hour{booking.extendRequestedHours !== 1 ? 's' : ''} to your date.
+        </Text>
+      </View>
+
+      <View style={styles.buttonRow}>
+        <TouchableOpacity
+          style={[styles.rejectBtn, responding && styles.btnDisabled]}
+          onPress={() => handleRespond(false)}
+          disabled={responding}
+          accessibilityLabel="Decline extension"
+          accessibilityRole="button"
+          accessibilityState={{ disabled: responding }}
+        >
+          <Text style={styles.rejectText}>Decline</Text>
+        </TouchableOpacity>
+
+        <TouchableOpacity
+          style={[styles.approveBtn, responding && styles.btnDisabled]}
+          onPress={() => handleRespond(true)}
+          disabled={responding}
+          accessibilityLabel="Approve extension"
+          accessibilityRole="button"
+          accessibilityState={{ disabled: responding }}
+        >
+          {responding
+            ? <ActivityIndicator color="#000" />
+            : <Text style={styles.approveText}>Approve</Text>
+          }
+        </TouchableOpacity>
+      </View>
+
+      <TouchableOpacity style={styles.backBtn} onPress={() => router.back()}
+        accessibilityLabel="Cancel"
+        accessibilityRole="button"
+      >
+        <Text style={styles.backText}>Cancel</Text>
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: '#F4F0EA', padding: 24, paddingTop: 60 },
+  center: { flex: 1, backgroundColor: '#F4F0EA', justifyContent: 'center', alignItems: 'center', padding: 24 },
+  title: { fontSize: 36, fontFamily: 'SpaceGrotesk-Bold', fontWeight: '700', color: '#000', marginBottom: 32 },
+  requestCard: {
+    backgroundColor: '#fff', borderWidth: 2, borderColor: '#000',
+    padding: 32, alignItems: 'center', marginBottom: 40,
+    shadowOffset: { width: 4, height: 4 }, shadowColor: '#000', shadowOpacity: 1, shadowRadius: 0,
+  },
+  requestLabel: { fontSize: 14, color: '#555', textTransform: 'uppercase', letterSpacing: 1, marginBottom: 8 },
+  requestHours: { fontSize: 72, fontFamily: 'SpaceGrotesk-Bold', fontWeight: '700', color: '#FF2A5F', lineHeight: 80 },
+  requestSubtext: { fontSize: 14, color: '#555', marginTop: 8, textAlign: 'center' },
+  buttonRow: { flexDirection: 'row', gap: 12, marginBottom: 24 },
+  rejectBtn: {
+    flex: 1, paddingVertical: 18, alignItems: 'center',
+    borderWidth: 2, borderColor: '#000', backgroundColor: '#fff',
+    shadowOffset: { width: 3, height: 3 }, shadowColor: '#000', shadowOpacity: 1, shadowRadius: 0,
+  },
+  rejectText: { fontSize: 18, fontFamily: 'SpaceGrotesk-Bold', fontWeight: '700', color: '#000' },
+  approveBtn: {
+    flex: 1, paddingVertical: 18, alignItems: 'center',
+    borderWidth: 2, borderColor: '#000', backgroundColor: '#4DF0FF',
+    shadowOffset: { width: 3, height: 3 }, shadowColor: '#000', shadowOpacity: 1, shadowRadius: 0,
+  },
+  approveText: { fontSize: 18, fontFamily: 'SpaceGrotesk-Bold', fontWeight: '700', color: '#000' },
+  btnDisabled: { opacity: 0.6 },
+  noRequest: { fontSize: 18, fontFamily: 'SpaceGrotesk-Bold', color: '#000', textAlign: 'center', marginBottom: 24 },
+  backBtn: { alignItems: 'center', padding: 12 },
+  backText: { fontSize: 16, color: '#555', textDecorationLine: 'underline' },
+});

--- a/app/app/date/extend/[bookingId].tsx
+++ b/app/app/date/extend/[bookingId].tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { View, Text, StyleSheet, TouchableOpacity, Alert, ActivityIndicator } from 'react-native';
 import { useLocalSearchParams, router } from 'expo-router';
 import { activeDateApi } from '../../../src/services/activeDateApi';
@@ -10,6 +10,28 @@ export default function ExtendDateScreen() {
   const [selected, setSelected] = useState(1);
   const [sending, setSending] = useState(false);
   const [sent, setSent] = useState(false);
+  const [responseStatus, setResponseStatus] = useState<'pending' | 'approved' | 'rejected'>('pending');
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  // Poll for companion's response after request is sent
+  useEffect(() => {
+    if (!sent) return;
+    pollRef.current = setInterval(async () => {
+      try {
+        const data = await activeDateApi.getBookingById(bookingId);
+        if (data.extendRequestApproved === true) {
+          setResponseStatus('approved');
+          if (pollRef.current) clearInterval(pollRef.current);
+          setTimeout(() => router.back(), 2000);
+        } else if (data.extendRequestApproved === false) {
+          setResponseStatus('rejected');
+          if (pollRef.current) clearInterval(pollRef.current);
+          setTimeout(() => router.back(), 2500);
+        }
+      } catch {}
+    }, 5000);
+    return () => { if (pollRef.current) clearInterval(pollRef.current); };
+  }, [sent, bookingId]);
 
   const handleSend = async () => {
     setSending(true);
@@ -46,11 +68,23 @@ export default function ExtendDateScreen() {
       </View>
 
       {sent ? (
-        <View style={styles.sentCard}>
-          <Text style={styles.sentText}>Request sent!</Text>
-          <Text style={styles.sentSubtext}>Waiting for companion's response...</Text>
-          <ActivityIndicator color="#FF2A5F" style={{ marginTop: 16 }} />
-        </View>
+        responseStatus === 'approved' ? (
+          <View style={[styles.sentCard, { backgroundColor: '#4DF0FF' }]}>
+            <Text style={styles.sentText}>Extension Approved!</Text>
+            <Text style={styles.sentSubtext}>Your date has been extended by {selected} hour{selected !== 1 ? 's' : ''}.</Text>
+          </View>
+        ) : responseStatus === 'rejected' ? (
+          <View style={[styles.sentCard, { backgroundColor: '#FF5A85' }]}>
+            <Text style={styles.sentText}>Request Declined</Text>
+            <Text style={styles.sentSubtext}>The companion declined the extension request.</Text>
+          </View>
+        ) : (
+          <View style={styles.sentCard}>
+            <Text style={styles.sentText}>Request sent!</Text>
+            <Text style={styles.sentSubtext}>Waiting for companion's response...</Text>
+            <ActivityIndicator color="#FF2A5F" style={{ marginTop: 16 }} />
+          </View>
+        )
       ) : (
         <TouchableOpacity
           style={[styles.button, sending && styles.buttonDisabled]}

--- a/app/src/services/activeDateApi.ts
+++ b/app/src/services/activeDateApi.ts
@@ -17,6 +17,9 @@ export interface ActiveBooking {
   actualDurationHours?: number;
   sosTriggeredAt?: string;
   noShowReason?: string;
+  extendRequestedHours?: number;
+  extendRequestedAt?: string;
+  extendRequestApproved?: boolean | null;
   seeker: { id: string; name: string; photos?: { url: string }[] };
   companion: { id: string; name: string; photos?: { url: string }[]; hourlyRate: number };
 }
@@ -33,10 +36,16 @@ export const activeDateApi = {
       method: 'POST',
     }),
 
-  extendDate: (bookingId: string, additionalHours: number) =>
-    apiRequest<ActiveBooking>(`/bookings/${bookingId}/extend`, {
+  extendDate: (bookingId: string, hours: number) =>
+    apiRequest<ActiveBooking>(`/bookings/${bookingId}/extend-request`, {
       method: 'POST',
-      body: { additionalHours },
+      body: { hours },
+    }),
+
+  extendResponse: (bookingId: string, approved: boolean) =>
+    apiRequest<ActiveBooking>(`/bookings/${bookingId}/extend-response`, {
+      method: 'PUT',
+      body: { approved },
     }),
 
   seekerCheckin: (bookingId: string, coords?: { lat: number; lon: number }) =>
@@ -91,13 +100,13 @@ export const activeDateApi = {
 
   savePlan: (bookingId: string, places: { name: string; address: string; time?: string }[]) =>
     apiRequest<{ ok: boolean }>(`/bookings/${bookingId}/plan`, {
-      method: 'POST',
-      body: { places },
+      method: 'PUT',
+      body: { plan: { places } },
     }),
 
   reportIssue: (bookingId: string, type: string, description: string) =>
-    apiRequest<{ ok: boolean }>(`/bookings/${bookingId}/report`, {
+    apiRequest<{ ok: boolean }>(`/bookings/${bookingId}/report-issue`, {
       method: 'POST',
-      body: { type, description },
+      body: { type, text: description },
     }),
 };

--- a/app/src/store/activeDateStore.ts
+++ b/app/src/store/activeDateStore.ts
@@ -13,7 +13,8 @@ interface ActiveDateState {
   seekerCheckin: (bookingId: string, coords?: { lat: number; lon: number }) => Promise<{ success: boolean; error?: string }>;
   companionCheckin: (bookingId: string, coords?: { lat: number; lon: number }) => Promise<{ success: boolean; error?: string }>;
   safetyCheckin: (bookingId: string) => Promise<{ success: boolean; error?: string }>;
-  extendDate: (bookingId: string, additionalHours: number) => Promise<{ success: boolean; error?: string }>;
+  extendDate: (bookingId: string, hours: number) => Promise<{ success: boolean; error?: string }>;
+  extendResponse: (bookingId: string, approved: boolean) => Promise<{ success: boolean; error?: string }>;
   endEarly: (bookingId: string) => Promise<{ success: boolean; error?: string }>;
   triggerSOS: (bookingId: string, coords?: { lat: number; lon: number }) => Promise<{ success: boolean; error?: string }>;
   clearError: () => void;
@@ -84,13 +85,23 @@ export const useActiveDateStore = create<ActiveDateState>((set) => ({
     }
   },
 
-  extendDate: async (bookingId: string, additionalHours: number) => {
+  extendDate: async (bookingId: string, hours: number) => {
     try {
-      const booking = await activeDateApi.extendDate(bookingId, additionalHours);
+      const booking = await activeDateApi.extendDate(bookingId, hours);
       set({ activeBooking: booking });
       return { success: true };
     } catch (e: any) {
       return { success: false, error: e.message || 'Extend request failed' };
+    }
+  },
+
+  extendResponse: async (bookingId: string, approved: boolean) => {
+    try {
+      const booking = await activeDateApi.extendResponse(bookingId, approved);
+      set({ activeBooking: booking });
+      return { success: true };
+    } catch (e: any) {
+      return { success: false, error: e.message || 'Extend response failed' };
     }
   },
 

--- a/app/src/store/authStore.ts
+++ b/app/src/store/authStore.ts
@@ -35,6 +35,7 @@ interface AuthState {
   isLoading: boolean;
   hasCompletedOnboarding: boolean;
   hasSeenOnboarding: boolean; // Intro slides (not profile setup)
+  _hasHydrated: boolean; // True once zustand persist has loaded from AsyncStorage
   authStep: AuthStep;
   pendingEmail: string | null;
   error: string | null;
@@ -56,6 +57,7 @@ interface AuthState {
   logout: () => Promise<void>;
   clearError: () => void;
   setOnboardingSeen: () => void;
+  setHasHydrated: (value: boolean) => void;
   refreshUser: () => Promise<void>;
   initialize: () => Promise<void>;
   setPendingEmail: (email: string) => void;
@@ -94,6 +96,7 @@ export const useAuthStore = create<AuthState>()(
       isLoading: false,
       hasCompletedOnboarding: false,
       hasSeenOnboarding: false,
+      _hasHydrated: false,
       authStep: 'idle',
       pendingEmail: null,
       error: null,
@@ -323,6 +326,8 @@ export const useAuthStore = create<AuthState>()(
 
       setOnboardingSeen: () => set({ hasSeenOnboarding: true }),
 
+      setHasHydrated: (value) => set({ _hasHydrated: value }),
+
       setPendingEmail: (email) => set({ pendingEmail: email }),
     }),
     {
@@ -332,6 +337,11 @@ export const useAuthStore = create<AuthState>()(
         hasSeenOnboarding: state.hasSeenOnboarding,
         hasCompletedOnboarding: state.hasCompletedOnboarding,
       }),
+      onRehydrateStorage: () => (_state, error) => {
+        if (!error) {
+          useAuthStore.getState().setHasHydrated(true);
+        }
+      },
     }
   )
 );


### PR DESCRIPTION
## Summary

- Adds `_hasHydrated` flag to `authStore` with `onRehydrateStorage` callback
- `NavigationGuard` in `_layout.tsx` now waits for hydration before making routing decisions
- Fixes returning users being shown onboarding slides on every app reload

## Root cause

Zustand `persist` middleware hydrates from AsyncStorage asynchronously. `NavigationGuard`'s `useEffect` was firing on first render with unhydrated initial state (`hasSeenOnboarding=false`), redirecting returning users to `/onboarding` before the persisted `true` value arrived.

## Test plan

- [ ] Complete onboarding → reload app → onboarding should NOT reappear
- [ ] Clear AsyncStorage → reload → onboarding appears → complete → reload → skipped
- [ ] New user flow unaffected: onboarding still shows on first launch

Fixes #1211