### PR TITLE
feat: end-early flow + post-date summary screen (#706)

### DIFF
--- a/app/app/date/summary/[bookingId].tsx
+++ b/app/app/date/summary/[bookingId].tsx
@@ -2,31 +2,47 @@ import React, { useState, useEffect } from 'react';
 import { View, Text, StyleSheet, TouchableOpacity, ScrollView, Image, FlatList } from 'react-native';
 import { useLocalSearchParams, router } from 'expo-router';
 import { activeDateApi, ActiveBooking } from '../../../src/services/activeDateApi';
+import { useAuthStore } from '../../../src/store/authStore';
+
+const STARS = [1, 2, 3, 4, 5];
 
 export default function DateSummaryScreen() {
   const { bookingId } = useLocalSearchParams<{ bookingId: string }>();
   const [booking, setBooking] = useState<ActiveBooking | null>(null);
   const [photos, setPhotos] = useState<{ id: string; url: string }[]>([]);
+  const [rating, setRating] = useState(0);
+  const user = useAuthStore(s => s.user);
 
   useEffect(() => {
     activeDateApi.getBookingById(bookingId).then(setBooking).catch(() => {});
     activeDateApi.getPhotos(bookingId).then(r => setPhotos(r.photos)).catch(() => {});
   }, [bookingId]);
 
+  const isCompanion = user?.role === 'companion';
   const duration = booking?.actualDurationHours ?? booking?.duration ?? 0;
+  const bookedDuration = booking?.duration ?? 0;
+  const endedEarly = booking?.actualDurationHours != null && Number(booking.actualDurationHours) < Number(bookedDuration);
   const price = booking?.totalPrice ?? 0;
+
+  // Role-based "With" name: seeker sees companion, companion sees seeker
+  const withName = isCompanion ? booking?.seeker?.name : booking?.companion?.name;
 
   return (
     <ScrollView style={styles.container} contentContainerStyle={styles.content}>
       <View style={styles.banner}>
         <Text style={styles.bannerText}>Date Complete!</Text>
+        {endedEarly && (
+          <View style={styles.earlyBadge}>
+            <Text style={styles.earlyBadgeText}>Ended Early</Text>
+          </View>
+        )}
       </View>
 
       {booking && (
         <View style={styles.card}>
           <View style={styles.row}>
             <Text style={styles.label}>With</Text>
-            <Text style={styles.value}>{booking.companion?.name}</Text>
+            <Text style={styles.value}>{withName}</Text>
           </View>
           <View style={styles.divider} />
           <View style={styles.row}>
@@ -45,12 +61,35 @@ export default function DateSummaryScreen() {
           <View style={styles.divider} />
           <View style={styles.row}>
             <Text style={styles.label}>Duration</Text>
-            <Text style={styles.value}>{duration}h</Text>
+            <Text style={styles.value}>
+              {Number(duration).toFixed(2)}h{endedEarly ? ` of ${bookedDuration}h booked` : ''}
+            </Text>
           </View>
           <View style={styles.divider} />
           <View style={styles.row}>
             <Text style={styles.label}>Total</Text>
             <Text style={[styles.value, styles.price]}>${Number(price).toFixed(2)}</Text>
+          </View>
+        </View>
+      )}
+
+      {/* Star rating prompt — for seekers only */}
+      {!isCompanion && (
+        <View style={styles.ratingSection}>
+          <Text style={styles.sectionTitle}>How was your date?</Text>
+          <View style={styles.starsRow}>
+            {STARS.map(star => (
+              <TouchableOpacity
+                key={star}
+                onPress={() => setRating(star)}
+                accessibilityLabel={`Rate ${star} star${star > 1 ? 's' : ''}`}
+                accessibilityRole="button"
+              >
+                <Text style={[styles.star, rating >= star && styles.starActive]}>
+                  {rating >= star ? '★' : '☆'}
+                </Text>
+              </TouchableOpacity>
+            ))}
           </View>
         </View>
       )}
@@ -79,6 +118,18 @@ export default function DateSummaryScreen() {
         <Text style={styles.reviewBtnText}>Leave a Review</Text>
       </TouchableOpacity>
 
+      {/* Book Again — seeker only, navigates to browse tab */}
+      {!isCompanion && (
+        <TouchableOpacity
+          style={styles.bookAgainBtn}
+          onPress={() => router.replace('/(tabs)/male/browse' as any)}
+          accessibilityLabel="Book again"
+          accessibilityRole="button"
+        >
+          <Text style={styles.bookAgainBtnText}>Book Again</Text>
+        </TouchableOpacity>
+      )}
+
       <TouchableOpacity
         style={styles.homeBtn}
         onPress={() => router.replace('/(tabs)' as any)}
@@ -96,17 +147,25 @@ const styles = StyleSheet.create({
   content: { padding: 24, paddingTop: 40 },
   banner: { backgroundColor: '#FF5A85', borderWidth: 2, borderColor: '#000', padding: 20, alignItems: 'center', marginBottom: 32, shadowOffset: { width: 4, height: 4 }, shadowColor: '#000', shadowOpacity: 1, shadowRadius: 0 },
   bannerText: { fontSize: 32, fontFamily: 'SpaceGrotesk-Bold', fontWeight: '700', color: '#000' },
+  earlyBadge: { backgroundColor: '#000', paddingHorizontal: 12, paddingVertical: 4, marginTop: 8 },
+  earlyBadgeText: { fontSize: 12, fontFamily: 'SpaceGrotesk-Bold', fontWeight: '700', color: '#FF5A85', letterSpacing: 1 },
   card: { backgroundColor: '#fff', borderWidth: 2, borderColor: '#000', marginBottom: 32, shadowOffset: { width: 3, height: 3 }, shadowColor: '#000', shadowOpacity: 1, shadowRadius: 0 },
   row: { flexDirection: 'row', justifyContent: 'space-between', padding: 16 },
   divider: { height: 2, backgroundColor: '#000' },
   label: { fontSize: 14, color: '#555' },
-  value: { fontSize: 15, fontFamily: 'SpaceGrotesk-Bold', fontWeight: '700', color: '#000' },
+  value: { fontSize: 15, fontFamily: 'SpaceGrotesk-Bold', fontWeight: '700', color: '#000', flexShrink: 1, textAlign: 'right', marginLeft: 8 },
   price: { fontSize: 18, color: '#FF2A5F' },
-  photosSection: { marginBottom: 32 },
+  ratingSection: { marginBottom: 32 },
   sectionTitle: { fontSize: 20, fontFamily: 'SpaceGrotesk-Bold', fontWeight: '700', color: '#000', marginBottom: 12 },
+  starsRow: { flexDirection: 'row', gap: 8 },
+  star: { fontSize: 40, color: '#ccc' },
+  starActive: { color: '#FF2A5F' },
+  photosSection: { marginBottom: 32 },
   photo: { width: 120, height: 120, borderWidth: 2, borderColor: '#000', marginRight: 12 },
   reviewBtn: { backgroundColor: '#FF2A5F', borderWidth: 2, borderColor: '#000', paddingVertical: 18, alignItems: 'center', marginBottom: 12, shadowOffset: { width: 4, height: 4 }, shadowColor: '#000', shadowOpacity: 1, shadowRadius: 0 },
   reviewBtnText: { fontSize: 18, fontFamily: 'SpaceGrotesk-Bold', fontWeight: '700', color: '#fff' },
+  bookAgainBtn: { backgroundColor: '#4DF0FF', borderWidth: 2, borderColor: '#000', paddingVertical: 16, alignItems: 'center', marginBottom: 12, shadowOffset: { width: 3, height: 3 }, shadowColor: '#000', shadowOpacity: 1, shadowRadius: 0 },
+  bookAgainBtnText: { fontSize: 16, fontFamily: 'SpaceGrotesk-Bold', fontWeight: '700', color: '#000' },
   homeBtn: { backgroundColor: '#fff', borderWidth: 2, borderColor: '#000', paddingVertical: 16, alignItems: 'center' },
   homeBtnText: { fontSize: 16, fontFamily: 'SpaceGrotesk-Bold', fontWeight: '700', color: '#000' },
 });

--- a/backend/daterabbit-api/src/bookings/bookings.controller.ts
+++ b/backend/daterabbit-api/src/bookings/bookings.controller.ts
@@ -268,6 +268,10 @@ export class BookingsController {
   @Post(':id/end-early')
   async endEarly(@Param('id', ParseUUIDPipe) id: string, @Request() req) {
     const booking = await this.bookingsService.endEarly(id, req.user.id);
+    // Proportional refund for unused time (fire-and-forget)
+    this.paymentsService.partialRefundForEndEarly(id, Number(booking.actualDurationHours ?? booking.duration)).catch(err =>
+      console.error('Partial refund error for booking', id, err),
+    );
     return this.formatBooking(booking);
   }
 

--- a/backend/daterabbit-api/src/payments/payments.service.ts
+++ b/backend/daterabbit-api/src/payments/payments.service.ts
@@ -170,6 +170,40 @@ export class PaymentsService {
     }
   }
 
+  // --- Partial refund for end-early ---
+
+  async partialRefundForEndEarly(bookingId: string, actualHours: number): Promise<void> {
+    const booking = await this.bookingsRepo.findOne({ where: { id: bookingId } });
+    if (!booking?.paymentIntentId) return;
+
+    const totalPrice = Number(booking.totalPrice);
+    const bookedDuration = Number(booking.duration);
+
+    // No refund if ended at or beyond booked duration
+    if (actualHours >= bookedDuration) return;
+
+    const refundFraction = 1 - actualHours / bookedDuration;
+    const refundAmountCents = Math.round(totalPrice * refundFraction * 100);
+
+    // Stripe minimum charge is 50 cents
+    if (refundAmountCents < 50) return;
+
+    if (!this.stripe) return; // Stripe not configured — skip silently
+
+    try {
+      const pi = await this.stripe.paymentIntents.retrieve(booking.paymentIntentId);
+      if (pi.status === 'succeeded') {
+        await this.stripe.refunds.create({
+          payment_intent: booking.paymentIntentId,
+          amount: refundAmountCents,
+        });
+      }
+      // requires_capture or other status — refund not applicable
+    } catch (err: any) {
+      console.error('Stripe partial refund error for end-early:', err.message);
+    }
+  }
+
   // --- Earnings ---
 
   async getEarnings(userId: string): Promise<{


### PR DESCRIPTION
## Summary
- `PaymentsService`: new `partialRefundForEndEarly(bookingId, actualHours)` — proportional Stripe refund with guards (skip if actualHours >= duration, skip if refund < 50 cents, skip if Stripe not configured)
- `BookingsController`: fire-and-forget partial refund call in `POST /bookings/:id/end-early` handler
- Summary screen: role-based "With" name (seeker sees companion's name, companion sees seeker's name), "Ended Early" badge when actualDurationHours < bookedDuration, star rating prompt (seeker only, local state — placeholder for review UC), "Book Again" button → browse tab, duration row shows actual vs booked

## Test plan
- [ ] POST /bookings/:id/end-early as seeker → booking status = completed, actualDurationHours set
- [ ] POST /bookings/:id/end-early as companion → same result
- [ ] Calling end-early twice returns 400 (guard in service), frontend catches silently
- [ ] Summary screen loads for both roles after end-early
- [ ] Summary shows "Ended Early" badge when date ended before booked duration
- [ ] Companion sees seeker's name in "With" row
- [ ] Seeker sees companion's name in "With" row
- [ ] "Book Again" navigates to browse tab
- [ ] Star rating renders 5 stars, tapping highlights correctly
- [ ] Partial refund skipped when actualHours >= duration (no Stripe call)

🤖 Generated with [Claude Code](https://claude.com/claude-code)