### PR TITLE
[#815] Add selfie verification MVP for Active Date

### DIFF
--- a/app/app/date/checkin/[bookingId].tsx
+++ b/app/app/date/checkin/[bookingId].tsx
@@ -25,6 +25,7 @@ export default function SeekerCheckinScreen() {
   const [step, setStep] = useState<Step>('selfie');
 
   const [selfieUri, setSelfieUri] = useState<string | null>(null);
+  const [selfieUploadStatus, setSelfieUploadStatus] = useState<'idle' | 'uploading' | 'done' | 'failed'>('idle');
   const [coords, setCoords] = useState<{ lat: number; lon: number } | null>(null);
   const [locationStatus, setLocationStatus] = useState<'idle' | 'loading' | 'done' | 'denied'>('idle');
 
@@ -74,8 +75,28 @@ export default function SeekerCheckinScreen() {
       cameraType: ImagePicker.CameraType.front,
     });
     if (!result.canceled && result.assets[0]) {
-      setSelfieUri(result.assets[0].uri);
+      const uri = result.assets[0].uri;
+      setSelfieUri(uri);
+      setSelfieUploadStatus('uploading');
+      try {
+        await activeDateApi.uploadSelfie(bookingId, uri);
+        setSelfieUploadStatus('done');
+      } catch (_e) {
+        // Graceful degradation: upload failed, show warning but allow proceeding
+        setSelfieUploadStatus('failed');
+      }
       setStep('location');
+    }
+  };
+
+  const handleRetrySelfieUpload = async () => {
+    if (!selfieUri) return;
+    setSelfieUploadStatus('uploading');
+    try {
+      await activeDateApi.uploadSelfie(bookingId, selfieUri);
+      setSelfieUploadStatus('done');
+    } catch (_e) {
+      setSelfieUploadStatus('failed');
     }
   };
 
