### PR TITLE
fix: update timer after extend approval, fix extend hour options (#705)

### DIFF
--- a/app/app/date/active/[bookingId].tsx
+++ b/app/app/date/active/[bookingId].tsx
@@ -42,6 +42,11 @@ export default function ActiveDateScreen() {
       activeDateApi.getBookingById(bookingId)
         .then(data => {
           setBooking(data);
+          // Recalculate remaining time so timer reflects updated duration after extend approval
+          if (data.activeDateStartedAt) {
+            const endTime = new Date(data.activeDateStartedAt).getTime() + data.duration * 3600 * 1000;
+            setRemaining(Math.max(0, endTime - Date.now()));
+          }
           if (data.status === 'completed') {
             clearInterval(interval);
             router.replace(`/date/summary/${bookingId}`);

--- a/app/app/date/extend/[bookingId].tsx
+++ b/app/app/date/extend/[bookingId].tsx
@@ -3,11 +3,23 @@ import { View, Text, StyleSheet, TouchableOpacity, Alert, ActivityIndicator } fr
 import { useLocalSearchParams, router } from 'expo-router';
 import { activeDateApi } from '../../../src/services/activeDateApi';
 
-const HOURS_OPTIONS = [1, 2, 3];
+const HOURS_OPTIONS = [0.5, 1, 2];
+
+function formatHoursLabel(h: number): string {
+  if (h === 0.5) return '+30 min';
+  if (h === 1) return '+1 hour';
+  return `+${h} hours`;
+}
+
+function formatHoursDuration(h: number): string {
+  if (h === 0.5) return '30 minutes';
+  if (h === 1) return '1 hour';
+  return `${h} hours`;
+}
 
 export default function ExtendDateScreen() {
   const { bookingId } = useLocalSearchParams<{ bookingId: string }>();
-  const [selected, setSelected] = useState(1);
+  const [selected, setSelected] = useState(0.5);
   const [sending, setSending] = useState(false);
   const [sent, setSent] = useState(false);
   const [responseStatus, setResponseStatus] = useState<'pending' | 'approved' | 'rejected'>('pending');
@@ -56,12 +68,12 @@ export default function ExtendDateScreen() {
             key={h}
             style={[styles.option, selected === h && styles.optionSelected]}
             onPress={() => setSelected(h)}
-            accessibilityLabel={`Extend by ${h} hour${h !== 1 ? 's' : ''}`}
+            accessibilityLabel={`Extend by ${formatHoursDuration(h)}`}
             accessibilityRole="button"
             accessibilityState={{ selected: selected === h }}
           >
             <Text style={[styles.optionText, selected === h && styles.optionTextSelected]}>
-              +{h}h
+              {formatHoursLabel(h)}
             </Text>
           </TouchableOpacity>
         ))}
@@ -71,7 +83,7 @@ export default function ExtendDateScreen() {
         responseStatus === 'approved' ? (
           <View style={[styles.sentCard, { backgroundColor: '#4DF0FF' }]}>
             <Text style={styles.sentText}>Extension Approved!</Text>
-            <Text style={styles.sentSubtext}>Your date has been extended by {selected} hour{selected !== 1 ? 's' : ''}.</Text>
+            <Text style={styles.sentSubtext}>Your date has been extended by {formatHoursDuration(selected)}.</Text>
           </View>
         ) : responseStatus === 'rejected' ? (
           <View style={[styles.sentCard, { backgroundColor: '#FF5A85' }]}>


### PR DESCRIPTION
## Summary
- Timer bug fix: 15s poll now recalculates `remaining` from `activeDateStartedAt + duration` so countdown resets correctly after companion approves extension
- Extend screen options changed from `[1,2,3]h` to `[0.5,1,2]h` with friendly labels: +30 min / +1 hour / +2 hours (UC-065 spec)

## Files changed
- `app/app/date/active/[bookingId].tsx` — recalculate remaining in poll handler
- `app/app/date/extend/[bookingId].tsx` — new HOURS_OPTIONS + formatHoursLabel/formatHoursDuration helpers

## Test plan
- [ ] Start active date, wait for extend request to be approved by companion
- [ ] Verify timer jumps to reflect new end time within 15s
- [ ] Verify extend screen shows +30 min / +1 hour / +2 hours options