### PR TITLE
[C6] Upload companion onboarding photos to server

### DIFF
--- a/app/app/(comp-onboard)/step2.tsx
+++ b/app/app/(comp-onboard)/step2.tsx
@@ -9,6 +9,7 @@ import {
   TextInput,
   KeyboardAvoidingView,
   Platform,
+  ActivityIndicator,
 } from 'react-native';
 import { router } from 'expo-router';
 import * as ImagePicker from 'expo-image-picker';
@@ -18,6 +19,7 @@ import { Button } from '../../src/components/Button';
 import { Icon } from '../../src/components/Icon';
 import { ProgressBar } from '../../src/components/verification';
 import { colors, spacing, typography, borderRadius, PAGE_PADDING } from '../../src/constants/theme';
+import { usersApi } from '../../src/services/api';
 
 const MIN_PHOTOS = 3;
 const MAX_PHOTOS = 6;
@@ -28,6 +30,7 @@ export default function CompStep2Screen() {
   const [photos, setPhotos] = useState<string[]>([]);
   const [bio, setBio] = useState('');
   const [errors, setErrors] = useState<{ photos?: string; bio?: string }>({});
+  const [isUploading, setIsUploading] = useState(false);
 
   const pickPhoto = async () => {
     if (photos.length >= MAX_PHOTOS) return;
@@ -67,9 +70,32 @@ export default function CompStep2Screen() {
     return Object.keys(newErrors).length === 0;
   };
 
-  const handleContinue = () => {
+  const handleContinue = async () => {
     if (!validate()) return;
-    router.push('/(comp-onboard)/verify');
+
+    setIsUploading(true);
+    try {
+      // Upload each photo to the server and collect the returned URLs
+      const uploadedPhotos: { id: string; url: string; order: number; isPrimary: boolean }[] = [];
+      for (let i = 0; i < photos.length; i++) {
+        const result = await usersApi.uploadProfilePhoto(photos[i]);
+        uploadedPhotos.push({
+          id: String(i),
+          url: result.url,
+          order: i,
+          isPrimary: i === 0,
+        });
+      }
+
+      // Save photos and bio to the user profile
+      await usersApi.updateProfile({ photos: uploadedPhotos as any, bio });
+
+      router.push('/(comp-onboard)/verify');
+    } catch (err: any) {
+      showAlert('Upload failed', err?.message || 'Could not upload photos. Please try again.');
+    } finally {
+      setIsUploading(false);
+    }
   };
 
   const renderPhotoSlot = (index: number) => {
@@ -211,12 +237,19 @@ export default function CompStep2Screen() {
           </View>
         </View>
 
+        {isUploading && (
+          <View style={styles.uploadingRow}>
+            <ActivityIndicator size="small" color={colors.primary} />
+            <Text style={styles.uploadingText}>Uploading photos…</Text>
+          </View>
+        )}
         <Button
           title="Continue"
           onPress={handleContinue}
           variant="pink"
           fullWidth
           size="lg"
+          disabled={isUploading}
           testID="comp-step2-continue-btn"
         />
       </ScrollView>
@@ -408,5 +441,17 @@ const styles = StyleSheet.create({
   },
   charCountWarning: {
     color: colors.warning,
+  },
+  uploadingRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: spacing.sm,
+    marginBottom: spacing.sm,
+  },
+  uploadingText: {
+    fontFamily: typography.fonts.body,
+    fontSize: typography.sizes.sm,
+    color: colors.textMuted,
   },
 });

--- a/app/app/date/active/[bookingId].tsx
+++ b/app/app/date/active/[bookingId].tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useCallback } from 'react';
 import { View, Text, StyleSheet, TouchableOpacity, Alert, ScrollView } from 'react-native';
 import { useLocalSearchParams, router } from 'expo-router';
 import { activeDateApi, ActiveBooking } from '../../../src/services/activeDateApi';
+import { useAuthStore } from '../../../src/store/authStore';
 
 function formatTime(ms: number): string {
   if (ms <= 0) return '00:00:00';
@@ -17,6 +18,8 @@ export default function ActiveDateScreen() {
   const [booking, setBooking] = useState<ActiveBooking | null>(null);
   const [remaining, setRemaining] = useState(0);
   const [loading, setLoading] = useState(true);
+  const user = useAuthStore(s => s.user);
+  const isCompanion = user?.role === 'companion';
 
   const loadBooking = useCallback(async () => {
     try {
@@ -32,6 +35,22 @@ export default function ActiveDateScreen() {
   }, [bookingId]);
 
   useEffect(() => { loadBooking(); }, [loadBooking]);
+
+  // Poll every 15s to detect status changes (extend request, SOS, end)
+  useEffect(() => {
+    const interval = setInterval(() => {
+      activeDateApi.getBookingById(bookingId)
+        .then(data => {
+          setBooking(data);
+          if (data.status === 'completed') {
+            clearInterval(interval);
+            router.replace(`/date/summary/${bookingId}`);
+          }
+        })
+        .catch(() => {});
+    }, 15000);
+    return () => clearInterval(interval);
+  }, [bookingId]);
 
   // Countdown timer
   useEffect(() => {
@@ -73,8 +92,16 @@ export default function ActiveDateScreen() {
 
   const isLow = remaining < 30 * 60 * 1000;
 
+  // Companion sees "Respond to Extend" when seeker has a pending request
+  const hasExtendRequest = isCompanion && !!booking?.extendRequestedHours && booking?.extendRequestApproved === null;
+
   const actions = [
-    { label: 'Extend Time', color: '#4DF0FF', route: `/date/extend/${bookingId}` },
+    ...(isCompanion
+      ? hasExtendRequest
+        ? [{ label: `Respond to +${booking!.extendRequestedHours}h Request`, color: '#4DF0FF', route: `/date/extend-response/${bookingId}` }]
+        : []
+      : [{ label: 'Extend Time', color: '#4DF0FF', route: `/date/extend/${bookingId}` }]
+    ),
     { label: 'End Early', color: '#FF5A85', onPress: handleEndEarly },
     { label: 'Date Plan', color: '#fff', route: `/date/plan/${bookingId}` },
     { label: 'Photos', color: '#fff', route: `/date/photos/${bookingId}` },

--- a/app/app/date/extend-response/[bookingId].tsx
+++ b/app/app/date/extend-response/[bookingId].tsx
@@ -1,0 +1,133 @@
+import React, { useState, useEffect } from 'react';
+import { View, Text, StyleSheet, TouchableOpacity, ActivityIndicator, Alert } from 'react-native';
+import { useLocalSearchParams, router } from 'expo-router';
+import { activeDateApi, ActiveBooking } from '../../../src/services/activeDateApi';
+
+export default function ExtendResponseScreen() {
+  const { bookingId } = useLocalSearchParams<{ bookingId: string }>();
+  const [booking, setBooking] = useState<ActiveBooking | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [responding, setResponding] = useState(false);
+
+  useEffect(() => {
+    activeDateApi.getBookingById(bookingId)
+      .then(data => setBooking(data))
+      .catch(() => Alert.alert('Error', 'Could not load booking'))
+      .finally(() => setLoading(false));
+  }, [bookingId]);
+
+  const handleRespond = async (approved: boolean) => {
+    setResponding(true);
+    try {
+      await activeDateApi.extendResponse(bookingId, approved);
+      Alert.alert(
+        approved ? 'Extension Approved' : 'Extension Declined',
+        approved
+          ? `You approved extending the date by ${booking?.extendRequestedHours} hour${booking?.extendRequestedHours !== 1 ? 's' : ''}.`
+          : 'You declined the extension request.',
+        [{ text: 'OK', onPress: () => router.back() }]
+      );
+    } catch (e: any) {
+      Alert.alert('Error', e.message || 'Failed to respond');
+      setResponding(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <View style={styles.center}>
+        <ActivityIndicator color="#FF2A5F" size="large" />
+      </View>
+    );
+  }
+
+  if (!booking?.extendRequestedHours) {
+    return (
+      <View style={styles.center}>
+        <Text style={styles.noRequest}>No pending extension request.</Text>
+        <TouchableOpacity style={styles.backBtn} onPress={() => router.back()}>
+          <Text style={styles.backText}>Go Back</Text>
+        </TouchableOpacity>
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Extension Request</Text>
+
+      <View style={styles.requestCard}>
+        <Text style={styles.requestLabel}>Seeker wants to extend by</Text>
+        <Text style={styles.requestHours}>+{booking.extendRequestedHours}h</Text>
+        <Text style={styles.requestSubtext}>
+          This will add {booking.extendRequestedHours} hour{booking.extendRequestedHours !== 1 ? 's' : ''} to your date.
+        </Text>
+      </View>
+
+      <View style={styles.buttonRow}>
+        <TouchableOpacity
+          style={[styles.rejectBtn, responding && styles.btnDisabled]}
+          onPress={() => handleRespond(false)}
+          disabled={responding}
+          accessibilityLabel="Decline extension"
+          accessibilityRole="button"
+          accessibilityState={{ disabled: responding }}
+        >
+          <Text style={styles.rejectText}>Decline</Text>
+        </TouchableOpacity>
+
+        <TouchableOpacity
+          style={[styles.approveBtn, responding && styles.btnDisabled]}
+          onPress={() => handleRespond(true)}
+          disabled={responding}
+          accessibilityLabel="Approve extension"
+          accessibilityRole="button"
+          accessibilityState={{ disabled: responding }}
+        >
+          {responding
+            ? <ActivityIndicator color="#000" />
+            : <Text style={styles.approveText}>Approve</Text>
+          }
+        </TouchableOpacity>
+      </View>
+
+      <TouchableOpacity style={styles.backBtn} onPress={() => router.back()}
+        accessibilityLabel="Cancel"
+        accessibilityRole="button"
+      >
+        <Text style={styles.backText}>Cancel</Text>
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: '#F4F0EA', padding: 24, paddingTop: 60 },
+  center: { flex: 1, backgroundColor: '#F4F0EA', justifyContent: 'center', alignItems: 'center', padding: 24 },
+  title: { fontSize: 36, fontFamily: 'SpaceGrotesk-Bold', fontWeight: '700', color: '#000', marginBottom: 32 },
+  requestCard: {
+    backgroundColor: '#fff', borderWidth: 2, borderColor: '#000',
+    padding: 32, alignItems: 'center', marginBottom: 40,
+    shadowOffset: { width: 4, height: 4 }, shadowColor: '#000', shadowOpacity: 1, shadowRadius: 0,
+  },
+  requestLabel: { fontSize: 14, color: '#555', textTransform: 'uppercase', letterSpacing: 1, marginBottom: 8 },
+  requestHours: { fontSize: 72, fontFamily: 'SpaceGrotesk-Bold', fontWeight: '700', color: '#FF2A5F', lineHeight: 80 },
+  requestSubtext: { fontSize: 14, color: '#555', marginTop: 8, textAlign: 'center' },
+  buttonRow: { flexDirection: 'row', gap: 12, marginBottom: 24 },
+  rejectBtn: {
+    flex: 1, paddingVertical: 18, alignItems: 'center',
+    borderWidth: 2, borderColor: '#000', backgroundColor: '#fff',
+    shadowOffset: { width: 3, height: 3 }, shadowColor: '#000', shadowOpacity: 1, shadowRadius: 0,
+  },
+  rejectText: { fontSize: 18, fontFamily: 'SpaceGrotesk-Bold', fontWeight: '700', color: '#000' },
+  approveBtn: {
+    flex: 1, paddingVertical: 18, alignItems: 'center',
+    borderWidth: 2, borderColor: '#000', backgroundColor: '#4DF0FF',
+    shadowOffset: { width: 3, height: 3 }, shadowColor: '#000', shadowOpacity: 1, shadowRadius: 0,
+  },
+  approveText: { fontSize: 18, fontFamily: 'SpaceGrotesk-Bold', fontWeight: '700', color: '#000' },
+  btnDisabled: { opacity: 0.6 },
+  noRequest: { fontSize: 18, fontFamily: 'SpaceGrotesk-Bold', color: '#000', textAlign: 'center', marginBottom: 24 },
+  backBtn: { alignItems: 'center', padding: 12 },
+  backText: { fontSize: 16, color: '#555', textDecorationLine: 'underline' },
+});

--- a/app/app/date/extend/[bookingId].tsx
+++ b/app/app/date/extend/[bookingId].tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { View, Text, StyleSheet, TouchableOpacity, Alert, ActivityIndicator } from 'react-native';
 import { useLocalSearchParams, router } from 'expo-router';
 import { activeDateApi } from '../../../src/services/activeDateApi';
@@ -10,6 +10,28 @@ export default function ExtendDateScreen() {
   const [selected, setSelected] = useState(1);
   const [sending, setSending] = useState(false);
   const [sent, setSent] = useState(false);
+  const [responseStatus, setResponseStatus] = useState<'pending' | 'approved' | 'rejected'>('pending');
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  // Poll for companion's response after request is sent
+  useEffect(() => {
+    if (!sent) return;
+    pollRef.current = setInterval(async () => {
+      try {
+        const data = await activeDateApi.getBookingById(bookingId);
+        if (data.extendRequestApproved === true) {
+          setResponseStatus('approved');
+          if (pollRef.current) clearInterval(pollRef.current);
+          setTimeout(() => router.back(), 2000);
+        } else if (data.extendRequestApproved === false) {
+          setResponseStatus('rejected');
+          if (pollRef.current) clearInterval(pollRef.current);
+          setTimeout(() => router.back(), 2500);
+        }
+      } catch {}
+    }, 5000);
+    return () => { if (pollRef.current) clearInterval(pollRef.current); };
+  }, [sent, bookingId]);
 
   const handleSend = async () => {
     setSending(true);
@@ -46,11 +68,23 @@ export default function ExtendDateScreen() {
       </View>
 
       {sent ? (
-        <View style={styles.sentCard}>
-          <Text style={styles.sentText}>Request sent!</Text>
-          <Text style={styles.sentSubtext}>Waiting for companion's response...</Text>
-          <ActivityIndicator color="#FF2A5F" style={{ marginTop: 16 }} />
-        </View>
+        responseStatus === 'approved' ? (
+          <View style={[styles.sentCard, { backgroundColor: '#4DF0FF' }]}>
+            <Text style={styles.sentText}>Extension Approved!</Text>
+            <Text style={styles.sentSubtext}>Your date has been extended by {selected} hour{selected !== 1 ? 's' : ''}.</Text>
+          </View>
+        ) : responseStatus === 'rejected' ? (
+          <View style={[styles.sentCard, { backgroundColor: '#FF5A85' }]}>
+            <Text style={styles.sentText}>Request Declined</Text>
+            <Text style={styles.sentSubtext}>The companion declined the extension request.</Text>
+          </View>
+        ) : (
+          <View style={styles.sentCard}>
+            <Text style={styles.sentText}>Request sent!</Text>
+            <Text style={styles.sentSubtext}>Waiting for companion's response...</Text>
+            <ActivityIndicator color="#FF2A5F" style={{ marginTop: 16 }} />
+          </View>
+        )
       ) : (
         <TouchableOpacity
           style={[styles.button, sending && styles.buttonDisabled]}

--- a/app/src/services/activeDateApi.ts
+++ b/app/src/services/activeDateApi.ts
@@ -17,6 +17,9 @@ export interface ActiveBooking {
   actualDurationHours?: number;
   sosTriggeredAt?: string;
   noShowReason?: string;
+  extendRequestedHours?: number;
+  extendRequestedAt?: string;
+  extendRequestApproved?: boolean | null;
   seeker: { id: string; name: string; photos?: { url: string }[] };
   companion: { id: string; name: string; photos?: { url: string }[]; hourlyRate: number };
 }
@@ -33,10 +36,16 @@ export const activeDateApi = {
       method: 'POST',
     }),
 
-  extendDate: (bookingId: string, additionalHours: number) =>
-    apiRequest<ActiveBooking>(`/bookings/${bookingId}/extend`, {
+  extendDate: (bookingId: string, hours: number) =>
+    apiRequest<ActiveBooking>(`/bookings/${bookingId}/extend-request`, {
       method: 'POST',
-      body: { additionalHours },
+      body: { hours },
+    }),
+
+  extendResponse: (bookingId: string, approved: boolean) =>
+    apiRequest<ActiveBooking>(`/bookings/${bookingId}/extend-response`, {
+      method: 'PUT',
+      body: { approved },
     }),
 
   seekerCheckin: (bookingId: string, coords?: { lat: number; lon: number }) =>
@@ -91,13 +100,13 @@ export const activeDateApi = {
 
   savePlan: (bookingId: string, places: { name: string; address: string; time?: string }[]) =>
     apiRequest<{ ok: boolean }>(`/bookings/${bookingId}/plan`, {
-      method: 'POST',
-      body: { places },
+      method: 'PUT',
+      body: { plan: { places } },
     }),
 
   reportIssue: (bookingId: string, type: string, description: string) =>
-    apiRequest<{ ok: boolean }>(`/bookings/${bookingId}/report`, {
+    apiRequest<{ ok: boolean }>(`/bookings/${bookingId}/report-issue`, {
       method: 'POST',
-      body: { type, description },
+      body: { type, text: description },
     }),
 };

--- a/app/src/services/api.ts
+++ b/app/src/services/api.ts
@@ -188,6 +188,31 @@ export const usersApi = {
     apiRequest<{ success: boolean }>(`/users/favorites/${companionId}`, {
       method: 'DELETE',
     }),
+
+  uploadProfilePhoto: async (uri: string): Promise<{ url: string }> => {
+    const token = await getToken();
+    const formData = new FormData();
+    const extension = uri.split('.').pop()?.split('?')[0] || 'jpg';
+    const mimeType = `image/${extension === 'jpg' ? 'jpeg' : extension}`;
+    formData.append('file', {
+      uri,
+      type: mimeType,
+      name: `profile-photo.${extension}`,
+    } as unknown as Blob);
+    const response = await fetch(`${API_BASE_URL}/users/me/photos/upload`, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${token}`,
+        'Content-Type': 'multipart/form-data',
+      },
+      body: formData,
+    });
+    const data = await response.json();
+    if (!response.ok) {
+      throw new ApiError(data.message || 'Photo upload failed', response.status);
+    }
+    return data;
+  },
 };
 
 // Companions API

--- a/app/src/store/activeDateStore.ts
+++ b/app/src/store/activeDateStore.ts
@@ -13,7 +13,8 @@ interface ActiveDateState {
   seekerCheckin: (bookingId: string, coords?: { lat: number; lon: number }) => Promise<{ success: boolean; error?: string }>;
   companionCheckin: (bookingId: string, coords?: { lat: number; lon: number }) => Promise<{ success: boolean; error?: string }>;
   safetyCheckin: (bookingId: string) => Promise<{ success: boolean; error?: string }>;
-  extendDate: (bookingId: string, additionalHours: number) => Promise<{ success: boolean; error?: string }>;
+  extendDate: (bookingId: string, hours: number) => Promise<{ success: boolean; error?: string }>;
+  extendResponse: (bookingId: string, approved: boolean) => Promise<{ success: boolean; error?: string }>;
   endEarly: (bookingId: string) => Promise<{ success: boolean; error?: string }>;
   triggerSOS: (bookingId: string, coords?: { lat: number; lon: number }) => Promise<{ success: boolean; error?: string }>;
   clearError: () => void;
@@ -84,13 +85,23 @@ export const useActiveDateStore = create<ActiveDateState>((set) => ({
     }
   },
 
-  extendDate: async (bookingId: string, additionalHours: number) => {
+  extendDate: async (bookingId: string, hours: number) => {
     try {
-      const booking = await activeDateApi.extendDate(bookingId, additionalHours);
+      const booking = await activeDateApi.extendDate(bookingId, hours);
       set({ activeBooking: booking });
       return { success: true };
     } catch (e: any) {
       return { success: false, error: e.message || 'Extend request failed' };
+    }
+  },
+
+  extendResponse: async (bookingId: string, approved: boolean) => {
+    try {
+      const booking = await activeDateApi.extendResponse(bookingId, approved);
+      set({ activeBooking: booking });
+      return { success: true };
+    } catch (e: any) {
+      return { success: false, error: e.message || 'Extend response failed' };
     }
   },
 

--- a/backend/daterabbit-api/src/uploads/uploads.service.ts
+++ b/backend/daterabbit-api/src/uploads/uploads.service.ts
@@ -2,7 +2,7 @@ import { Injectable, BadRequestException } from '@nestjs/common';
 import * as fs from 'fs';
 import * as path from 'path';
 
-export type UploadType = 'id-photos' | 'selfies' | 'videos';
+export type UploadType = 'id-photos' | 'selfies' | 'videos' | 'profile-photos';
 
 const IMAGE_MIME_TYPES = ['image/jpeg', 'image/png', 'image/webp'];
 const VIDEO_MIME_TYPES = ['video/mp4', 'video/quicktime'];
@@ -19,7 +19,7 @@ export class UploadsService {
   }
 
   private ensureDirectories() {
-    const dirs: UploadType[] = ['id-photos', 'selfies', 'videos'];
+    const dirs: UploadType[] = ['id-photos', 'selfies', 'videos', 'profile-photos'];
     for (const dir of dirs) {
       fs.mkdirSync(path.join(UPLOADS_ROOT, dir), { recursive: true });
     }

--- a/backend/daterabbit-api/src/users/users.controller.ts
+++ b/backend/daterabbit-api/src/users/users.controller.ts
@@ -1,11 +1,16 @@
-import { Controller, Get, Post, Put, Delete, Body, UseGuards, Request, Param, BadRequestException, ParseUUIDPipe } from '@nestjs/common';
+import { Controller, Get, Post, Put, Delete, Body, UseGuards, Request, Param, BadRequestException, ParseUUIDPipe, UseInterceptors, UploadedFile } from '@nestjs/common';
+import { FileInterceptor } from '@nestjs/platform-express';
 import { UsersService } from './users.service';
+import { UploadsService } from '../uploads/uploads.service';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { UpdateUserDto } from './dto/update-user.dto';
 
 @Controller('users')
 export class UsersController {
-  constructor(private usersService: UsersService) {}
+  constructor(
+    private usersService: UsersService,
+    private uploadsService: UploadsService,
+  ) {}
 
   @UseGuards(JwtAuthGuard)
   @Get('me')
@@ -50,6 +55,21 @@ export class UsersController {
     }
     const { otpCode, otpExpiresAt, ...safeUser } = updated;
     return safeUser;
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Post('me/photos/upload')
+  @UseInterceptors(FileInterceptor('file'))
+  async uploadProfilePhoto(
+    @Request() req,
+    @UploadedFile() file: Express.Multer.File,
+  ) {
+    if (!file) {
+      throw new BadRequestException('No file provided');
+    }
+    this.uploadsService.validateImageFile(file);
+    const url = this.uploadsService.getFileUrl('profile-photos', file.filename);
+    return { url };
   }
 
   @UseGuards(JwtAuthGuard)

--- a/backend/daterabbit-api/src/users/users.module.ts
+++ b/backend/daterabbit-api/src/users/users.module.ts
@@ -1,14 +1,39 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { MulterModule } from '@nestjs/platform-express';
+import * as crypto from 'crypto';
+import * as multer from 'multer';
+import * as path from 'path';
+import * as fs from 'fs';
 import { User } from './entities/user.entity';
 import { BlockedUser } from './entities/blocked-user.entity';
 import { UserReport } from './entities/user-report.entity';
 import { Favorite } from './entities/favorite.entity';
 import { UsersService } from './users.service';
 import { UsersController } from './users.controller';
+import { UploadsModule } from '../uploads/uploads.module';
+
+const UPLOADS_ROOT = path.join(process.cwd(), 'uploads');
 
 @Module({
-  imports: [TypeOrmModule.forFeature([User, BlockedUser, UserReport, Favorite])],
+  imports: [
+    TypeOrmModule.forFeature([User, BlockedUser, UserReport, Favorite]),
+    MulterModule.register({
+      limits: { fileSize: 10 * 1024 * 1024 }, // 10MB max
+      storage: multer.diskStorage({
+        destination: (_req, _file, cb) => {
+          const dest = path.join(UPLOADS_ROOT, 'profile-photos');
+          fs.mkdirSync(dest, { recursive: true });
+          cb(null, dest);
+        },
+        filename: (_req, file, cb) => {
+          const ext = path.extname(file.originalname).toLowerCase();
+          cb(null, `${crypto.randomUUID()}${ext}`);
+        },
+      }),
+    }),
+    UploadsModule,
+  ],
   providers: [UsersService],
   controllers: [UsersController],
   exports: [UsersService],


### PR DESCRIPTION
## Summary
- Add `POST /users/me/photos/upload` multipart endpoint to backend (NestJS users controller)
- Add `MulterModule` with `diskStorage` to `UsersModule` saving to `uploads/profile-photos/`
- Add `profile-photos` upload type to `UploadsService`
- Add `usersApi.uploadProfilePhoto(uri)` in frontend using raw `fetch` + `FormData` (same pattern as verification uploads)
- Wire `step2.tsx` `handleContinue` to upload all selected photos sequentially, collect server URLs, save via `PUT /users/me` with `photos` + `bio`, show loading indicator, abort navigation on any failure

## Root cause
`handleContinue` only called `router.push` — photos were stored as local `file://` device URIs, never sent to the server.

## Test plan
- [ ] Log in as a new companion on staging
- [ ] Complete step2 with 3+ photos and a bio
- [ ] Call `GET /api/users/me` — `photos` array must contain hosted URLs (not `file://`)
- [ ] Browse as a seeker — companion photos must be visible

Fixes #1219