### PR TITLE
[#1204] Fix welcome screen button cutoff on mobile

### DIFF
--- a/app/app/(auth)/welcome.tsx
+++ b/app/app/(auth)/welcome.tsx
@@ -148,10 +148,10 @@ const styles = StyleSheet.create({
   },
   content: {
     paddingHorizontal: PAGE_PADDING,
-    // flexGrow: 1 breaks scrolling on web — the container stretches to
-    // fill the viewport and ScrollView thinks content fits, so it won't
-    // scroll. Only use flexGrow on native where it works correctly.
-    ...(Platform.OS === 'web' ? {} : { flexGrow: 1 }),
+    // Do NOT use flexGrow: 1 — it expands content to fill the viewport
+    // height, making ScrollView think everything fits and disabling scroll.
+    // On small screens (390x664) the bottom buttons get clipped. Let
+    // content be its natural height so the ScrollView actually scrolls.
     paddingTop: spacing.xl,
   },
 


### PR DESCRIPTION
Makes welcome screen content scrollable on small viewports (390x664).

## Root cause
`flexGrow: 1` was applied to the ScrollView `contentContainerStyle` on native. This caused the content container to expand to the full viewport height, making ScrollView believe all content fit — scroll was disabled. On iPhone SE/13 mini viewports the BECOME A COMPANION button, Sign in link, and footer were clipped below the fold.

## Fix
Removed `flexGrow: 1` from the native branch of the content style. Content now has its natural height and ScrollView scrolls correctly on all screen sizes.

## Verification
Open welcome screen on 390x664 viewport — all buttons and footer links visible, page scrolls.

Fixes #1204