### PR TITLE
fix: correct multer destination for date-photos upload

### DIFF
--- a/backend/daterabbit-api/src/bookings/bookings.module.ts
+++ b/backend/daterabbit-api/src/bookings/bookings.module.ts
@@ -26,7 +26,7 @@ const UPLOADS_ROOT = path.join(process.cwd(), 'uploads');
       limits: { fileSize: 10 * 1024 * 1024 }, // 10MB max
       storage: multer.diskStorage({
         destination: (_req, _file, cb) => {
-          const dest = path.join(UPLOADS_ROOT, 'selfies');
+          const dest = path.join(UPLOADS_ROOT, 'date-photos');
           fs.mkdirSync(dest, { recursive: true });
           cb(null, dest);
         },


### PR DESCRIPTION
## Summary
- Fixed wrong MulterModule destination in bookings.module.ts
- Date photos were being saved to `uploads/selfies/` while URLs pointed to `uploads/date-photos/`, causing 404s
- Changed `path.join(UPLOADS_ROOT, 'selfies')` to `path.join(UPLOADS_ROOT, 'date-photos')`

Fixes #708