### PR TITLE
[#1206] Fix 404 page overridden by NavigationGuard

### DIFF
--- a/app/app/_layout.tsx
+++ b/app/app/_layout.tsx
@@ -84,6 +84,9 @@ function NavigationGuard() {
     // (hasSeenOnboarding=false) and immediately redirects returning users to onboarding.
     if (!_hasHydrated) return;
 
+    // Don't redirect 404 pages
+    if (segments[0] === '+not-found') return;
+
     const currentSegment = segments[0];
     const needsVerification = isAuthenticated && user?.verificationStatus !== 'approved';
     const isSeeker = user?.role === 'seeker';


### PR DESCRIPTION
Adds +not-found exclusion to NavigationGuard so 404 pages render correctly for all users instead of being redirected to welcome/onboarding.

## Changes
- NavigationGuard now returns early when `segments[0] === '+not-found'`
- 404 page renders as intended for unauthenticated, unverified, and authenticated users alike

Fixes #1206.