### PR TITLE
[#1252] Replace hardcoded colors with theme tokens (3 screens)

### DIFF
--- a/app/app/(tabs)/male/browse.tsx
+++ b/app/app/(tabs)/male/browse.tsx
@@ -9,7 +9,7 @@ import { Button } from '../../../src/components/Button';
 import { Icon } from '../../../src/components/Icon';
 import { EmptyState } from '../../../src/components/EmptyState';
 import { FilterModal, FilterOptions } from '../../../src/components/FilterModal';
-import { useTheme, spacing, typography, borderRadius } from '../../../src/constants/theme';
+import { useTheme, colors, spacing, typography, borderRadius } from '../../../src/constants/theme';
 import { companionsApi, CompanionListItem } from '../../../src/services/api';
 import { showAlert } from '../../../src/utils/alert';
 
@@ -410,7 +410,7 @@ const styles = StyleSheet.create({
     paddingVertical: spacing.xs,
     borderRadius: borderRadius.sm,
     borderWidth: 2,
-    borderColor: '#000000',
+    borderColor: colors.border,
     marginBottom: spacing.md,
     gap: spacing.xs,
   },
@@ -433,11 +433,11 @@ const styles = StyleSheet.create({
     paddingHorizontal: spacing.md,
     paddingVertical: spacing.sm,
     borderWidth: 2,
-    borderColor: '#000000',
+    borderColor: colors.border,
     gap: spacing.sm,
     overflow: 'hidden',
     // Neo-Brutalism offset shadow
-    shadowColor: '#000000',
+    shadowColor: colors.shadow,
     shadowOffset: { width: 3, height: 3 },
     shadowOpacity: 1,
     shadowRadius: 0,
@@ -451,9 +451,9 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
     borderWidth: 2,
-    borderColor: '#000000',
+    borderColor: colors.border,
     // Neo-Brutalism offset shadow
-    shadowColor: '#000000',
+    shadowColor: colors.shadow,
     shadowOffset: { width: 3, height: 3 },
     shadowOpacity: 1,
     shadowRadius: 0,
@@ -470,7 +470,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
     borderWidth: 2,
-    borderColor: '#000000',
+    borderColor: colors.border,
   },
   filterBadgeText: {
     fontFamily: typography.fonts.heading,
@@ -501,9 +501,9 @@ const styles = StyleSheet.create({
     paddingVertical: 8,
     borderRadius: borderRadius.sm,
     borderWidth: 2,
-    borderColor: '#000000',
+    borderColor: colors.border,
     // Inactive chip: subtle shadow
-    shadowColor: '#000000',
+    shadowColor: colors.shadow,
     shadowOffset: { width: 2, height: 2 },
     shadowOpacity: 1,
     shadowRadius: 0,
@@ -574,8 +574,8 @@ const styles = StyleSheet.create({
     paddingVertical: spacing.sm,
     borderRadius: borderRadius.sm,
     borderWidth: 2,
-    borderColor: '#000000',
-    shadowColor: '#000000',
+    borderColor: colors.border,
+    shadowColor: colors.shadow,
     shadowOffset: { width: 2, height: 2 },
     shadowOpacity: 1,
     shadowRadius: 0,

--- a/app/app/date/companion-checkin/[bookingId].tsx
+++ b/app/app/date/companion-checkin/[bookingId].tsx
@@ -117,7 +117,7 @@ export default function CompanionCheckinScreen() {
   if (loading) {
     return (
       <View style={styles.center}>
-        <ActivityIndicator size="large" color="#FF2A5F" />
+        <ActivityIndicator size="large" color={colors.primary} />
       </View>
     );
   }
@@ -135,7 +135,7 @@ export default function CompanionCheckinScreen() {
         <View style={styles.waitingCard}>
           <Text style={styles.waitingText}>Waiting for {booking?.seeker?.name ?? 'your guest'}...</Text>
           <Text style={styles.waitingSubtext}>They'll check in when they arrive</Text>
-          <ActivityIndicator color="#FF2A5F" style={{ marginTop: 16 }} />
+          <ActivityIndicator color={colors.primary} style={{ marginTop: 16 }} />
         </View>
         <View style={styles.statusRow}>
           <View style={[styles.dot, styles.dotGreen]} />
@@ -240,41 +240,41 @@ export default function CompanionCheckinScreen() {
 }
 
 const styles = StyleSheet.create({
-  scroll: { flex: 1, backgroundColor: '#F4F0EA' },
+  scroll: { flex: 1, backgroundColor: colors.background },
   container: { padding: 24, paddingTop: 60, paddingBottom: 40 },
-  center: { flex: 1, backgroundColor: '#F4F0EA', justifyContent: 'center', alignItems: 'center' },
-  title: { fontSize: 40, fontFamily: 'SpaceGrotesk-Bold', fontWeight: '700', color: '#000', lineHeight: 48, marginBottom: 24 },
-  locationCard: { backgroundColor: '#4DF0FF', borderWidth: 2, borderColor: '#000', padding: 16, marginBottom: 24, shadowOffset: { width: 3, height: 3 }, shadowColor: '#000', shadowOpacity: 1, shadowRadius: 0 },
-  locationLabel: { fontSize: 12, fontFamily: 'SpaceGrotesk-Bold', fontWeight: '700', textTransform: 'uppercase', color: '#000', marginBottom: 4 },
-  locationText: { fontSize: 18, fontFamily: 'SpaceGrotesk-Bold', fontWeight: '700', color: '#000' },
-  stepCard: { backgroundColor: '#fff', borderWidth: 2, borderColor: '#000', padding: 16, marginBottom: 16, shadowOffset: { width: 3, height: 3 }, shadowColor: '#000', shadowOpacity: 1, shadowRadius: 0 },
+  center: { flex: 1, backgroundColor: colors.background, justifyContent: 'center', alignItems: 'center' },
+  title: { fontSize: 40, fontFamily: 'SpaceGrotesk-Bold', fontWeight: '700', color: colors.text, lineHeight: 48, marginBottom: 24 },
+  locationCard: { backgroundColor: colors.accent, borderWidth: 2, borderColor: colors.border, padding: 16, marginBottom: 24, shadowOffset: { width: 3, height: 3 }, shadowColor: colors.shadow, shadowOpacity: 1, shadowRadius: 0 },
+  locationLabel: { fontSize: 12, fontFamily: 'SpaceGrotesk-Bold', fontWeight: '700', textTransform: 'uppercase', color: colors.text, marginBottom: 4 },
+  locationText: { fontSize: 18, fontFamily: 'SpaceGrotesk-Bold', fontWeight: '700', color: colors.text },
+  stepCard: { backgroundColor: colors.surface, borderWidth: 2, borderColor: colors.border, padding: 16, marginBottom: 16, shadowOffset: { width: 3, height: 3 }, shadowColor: colors.shadow, shadowOpacity: 1, shadowRadius: 0 },
   stepCardDimmed: { opacity: 0.4 },
   stepHeader: { flexDirection: 'row', alignItems: 'center', marginBottom: 6 },
-  stepBadge: { width: 28, height: 28, borderRadius: 14, borderWidth: 2, borderColor: '#000', justifyContent: 'center', alignItems: 'center', marginRight: 10 },
-  stepBadgeTodo: { backgroundColor: '#fff' },
+  stepBadge: { width: 28, height: 28, borderRadius: 14, borderWidth: 2, borderColor: colors.border, justifyContent: 'center', alignItems: 'center', marginRight: 10 },
+  stepBadgeTodo: { backgroundColor: colors.surface },
   stepBadgeDone: { backgroundColor: colors.successStrong },
-  stepBadgeText: { fontSize: 12, fontFamily: 'SpaceGrotesk-Bold', fontWeight: '700', color: '#000' },
-  stepTitle: { fontSize: 18, fontFamily: 'SpaceGrotesk-Bold', fontWeight: '700', color: '#000' },
-  stepDesc: { fontSize: 13, color: '#555', marginBottom: 14, marginLeft: 38 },
+  stepBadgeText: { fontSize: 12, fontFamily: 'SpaceGrotesk-Bold', fontWeight: '700', color: colors.text },
+  stepTitle: { fontSize: 18, fontFamily: 'SpaceGrotesk-Bold', fontWeight: '700', color: colors.text },
+  stepDesc: { fontSize: 13, color: colors.textMuted, marginBottom: 14, marginLeft: 38 },
   selfieRow: { flexDirection: 'row', alignItems: 'center', gap: 12 },
-  selfieThumb: { width: 72, height: 72, borderWidth: 2, borderColor: '#000' },
-  retakeBtn: { borderWidth: 2, borderColor: '#000', paddingHorizontal: 16, paddingVertical: 8 },
-  retakeBtnText: { fontSize: 14, fontFamily: 'SpaceGrotesk-Bold', fontWeight: '700', color: '#000' },
-  cameraBtn: { backgroundColor: '#FF5A85', borderWidth: 2, borderColor: '#000', paddingVertical: 14, alignItems: 'center', shadowOffset: { width: 3, height: 3 }, shadowColor: '#000', shadowOpacity: 1, shadowRadius: 0 },
-  cameraBtnText: { fontSize: 16, fontFamily: 'SpaceGrotesk-Bold', fontWeight: '700', color: '#000' },
-  locationBtn: { backgroundColor: '#4DF0FF', borderWidth: 2, borderColor: '#000', paddingVertical: 14, alignItems: 'center', shadowOffset: { width: 3, height: 3 }, shadowColor: '#000', shadowOpacity: 1, shadowRadius: 0 },
-  locationBtnText: { fontSize: 16, fontFamily: 'SpaceGrotesk-Bold', fontWeight: '700', color: '#000' },
-  locationDoneRow: { backgroundColor: '#F4F0EA', borderWidth: 1, borderColor: '#ccc', padding: 10 },
-  locationDoneText: { fontSize: 14, fontFamily: 'SpaceGrotesk-Bold', color: '#000' },
-  checkinBtn: { backgroundColor: '#FF2A5F', borderWidth: 2, borderColor: '#000', paddingVertical: 20, alignItems: 'center', marginTop: 8, shadowOffset: { width: 4, height: 4 }, shadowColor: '#000', shadowOpacity: 1, shadowRadius: 0 },
+  selfieThumb: { width: 72, height: 72, borderWidth: 2, borderColor: colors.border },
+  retakeBtn: { borderWidth: 2, borderColor: colors.border, paddingHorizontal: 16, paddingVertical: 8 },
+  retakeBtnText: { fontSize: 14, fontFamily: 'SpaceGrotesk-Bold', fontWeight: '700', color: colors.text },
+  cameraBtn: { backgroundColor: colors.primaryLight, borderWidth: 2, borderColor: colors.border, paddingVertical: 14, alignItems: 'center', shadowOffset: { width: 3, height: 3 }, shadowColor: colors.shadow, shadowOpacity: 1, shadowRadius: 0 },
+  cameraBtnText: { fontSize: 16, fontFamily: 'SpaceGrotesk-Bold', fontWeight: '700', color: colors.text },
+  locationBtn: { backgroundColor: colors.accent, borderWidth: 2, borderColor: colors.border, paddingVertical: 14, alignItems: 'center', shadowOffset: { width: 3, height: 3 }, shadowColor: colors.shadow, shadowOpacity: 1, shadowRadius: 0 },
+  locationBtnText: { fontSize: 16, fontFamily: 'SpaceGrotesk-Bold', fontWeight: '700', color: colors.text },
+  locationDoneRow: { backgroundColor: colors.background, borderWidth: 1, borderColor: colors.borderLight, padding: 10 },
+  locationDoneText: { fontSize: 14, fontFamily: 'SpaceGrotesk-Bold', color: colors.text },
+  checkinBtn: { backgroundColor: colors.primary, borderWidth: 2, borderColor: colors.border, paddingVertical: 20, alignItems: 'center', marginTop: 8, shadowOffset: { width: 4, height: 4 }, shadowColor: colors.shadow, shadowOpacity: 1, shadowRadius: 0 },
   btnDisabled: { opacity: 0.4 },
-  checkinBtnText: { fontSize: 20, fontFamily: 'SpaceGrotesk-Bold', fontWeight: '700', color: '#fff' },
-  waitingCard: { backgroundColor: '#FF5A85', borderWidth: 2, borderColor: '#000', padding: 20, alignItems: 'center', shadowOffset: { width: 3, height: 3 }, shadowColor: '#000', shadowOpacity: 1, shadowRadius: 0, marginBottom: 24 },
-  waitingText: { fontSize: 20, fontFamily: 'SpaceGrotesk-Bold', fontWeight: '700', color: '#000' },
-  waitingSubtext: { fontSize: 14, color: '#000', marginTop: 8, textAlign: 'center' },
+  checkinBtnText: { fontSize: 20, fontFamily: 'SpaceGrotesk-Bold', fontWeight: '700', color: colors.textInverse },
+  waitingCard: { backgroundColor: colors.primaryLight, borderWidth: 2, borderColor: colors.border, padding: 20, alignItems: 'center', shadowOffset: { width: 3, height: 3 }, shadowColor: colors.shadow, shadowOpacity: 1, shadowRadius: 0, marginBottom: 24 },
+  waitingText: { fontSize: 20, fontFamily: 'SpaceGrotesk-Bold', fontWeight: '700', color: colors.text },
+  waitingSubtext: { fontSize: 14, color: colors.text, marginTop: 8, textAlign: 'center' },
   statusRow: { flexDirection: 'row', alignItems: 'center', justifyContent: 'center' },
-  dot: { width: 14, height: 14, borderRadius: 7, borderWidth: 2, borderColor: '#000' },
+  dot: { width: 14, height: 14, borderRadius: 7, borderWidth: 2, borderColor: colors.border },
   dotGreen: { backgroundColor: colors.successStrong },
-  dotGray: { backgroundColor: '#ccc' },
-  statusName: { fontSize: 14, fontFamily: 'SpaceGrotesk-Bold', marginLeft: 6, color: '#000' },
+  dotGray: { backgroundColor: colors.textLight },
+  statusName: { fontSize: 14, fontFamily: 'SpaceGrotesk-Bold', marginLeft: 6, color: colors.text },
 });

--- a/app/app/date/plan/[bookingId].tsx
+++ b/app/app/date/plan/[bookingId].tsx
@@ -5,6 +5,7 @@ import {
 } from 'react-native';
 import { useLocalSearchParams } from 'expo-router';
 import { activeDateApi } from '../../../src/services/activeDateApi';
+import { colors, spacing, typography } from '../../../src/constants/theme';
 
 interface Place {
   name: string;
@@ -74,7 +75,7 @@ export default function DatePlanScreen() {
 
   if (loading) return (
     <View style={styles.center}>
-      <ActivityIndicator color="#FF2A5F" size="large" />
+      <ActivityIndicator color={colors.primary} size="large" />
     </View>
   );
 
@@ -177,30 +178,30 @@ export default function DatePlanScreen() {
 }
 
 const styles = StyleSheet.create({
-  container: { flex: 1, backgroundColor: '#F4F0EA' },
-  center: { flex: 1, backgroundColor: '#F4F0EA', justifyContent: 'center', alignItems: 'center' },
-  list: { padding: 24, paddingBottom: 40 },
-  title: { fontSize: 28, fontFamily: 'SpaceGrotesk-Bold', fontWeight: '700', color: '#000', marginBottom: 20 },
-  placeCard: { flexDirection: 'row', alignItems: 'center', backgroundColor: '#fff', borderWidth: 2, borderColor: '#000', padding: 14, marginBottom: 10, shadowOffset: { width: 2, height: 2 }, shadowColor: '#000', shadowOpacity: 1, shadowRadius: 0 },
-  placeNum: { backgroundColor: '#FF2A5F', width: 32, height: 32, alignItems: 'center', justifyContent: 'center', borderWidth: 2, borderColor: '#000', marginRight: 12 },
-  placeNumText: { color: '#fff', fontFamily: 'SpaceGrotesk-Bold', fontWeight: '700', fontSize: 14 },
+  container: { flex: 1, backgroundColor: colors.background },
+  center: { flex: 1, backgroundColor: colors.background, justifyContent: 'center', alignItems: 'center' },
+  list: { padding: spacing.xl, paddingBottom: 40 },
+  title: { fontSize: typography.sizes.xl, fontFamily: typography.fonts.heading, fontWeight: '700', color: colors.text, marginBottom: spacing.lg },
+  placeCard: { flexDirection: 'row', alignItems: 'center', backgroundColor: colors.surface, borderWidth: 2, borderColor: colors.border, padding: 14, marginBottom: 10, shadowOffset: { width: 2, height: 2 }, shadowColor: colors.shadow, shadowOpacity: 1, shadowRadius: 0 },
+  placeNum: { backgroundColor: colors.primary, width: 32, height: 32, alignItems: 'center', justifyContent: 'center', borderWidth: 2, borderColor: colors.border, marginRight: 12 },
+  placeNumText: { color: colors.textInverse, fontFamily: typography.fonts.heading, fontWeight: '700', fontSize: typography.sizes.sm },
   placeInfo: { flex: 1 },
-  placeName: { fontSize: 16, fontFamily: 'SpaceGrotesk-Bold', fontWeight: '700', color: '#000' },
-  placeAddress: { fontSize: 13, color: '#555', marginTop: 2 },
-  placeTime: { fontSize: 13, color: '#FF2A5F', marginTop: 4, fontFamily: 'SpaceGrotesk-Bold' },
-  removeBtn: { padding: 8 },
-  removeText: { fontSize: 18, color: '#FF2A5F', fontFamily: 'SpaceGrotesk-Bold' },
+  placeName: { fontSize: typography.sizes.md, fontFamily: typography.fonts.heading, fontWeight: '700', color: colors.text },
+  placeAddress: { fontSize: typography.sizes.sm, color: colors.textMuted, marginTop: 2 },
+  placeTime: { fontSize: typography.sizes.sm, color: colors.primary, marginTop: 4, fontFamily: typography.fonts.heading },
+  removeBtn: { padding: spacing.sm },
+  removeText: { fontSize: 18, color: colors.primary, fontFamily: typography.fonts.heading },
   empty: { alignItems: 'center', paddingVertical: 40 },
-  emptyText: { fontSize: 20, fontFamily: 'SpaceGrotesk-Bold', fontWeight: '700', color: '#000' },
-  emptySubtext: { fontSize: 14, color: '#555', marginTop: 8 },
-  addBtn: { backgroundColor: '#4DF0FF', borderWidth: 2, borderColor: '#000', paddingVertical: 16, alignItems: 'center', marginTop: 8, shadowOffset: { width: 3, height: 3 }, shadowColor: '#000', shadowOpacity: 1, shadowRadius: 0 },
-  addBtnText: { fontSize: 16, fontFamily: 'SpaceGrotesk-Bold', fontWeight: '700', color: '#000' },
-  addForm: { backgroundColor: '#fff', borderWidth: 2, borderColor: '#000', padding: 16, marginTop: 8 },
-  input: { borderWidth: 2, borderColor: '#000', padding: 12, fontSize: 15, marginBottom: 10, backgroundColor: '#F4F0EA' },
+  emptyText: { fontSize: typography.sizes.lg, fontFamily: typography.fonts.heading, fontWeight: '700', color: colors.text },
+  emptySubtext: { fontSize: typography.sizes.sm, color: colors.textMuted, marginTop: spacing.sm },
+  addBtn: { backgroundColor: colors.accent, borderWidth: 2, borderColor: colors.border, paddingVertical: spacing.md, alignItems: 'center', marginTop: spacing.sm, shadowOffset: { width: 3, height: 3 }, shadowColor: colors.shadow, shadowOpacity: 1, shadowRadius: 0 },
+  addBtnText: { fontSize: typography.sizes.md, fontFamily: typography.fonts.heading, fontWeight: '700', color: colors.text },
+  addForm: { backgroundColor: colors.surface, borderWidth: 2, borderColor: colors.border, padding: spacing.md, marginTop: spacing.sm },
+  input: { borderWidth: 2, borderColor: colors.border, padding: 12, fontSize: typography.sizes.md, marginBottom: spacing.sm, backgroundColor: colors.background },
   formBtns: { flexDirection: 'row', gap: 10 },
-  saveBtn: { flex: 1, backgroundColor: '#FF2A5F', borderWidth: 2, borderColor: '#000', paddingVertical: 12, alignItems: 'center' },
-  saveBtnText: { fontSize: 15, fontFamily: 'SpaceGrotesk-Bold', fontWeight: '700', color: '#fff' },
-  cancelBtn: { flex: 1, backgroundColor: '#fff', borderWidth: 2, borderColor: '#000', paddingVertical: 12, alignItems: 'center' },
-  cancelText: { fontSize: 15, color: '#000' },
+  saveBtn: { flex: 1, backgroundColor: colors.primary, borderWidth: 2, borderColor: colors.border, paddingVertical: 12, alignItems: 'center' },
+  saveBtnText: { fontSize: typography.sizes.md, fontFamily: typography.fonts.heading, fontWeight: '700', color: colors.textInverse },
+  cancelBtn: { flex: 1, backgroundColor: colors.surface, borderWidth: 2, borderColor: colors.border, paddingVertical: 12, alignItems: 'center' },
+  cancelText: { fontSize: typography.sizes.md, color: colors.text },
   btnDisabled: { opacity: 0.6 },
 });


### PR DESCRIPTION
## Summary
- **browse.tsx**: replace 6x hardcoded `#000000` borderColor/shadowColor with `colors.border`/`colors.shadow`
- **plan/[bookingId].tsx**: add theme import, replace all hardcoded hex colors (`#FF2A5F`, `#4DF0FF`, `#F4F0EA`, `#000`, `#fff`, `#555`) and raw spacing/font values with theme tokens
- **companion-checkin/[bookingId].tsx**: replace all hardcoded hex colors with `colors.*` tokens (primary, accent, background, surface, border, shadow, text, textMuted, textInverse, primaryLight, borderLight, textLight)

Total: ~27 hardcoded values replaced across 3 files. Part of brand consistency audit.

Fixes #1252.