### PR TITLE
[#1210] Add OTP explanation text on registration

### DIFF
--- a/app/app/(auth)/register.tsx
+++ b/app/app/(auth)/register.tsx
@@ -259,6 +259,7 @@ export default function RegisterScreen() {
             keyboardType="email-address"
             autoCapitalize="none"
             leftIcon={<Icon name="mail" size={20} color={colors.textLight} />}
+            hint="We'll email you a one-time code to sign in. No password needed."
             testID="register-email-input"
           />
 


### PR DESCRIPTION
## Summary
- Adds hint text below email input on register screen
- Text: "We'll email you a one-time code to sign in. No password needed."
- Clarifies passwordless/OTP auth flow for new users who expect a password field

## Test plan
- Open registration screen
- Verify helper text appears below Email field
- Confirm no TS/build errors

Fixes #1210.