### PR TITLE
feat: shared photo album and date plan for active date (#708)

### DIFF
--- a/app/app/date/plan/[bookingId].tsx
+++ b/app/app/date/plan/[bookingId].tsx
@@ -63,6 +63,7 @@ export default function DatePlanScreen() {
   };
 
   const handleRemove = async (index: number) => {
+    if (!isSeeker) return;
     const updated = places.filter((_, i) => i !== index);
     setSaving(true);
     try {

--- a/app/src/services/activeDateApi.ts
+++ b/app/src/services/activeDateApi.ts
@@ -84,7 +84,7 @@ export const activeDateApi = {
     formData.append('file', { uri, type: `image/${ext === 'jpg' ? 'jpeg' : ext}`, name: `date-photo.${ext}` } as any);
     const resp = await fetch(`${API_BASE}/bookings/${bookingId}/photos`, {
       method: 'POST',
-      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'multipart/form-data' },
+      headers: { Authorization: `Bearer ${token}` },
       body: formData,
     });
     const data = await resp.json();

--- a/backend/daterabbit-api/src/bookings/bookings.controller.ts
+++ b/backend/daterabbit-api/src/bookings/bookings.controller.ts
@@ -286,27 +286,32 @@ export class BookingsController {
   // --- Group 1: Photos ---
 
   @Post(':id/photos')
+  @UseInterceptors(FileInterceptor('file'))
   async uploadPhoto(
     @Param('id', ParseUUIDPipe) id: string,
     @Request() req,
-    @Body() body: { url: string },
+    @UploadedFile() file: Express.Multer.File,
   ) {
-    if (!body.url) {
-      throw new HttpException('Photo URL is required', HttpStatus.BAD_REQUEST);
+    if (!file) {
+      throw new BadRequestException('No file provided');
     }
-    return this.bookingsService.addPhoto(id, req.user.id, body.url);
+    this.uploadsService.validateImageFile(file);
+    const url = this.uploadsService.getFileUrl('date-photos', file.filename);
+    return this.bookingsService.addPhoto(id, req.user.id, url);
   }
 
   @Get(':id/photos')
   async getPhotos(@Param('id', ParseUUIDPipe) id: string, @Request() req) {
-    return this.bookingsService.getPhotos(id, req.user.id);
+    const photos = await this.bookingsService.getPhotos(id, req.user.id);
+    return { photos };
   }
 
   // --- Group 1: Date plan ---
 
   @Get(':id/plan')
   async getDatePlan(@Param('id', ParseUUIDPipe) id: string, @Request() req) {
-    return this.bookingsService.getDatePlan(id, req.user.id);
+    const plan = await this.bookingsService.getDatePlan(id, req.user.id);
+    return plan || { places: [] };
   }
 
   @Put(':id/plan')

--- a/backend/daterabbit-api/src/uploads/uploads.service.ts
+++ b/backend/daterabbit-api/src/uploads/uploads.service.ts
@@ -2,7 +2,7 @@ import { Injectable, BadRequestException } from '@nestjs/common';
 import * as fs from 'fs';
 import * as path from 'path';
 
-export type UploadType = 'id-photos' | 'selfies' | 'videos' | 'profile-photos';
+export type UploadType = 'id-photos' | 'selfies' | 'videos' | 'profile-photos' | 'date-photos';
 
 const IMAGE_MIME_TYPES = ['image/jpeg', 'image/png', 'image/webp'];
 const VIDEO_MIME_TYPES = ['video/mp4', 'video/quicktime'];
@@ -19,7 +19,7 @@ export class UploadsService {
   }
 
   private ensureDirectories() {
-    const dirs: UploadType[] = ['id-photos', 'selfies', 'videos', 'profile-photos'];
+    const dirs: UploadType[] = ['id-photos', 'selfies', 'videos', 'profile-photos', 'date-photos'];
     for (const dir of dirs) {
       fs.mkdirSync(path.join(UPLOADS_ROOT, dir), { recursive: true });
     }


### PR DESCRIPTION
## Summary
- `POST /bookings/:id/photos` now accepts real multipart upload via `FileInterceptor`, saves to `uploads/date-photos/` via `UploadsService`, returns `{url, id}`
- `GET /bookings/:id/photos` now wraps response as `{photos: [...]}` (was returning raw array — caused `resp.photos` to be undefined on client)
- `GET /bookings/:id/plan` returns `{places: []}` when no plan exists (prevents null crash on client)
- `activeDateApi.uploadPhoto`: removed manual `Content-Type: multipart/form-data` header — fetch must auto-set it with boundary, otherwise uploads silently fail
- Plan screen `handleRemove`: added `if (!isSeeker) return` guard to prevent companion from mutating plan
- `UploadsService`: added `date-photos` to `UploadType` and `ensureDirectories` list

## Test plan
- [ ] Upload photo from photos screen → appears in 2-column grid for both seeker and companion
- [ ] `GET /bookings/:id/photos` returns `{photos: [...]}` shape
- [ ] Plan screen: seeker can add/remove places, changes persist on reload
- [ ] Plan screen: companion sees plan read-only, no Add button, remove not callable
- [ ] Plan screen with no plan: no crash, shows "No plan yet" empty state