### PR TITLE
[#1205] Make /safety page publicly accessible

### DIFF
--- a/app/app/_layout.tsx
+++ b/app/app/_layout.tsx
@@ -54,7 +54,7 @@ function useCleanUrl() {
 }
 
 // Public routes accessible without authentication
-const PUBLIC_ROUTES = ['terms', 'privacy', 'onboarding', '(auth)', '(dev)'];
+const PUBLIC_ROUTES = ['terms', 'privacy', 'safety', 'onboarding', '(auth)', '(dev)'];
 
 // Authenticated non-tab routes — accessible to all authenticated users (verified or not)
 const NON_TAB_AUTH_ROUTES = [
@@ -213,6 +213,7 @@ export default function RootLayout() {
         <Stack.Screen name="(comp-onboard)" />
         <Stack.Screen name="terms" />
         <Stack.Screen name="privacy" />
+        <Stack.Screen name="safety" />
         <Stack.Screen name="booking/[id]" options={{ animation: 'slide_from_bottom', gestureEnabled: false }} />
         <Stack.Screen name="chat/[id]" options={{ animation: 'slide_from_bottom' }} />
         <Stack.Screen name="profile/[id]" />


### PR DESCRIPTION
## Summary
- Adds `safety` to `PUBLIC_ROUTES` in `NavigationGuard` so unauthenticated users can visit `/safety` without being redirected to `/welcome`
- Registers `Stack.Screen name="safety"` alongside `terms` and `privacy` in the root Stack navigator

## Root cause
`/safety` was not listed in `PUBLIC_ROUTES`, so the guard's `!isAuthenticated` branch redirected unauthenticated visitors to `/(auth)/welcome`.

## Test plan
- [ ] Open `/safety` while logged out — should render the Safety page
- [ ] Open `/safety` while logged in — should still render the Safety page
- [ ] `/terms` and `/privacy` still work without auth (no regression)

Fixes #1205