@@ -161,34 +182,59 @@ export default function SeekerCheckinScreen() {
       {/* Step 1: Selfie */}
       <View style={styles.stepCard}>
         <View style={styles.stepHeader}>
-          <View style={[styles.stepBadge, selfieUri ? styles.stepBadgeDone : styles.stepBadgeTodo]}>
-            <Text style={styles.stepBadgeText}>{selfieUri ? '✓' : '1'}</Text>
+          <View style={[styles.stepBadge, selfieUploadStatus === 'done' ? styles.stepBadgeDone : styles.stepBadgeTodo]}>
+            <Text style={styles.stepBadgeText}>{selfieUploadStatus === 'done' ? '✓' : '1'}</Text>
           </View>
           <Text style={styles.stepTitle}>Take a Selfie</Text>
         </View>
         <Text style={styles.stepDesc}>Verify your identity at the location</Text>
         {selfieUri ? (
-          <View style={styles.selfieRow}>
-            <Image source={{ uri: selfieUri }} style={styles.selfieThumb} />
-            <TouchableOpacity style={styles.retakeBtn} onPress={handleTakeSelfie}
-              accessibilityLabel="Retake selfie"
-              accessibilityRole="button"
-            >
-              <Text style={styles.retakeBtnText}>Retake</Text>
-            </TouchableOpacity>
+          <View>
+            <View style={styles.selfieRow}>
+              <Image source={{ uri: selfieUri }} style={styles.selfieThumb} />
+              <View style={styles.selfieActions}>
+                {selfieUploadStatus === 'uploading' && (
+                  <View style={styles.uploadingRow}>
+                    <ActivityIndicator color="#FF2A5F" size="small" />
+                    <Text style={styles.uploadingText}>Uploading...</Text>
+                  </View>
+                )}
+                {selfieUploadStatus === 'done' && (
+                  <Text style={styles.uploadDoneText}>Uploaded</Text>
+                )}
+                {selfieUploadStatus === 'failed' && (
+                  <View>
+                    <Text style={styles.uploadFailText}>Upload failed</Text>
+                    <TouchableOpacity style={styles.retryBtn} onPress={handleRetrySelfieUpload}
+                      accessibilityLabel="Retry selfie upload"
+                      accessibilityRole="button"
+                    >
+                      <Text style={styles.retakeBtnText}>Retry</Text>
+                    </TouchableOpacity>
+                  </View>
+                )}
+                <TouchableOpacity style={[styles.retakeBtn, selfieUploadStatus === 'uploading' && styles.btnDisabled]}
+                  onPress={selfieUploadStatus === 'uploading' ? undefined : handleTakeSelfie}
+                  accessibilityLabel="Retake selfie"
+                  accessibilityRole="button"
+                >
+                  <Text style={styles.retakeBtnText}>Retake</Text>
+                </TouchableOpacity>
+              </View>
+            </View>
           </View>
         ) : (
           <TouchableOpacity style={styles.cameraBtn} onPress={handleTakeSelfie}
             accessibilityLabel="Open camera for selfie"
             accessibilityRole="button"
           >
-            <Text style={styles.cameraBtnText}>📸  Open Camera</Text>
+            <Text style={styles.cameraBtnText}>Open Camera</Text>
           </TouchableOpacity>
         )}
       </View>
 
       {/* Step 2: Location */}
-      <View style={[styles.stepCard, step === 'selfie' && styles.stepCardDimmed]}>
+      <View style={[styles.stepCard, !selfieUri && styles.stepCardDimmed]}>
         <View style={styles.stepHeader}>
           <View style={[styles.stepBadge, locationStatus === 'done' ? styles.stepBadgeDone : styles.stepBadgeTodo]}>
             <Text style={styles.stepBadgeText}>{locationStatus === 'done' ? '✓' : '2'}</Text>
@@ -198,24 +244,24 @@ export default function SeekerCheckinScreen() {
         <Text style={styles.stepDesc}>Confirm you're at the meeting spot</Text>
         {locationStatus === 'done' ? (
           <View style={styles.locationDoneRow}>
-            <Text style={styles.locationDoneText}>📍 Location captured</Text>
+            <Text style={styles.locationDoneText}>Location captured</Text>
           </View>
         ) : locationStatus === 'denied' ? (
           <View style={styles.locationDoneRow}>
-            <Text style={styles.locationDoneText}>⚠️ Location skipped</Text>
+            <Text style={styles.locationDoneText}>Location skipped</Text>
           </View>
         ) : (
           <TouchableOpacity
-            style={[styles.locationBtn, (step === 'selfie' || locationStatus === 'loading') && styles.btnDisabled]}
+            style={[styles.locationBtn, (!selfieUri || locationStatus === 'loading') && styles.btnDisabled]}
             onPress={handleGetLocation}
-            disabled={step === 'selfie' || locationStatus === 'loading'}
+            disabled={!selfieUri || locationStatus === 'loading'}
             accessibilityLabel="Get current location"
             accessibilityRole="button"
-            accessibilityState={{ disabled: step === 'selfie' || locationStatus === 'loading' }}
+            accessibilityState={{ disabled: !selfieUri || locationStatus === 'loading' }}
           >
             {locationStatus === 'loading'
               ? <ActivityIndicator color="#000" size="small" />
-              : <Text style={styles.locationBtnText}>📍  Get Location</Text>
+              : <Text style={styles.locationBtnText}>Get Location</Text>
             }
           </TouchableOpacity>
         )}
@@ -256,8 +302,14 @@ const styles = StyleSheet.create({
   stepBadgeText: { fontSize: 12, fontFamily: 'SpaceGrotesk-Bold', fontWeight: '700', color: '#000' },
   stepTitle: { fontSize: 18, fontFamily: 'SpaceGrotesk-Bold', fontWeight: '700', color: '#000' },
   stepDesc: { fontSize: 13, color: '#555', marginBottom: 14, marginLeft: 38 },
-  selfieRow: { flexDirection: 'row', alignItems: 'center', gap: 12 },
+  selfieRow: { flexDirection: 'row', alignItems: 'flex-start', gap: 12 },
   selfieThumb: { width: 72, height: 72, borderWidth: 2, borderColor: '#000' },
+  selfieActions: { flex: 1, gap: 8 },
+  uploadingRow: { flexDirection: 'row', alignItems: 'center', gap: 6 },
+  uploadingText: { fontSize: 13, fontFamily: 'SpaceGrotesk-Bold', color: '#555' },
+  uploadDoneText: { fontSize: 13, fontFamily: 'SpaceGrotesk-Bold', color: '#16a34a' },
+  uploadFailText: { fontSize: 13, fontFamily: 'SpaceGrotesk-Bold', color: '#dc2626', marginBottom: 6 },
+  retryBtn: { borderWidth: 2, borderColor: '#dc2626', paddingHorizontal: 12, paddingVertical: 6, marginBottom: 6 },
   retakeBtn: { borderWidth: 2, borderColor: '#000', paddingHorizontal: 16, paddingVertical: 8 },
   retakeBtnText: { fontSize: 14, fontFamily: 'SpaceGrotesk-Bold', fontWeight: '700', color: '#000' },
   cameraBtn: { backgroundColor: '#FF5A85', borderWidth: 2, borderColor: '#000', paddingVertical: 14, alignItems: 'center', shadowOffset: { width: 3, height: 3 }, shadowColor: '#000', shadowOpacity: 1, shadowRadius: 0 },

--- a/app/app/date/companion-checkin/[bookingId].tsx
+++ b/app/app/date/companion-checkin/[bookingId].tsx
@@ -25,6 +25,7 @@ export default function CompanionCheckinScreen() {
   const [step, setStep] = useState<Step>('selfie');
 
   const [selfieUri, setSelfieUri] = useState<string | null>(null);
+  const [selfieUploadStatus, setSelfieUploadStatus] = useState<'idle' | 'uploading' | 'done' | 'failed'>('idle');
   const [coords, setCoords] = useState<{ lat: number; lon: number } | null>(null);
   const [locationStatus, setLocationStatus] = useState<'idle' | 'loading' | 'done' | 'denied'>('idle');
 
@@ -74,8 +75,28 @@ export default function CompanionCheckinScreen() {
       cameraType: ImagePicker.CameraType.front,
     });
     if (!result.canceled && result.assets[0]) {
-      setSelfieUri(result.assets[0].uri);
+      const uri = result.assets[0].uri;
+      setSelfieUri(uri);
+      setSelfieUploadStatus('uploading');
+      try {
+        await activeDateApi.uploadSelfie(bookingId, uri);
+        setSelfieUploadStatus('done');
+      } catch (_e) {
+        // Graceful degradation: upload failed, show warning but allow proceeding
+        setSelfieUploadStatus('failed');
+      }
       setStep('location');
+    }
+  };
+
+  const handleRetrySelfieUpload = async () => {
+    if (!selfieUri) return;
+    setSelfieUploadStatus('uploading');
+    try {
+      await activeDateApi.uploadSelfie(bookingId, selfieUri);
+      setSelfieUploadStatus('done');
+    } catch (_e) {
+      setSelfieUploadStatus('failed');
     }
   };
 
@@ -161,34 +182,59 @@ export default function CompanionCheckinScreen() {
       {/* Step 1: Selfie */}
       <View style={styles.stepCard}>
         <View style={styles.stepHeader}>
-          <View style={[styles.stepBadge, selfieUri ? styles.stepBadgeDone : styles.stepBadgeTodo]}>
-            <Text style={styles.stepBadgeText}>{selfieUri ? '✓' : '1'}</Text>
+          <View style={[styles.stepBadge, selfieUploadStatus === 'done' ? styles.stepBadgeDone : styles.stepBadgeTodo]}>
+            <Text style={styles.stepBadgeText}>{selfieUploadStatus === 'done' ? '✓' : '1'}</Text>
           </View>
           <Text style={styles.stepTitle}>Take a Selfie</Text>
         </View>
         <Text style={styles.stepDesc}>Verify your identity at the location</Text>
         {selfieUri ? (
-          <View style={styles.selfieRow}>
-            <Image source={{ uri: selfieUri }} style={styles.selfieThumb} />
-            <TouchableOpacity style={styles.retakeBtn} onPress={handleTakeSelfie}
-              accessibilityLabel="Retake selfie"
-              accessibilityRole="button"
-            >
-              <Text style={styles.retakeBtnText}>Retake</Text>
-            </TouchableOpacity>
+          <View>
+            <View style={styles.selfieRow}>
+              <Image source={{ uri: selfieUri }} style={styles.selfieThumb} />
+              <View style={styles.selfieActions}>
+                {selfieUploadStatus === 'uploading' && (
+                  <View style={styles.uploadingRow}>
+                    <ActivityIndicator color="#FF2A5F" size="small" />
+                    <Text style={styles.uploadingText}>Uploading...</Text>
+                  </View>
+                )}
+                {selfieUploadStatus === 'done' && (
+                  <Text style={styles.uploadDoneText}>Uploaded</Text>
+                )}
+                {selfieUploadStatus === 'failed' && (
+                  <View>
+                    <Text style={styles.uploadFailText}>Upload failed</Text>
+                    <TouchableOpacity style={styles.retryBtn} onPress={handleRetrySelfieUpload}
+                      accessibilityLabel="Retry selfie upload"
+                      accessibilityRole="button"
+                    >
+                      <Text style={styles.retakeBtnText}>Retry</Text>
+                    </TouchableOpacity>
+                  </View>
+                )}
+                <TouchableOpacity style={[styles.retakeBtn, selfieUploadStatus === 'uploading' && styles.btnDisabled]}
+                  onPress={selfieUploadStatus === 'uploading' ? undefined : handleTakeSelfie}
+                  accessibilityLabel="Retake selfie"
+                  accessibilityRole="button"
+                >
+                  <Text style={styles.retakeBtnText}>Retake</Text>
+                </TouchableOpacity>
+              </View>
+            </View>
           </View>
         ) : (
           <TouchableOpacity style={styles.cameraBtn} onPress={handleTakeSelfie}
             accessibilityLabel="Open camera for selfie"
             accessibilityRole="button"
           >
-            <Text style={styles.cameraBtnText}>📸  Open Camera</Text>
+            <Text style={styles.cameraBtnText}>Open Camera</Text>
           </TouchableOpacity>
         )}
       </View>
 
       {/* Step 2: Location */}
-      <View style={[styles.stepCard, step === 'selfie' && styles.stepCardDimmed]}>
+      <View style={[styles.stepCard, !selfieUri && styles.stepCardDimmed]}>
         <View style={styles.stepHeader}>
           <View style={[styles.stepBadge, locationStatus === 'done' ? styles.stepBadgeDone : styles.stepBadgeTodo]}>
             <Text style={styles.stepBadgeText}>{locationStatus === 'done' ? '✓' : '2'}</Text>
@@ -198,24 +244,24 @@ export default function CompanionCheckinScreen() {
         <Text style={styles.stepDesc}>Confirm you're at the meeting spot</Text>
         {locationStatus === 'done' ? (
           <View style={styles.locationDoneRow}>
-            <Text style={styles.locationDoneText}>📍 Location captured</Text>
+            <Text style={styles.locationDoneText}>Location captured</Text>
           </View>
         ) : locationStatus === 'denied' ? (
           <View style={styles.locationDoneRow}>
-            <Text style={styles.locationDoneText}>⚠️ Location skipped</Text>
+            <Text style={styles.locationDoneText}>Location skipped</Text>
           </View>
         ) : (
           <TouchableOpacity
-            style={[styles.locationBtn, (step === 'selfie' || locationStatus === 'loading') && styles.btnDisabled]}
+            style={[styles.locationBtn, (!selfieUri || locationStatus === 'loading') && styles.btnDisabled]}
             onPress={handleGetLocation}
-            disabled={step === 'selfie' || locationStatus === 'loading'}
+            disabled={!selfieUri || locationStatus === 'loading'}
             accessibilityLabel="Get current location"
             accessibilityRole="button"
-            accessibilityState={{ disabled: step === 'selfie' || locationStatus === 'loading' }}
+            accessibilityState={{ disabled: !selfieUri || locationStatus === 'loading' }}
           >
             {locationStatus === 'loading'
               ? <ActivityIndicator color="#000" size="small" />
-              : <Text style={styles.locationBtnText}>📍  Get Location</Text>
+              : <Text style={styles.locationBtnText}>Get Location</Text>
             }
           </TouchableOpacity>
         )}
@@ -256,8 +302,14 @@ const styles = StyleSheet.create({
   stepBadgeText: { fontSize: 12, fontFamily: 'SpaceGrotesk-Bold', fontWeight: '700', color: colors.text },
   stepTitle: { fontSize: 18, fontFamily: 'SpaceGrotesk-Bold', fontWeight: '700', color: colors.text },
   stepDesc: { fontSize: 13, color: colors.textMuted, marginBottom: 14, marginLeft: 38 },
-  selfieRow: { flexDirection: 'row', alignItems: 'center', gap: 12 },
+  selfieRow: { flexDirection: 'row', alignItems: 'flex-start', gap: 12 },
   selfieThumb: { width: 72, height: 72, borderWidth: 2, borderColor: colors.border },
+  selfieActions: { flex: 1, gap: 8 },
+  uploadingRow: { flexDirection: 'row', alignItems: 'center', gap: 6 },
+  uploadingText: { fontSize: 13, fontFamily: 'SpaceGrotesk-Bold', color: colors.textMuted },
+  uploadDoneText: { fontSize: 13, fontFamily: 'SpaceGrotesk-Bold', color: colors.successStrong },
+  uploadFailText: { fontSize: 13, fontFamily: 'SpaceGrotesk-Bold', color: colors.error, marginBottom: 6 },
+  retryBtn: { borderWidth: 2, borderColor: colors.error, paddingHorizontal: 12, paddingVertical: 6, marginBottom: 6 },
   retakeBtn: { borderWidth: 2, borderColor: colors.border, paddingHorizontal: 16, paddingVertical: 8 },
   retakeBtnText: { fontSize: 14, fontFamily: 'SpaceGrotesk-Bold', fontWeight: '700', color: colors.text },
   cameraBtn: { backgroundColor: colors.primaryLight, borderWidth: 2, borderColor: colors.border, paddingVertical: 14, alignItems: 'center', shadowOffset: { width: 3, height: 3 }, shadowColor: colors.shadow, shadowOpacity: 1, shadowRadius: 0 },

--- a/app/src/services/activeDateApi.ts
+++ b/app/src/services/activeDateApi.ts
@@ -109,4 +109,19 @@ export const activeDateApi = {
       method: 'POST',
       body: { type, text: description },
     }),
+
+  uploadSelfie: async (bookingId: string, uri: string): Promise<{ id: string; photoUrl: string }> => {
+    const token = await getToken();
+    const formData = new FormData();
+    const ext = uri.split('.').pop() || 'jpg';
+    formData.append('file', { uri, type: `image/${ext === 'jpg' ? 'jpeg' : ext}`, name: `selfie.${ext}` } as any);
+    const resp = await fetch(`${API_BASE}/bookings/${bookingId}/verify-selfie/upload`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}` },
+      body: formData,
+    });
+    const data = await resp.json();
+    if (!resp.ok) throw new Error(data.message || 'Selfie upload failed');
+    return data;
+  },
 };

--- a/backend/daterabbit-api/src/bookings/bookings.controller.ts
+++ b/backend/daterabbit-api/src/bookings/bookings.controller.ts
@@ -1,6 +1,8 @@
-import { Controller, Get, Post, Put, Body, Param, Query, UseGuards, Request, HttpException, HttpStatus, ParseUUIDPipe } from '@nestjs/common';
+import { Controller, Get, Post, Put, Body, Param, Query, UseGuards, Request, HttpException, HttpStatus, ParseUUIDPipe, UseInterceptors, UploadedFile, BadRequestException } from '@nestjs/common';
+import { FileInterceptor } from '@nestjs/platform-express';
 import { BookingsService } from './bookings.service';
 import { PaymentsService } from '../payments/payments.service';
+import { UploadsService } from '../uploads/uploads.service';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { BookingStatus, ActivityType } from './entities/booking.entity';
 import { NotificationsService } from '../notifications/notifications.service';
@@ -13,6 +15,7 @@ export class BookingsController {
     private bookingsService: BookingsService,
     private paymentsService: PaymentsService,
     private notificationsService: NotificationsService,
+    private uploadsService: UploadsService,
   ) {}
 
   @Post()
@@ -353,6 +356,25 @@ export class BookingsController {
   }
 
   // --- UC-061: Selfie verification ---
+
+  /**
+   * Multipart upload: POST /bookings/:id/verify-selfie/upload
+   * Accepts `file` (image), saves to uploads/selfies/, then records selfie verification.
+   */
+  @Post(':id/verify-selfie/upload')
+  @UseInterceptors(FileInterceptor('file'))
+  async uploadSelfieFile(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Request() req,
+    @UploadedFile() file: Express.Multer.File,
+  ) {
+    if (!file) {
+      throw new BadRequestException('No file provided');
+    }
+    this.uploadsService.validateImageFile(file);
+    const photoUrl = this.uploadsService.getFileUrl('selfies', file.filename);
+    return this.bookingsService.submitSelfie(id, req.user.id, photoUrl);
+  }
 
   @Post(':id/verify-selfie')
   async submitSelfie(

--- a/backend/daterabbit-api/src/bookings/bookings.module.ts
+++ b/backend/daterabbit-api/src/bookings/bookings.module.ts
@@ -1,5 +1,10 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { MulterModule } from '@nestjs/platform-express';
+import * as crypto from 'crypto';
+import * as multer from 'multer';
+import * as path from 'path';
+import * as fs from 'fs';
 import { Booking } from './entities/booking.entity';
 import { DatePhoto } from './entities/date-photo.entity';
 import { SelfieVerification } from './entities/selfie-verification.entity';
@@ -10,9 +15,33 @@ import { UsersModule } from '../users/users.module';
 import { EmailModule } from '../email/email.module';
 import { PaymentsModule } from '../payments/payments.module';
 import { NotificationsModule } from '../notifications/notifications.module';
+import { UploadsModule } from '../uploads/uploads.module';
+
+const UPLOADS_ROOT = path.join(process.cwd(), 'uploads');
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Booking, DatePhoto, SelfieVerification]), UsersModule, EmailModule, PaymentsModule, NotificationsModule],
+  imports: [
+    TypeOrmModule.forFeature([Booking, DatePhoto, SelfieVerification]),
+    MulterModule.register({
+      limits: { fileSize: 10 * 1024 * 1024 }, // 10MB max
+      storage: multer.diskStorage({
+        destination: (_req, _file, cb) => {
+          const dest = path.join(UPLOADS_ROOT, 'selfies');
+          fs.mkdirSync(dest, { recursive: true });
+          cb(null, dest);
+        },
+        filename: (_req, file, cb) => {
+          const ext = path.extname(file.originalname).toLowerCase() || '.jpg';
+          cb(null, `${crypto.randomUUID()}${ext}`);
+        },
+      }),
+    }),
+    UsersModule,
+    EmailModule,
+    PaymentsModule,
+    NotificationsModule,
+    UploadsModule,
+  ],
   providers: [BookingsService, BookingsCron],
   controllers: [BookingsController],
   exports: [BookingsService],


### PR DESCRIPTION
## Summary

- Backend: `POST /bookings/:id/verify-selfie/upload` — multipart endpoint, saves to `uploads/selfies/`, calls existing `submitSelfie` service (auto-verified, sets `selfieVerified=true` when both submitted)
- Backend: Added `MulterModule` (selfies/ folder) + `UploadsModule` to `BookingsModule`
- Frontend: `activeDateApi.uploadSelfie()` — multipart POST, same pattern as `uploadPhoto`
- Frontend: Both checkin screens now upload selfie immediately after capture with uploading/done/failed UI states
- Graceful degradation: upload failure shows warning + Retry button, does NOT block check-in

## No AI face matching. No auto-approval UI. No blocking on upload failure.

Fixes #815