### PR TITLE
feat: safety features — SOS geo, notifications, report type fix, check-in prompt (#707)

### DIFF
--- a/app/app/date/active/[bookingId].tsx
+++ b/app/app/date/active/[bookingId].tsx
@@ -1,8 +1,10 @@
-import React, { useState, useEffect, useCallback } from 'react';
-import { View, Text, StyleSheet, TouchableOpacity, Alert, ScrollView } from 'react-native';
+import React, { useState, useEffect, useCallback, useRef } from 'react';
+import { View, Text, StyleSheet, TouchableOpacity, Alert, ScrollView, Modal } from 'react-native';
 import { useLocalSearchParams, router } from 'expo-router';
 import { activeDateApi, ActiveBooking } from '../../../src/services/activeDateApi';
 import { useAuthStore } from '../../../src/store/authStore';
+
+const SAFETY_CHECKIN_INTERVAL_MS = 30 * 60 * 1000; // 30 minutes
 
 function formatTime(ms: number): string {
   if (ms <= 0) return '00:00:00';
@@ -18,6 +20,9 @@ export default function ActiveDateScreen() {
   const [booking, setBooking] = useState<ActiveBooking | null>(null);
   const [remaining, setRemaining] = useState(0);
   const [loading, setLoading] = useState(true);
+  const [showCheckinModal, setShowCheckinModal] = useState(false);
+  const [checkinLoading, setCheckinLoading] = useState(false);
+  const lastCheckinRef = useRef<number>(Date.now());
   const user = useAuthStore(s => s.user);
   const isCompanion = user?.role === 'companion';
 
@@ -72,6 +77,36 @@ export default function ActiveDateScreen() {
     }, 1000);
     return () => clearInterval(interval);
   }, [booking, bookingId]);
+
+  // Safety check-in: prompt user every 30 min while date is active
+  useEffect(() => {
+    if (!booking?.activeDateStartedAt) return;
+    // Seed last-checkin from backend timestamp if available
+    if (booking.safetyCheckinAt) {
+      lastCheckinRef.current = new Date(booking.safetyCheckinAt).getTime();
+    }
+    const interval = setInterval(() => {
+      const sinceLastCheckin = Date.now() - lastCheckinRef.current;
+      if (sinceLastCheckin >= SAFETY_CHECKIN_INTERVAL_MS) {
+        setShowCheckinModal(true);
+      }
+    }, 60 * 1000); // check every minute
+    return () => clearInterval(interval);
+  }, [booking?.activeDateStartedAt, booking?.safetyCheckinAt]);
+
+  const handleSafetyCheckinOk = async () => {
+    setCheckinLoading(true);
+    try {
+      await activeDateApi.safetyCheckin(bookingId);
+      lastCheckinRef.current = Date.now();
+    } catch {
+      // Non-critical — reset timer anyway
+      lastCheckinRef.current = Date.now();
+    } finally {
+      setCheckinLoading(false);
+      setShowCheckinModal(false);
+    }
+  };
 
   const handleEndEarly = () => {
     Alert.alert(
@@ -151,6 +186,38 @@ export default function ActiveDateScreen() {
           </TouchableOpacity>
         ))}
       </View>
+
+      {/* Safety check-in modal */}
+      <Modal
+        visible={showCheckinModal}
+        transparent
+        animationType="fade"
+        onRequestClose={() => setShowCheckinModal(false)}
+      >
+        <View style={styles.modalOverlay}>
+          <View style={styles.modalCard}>
+            <Text style={styles.modalTitle}>Safety Check-in</Text>
+            <Text style={styles.modalBody}>Are you OK? Tap to confirm you're safe.</Text>
+            <TouchableOpacity
+              style={[styles.modalOkBtn, checkinLoading && styles.btnDisabled]}
+              onPress={handleSafetyCheckinOk}
+              disabled={checkinLoading}
+              accessibilityLabel="I'm OK"
+              accessibilityRole="button"
+            >
+              <Text style={styles.modalOkText}>{checkinLoading ? 'Confirming...' : "I'm OK"}</Text>
+            </TouchableOpacity>
+            <TouchableOpacity
+              style={styles.modalSosBtn}
+              onPress={() => { setShowCheckinModal(false); router.push(`/date/sos/${bookingId}` as any); }}
+              accessibilityLabel="I need help"
+              accessibilityRole="button"
+            >
+              <Text style={styles.modalSosText}>I Need Help</Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+      </Modal>
     </ScrollView>
   );
 }
@@ -179,4 +246,13 @@ const styles = StyleSheet.create({
     shadowOffset: { width: 3, height: 3 }, shadowColor: '#000', shadowOpacity: 1, shadowRadius: 0,
   },
   actionText: { fontSize: 15, fontFamily: 'SpaceGrotesk-Bold', fontWeight: '700', color: '#000' },
+  modalOverlay: { flex: 1, backgroundColor: 'rgba(0,0,0,0.6)', justifyContent: 'center', alignItems: 'center', padding: 24 },
+  modalCard: { backgroundColor: '#F4F0EA', borderWidth: 3, borderColor: '#000', padding: 32, width: '100%', maxWidth: 400, shadowOffset: { width: 5, height: 5 }, shadowColor: '#000', shadowOpacity: 1, shadowRadius: 0 },
+  modalTitle: { fontSize: 26, fontFamily: 'SpaceGrotesk-Bold', fontWeight: '700', color: '#000', marginBottom: 12 },
+  modalBody: { fontSize: 16, color: '#333', marginBottom: 32 },
+  modalOkBtn: { backgroundColor: '#4DF0FF', borderWidth: 2, borderColor: '#000', paddingVertical: 18, alignItems: 'center', marginBottom: 12, shadowOffset: { width: 3, height: 3 }, shadowColor: '#000', shadowOpacity: 1, shadowRadius: 0 },
+  modalOkText: { fontSize: 18, fontFamily: 'SpaceGrotesk-Bold', fontWeight: '700', color: '#000' },
+  modalSosBtn: { backgroundColor: '#FF0000', borderWidth: 2, borderColor: '#000', paddingVertical: 14, alignItems: 'center' },
+  modalSosText: { fontSize: 16, fontFamily: 'SpaceGrotesk-Bold', fontWeight: '700', color: '#fff' },
+  btnDisabled: { opacity: 0.5 },
 });

--- a/app/app/date/report/[bookingId].tsx
+++ b/app/app/date/report/[bookingId].tsx
@@ -3,11 +3,12 @@ import { View, Text, StyleSheet, TouchableOpacity, TextInput, ScrollView, Alert 
 import { useLocalSearchParams, router } from 'expo-router';
 import { activeDateApi } from '../../../src/services/activeDateApi';
 
-const ISSUE_TYPES = [
-  'Inappropriate behavior',
-  'Safety concern',
-  'No show',
-  'Other',
+// Backend validates: safety | behavior | scam | other
+const ISSUE_TYPES: { label: string; value: string }[] = [
+  { label: 'Inappropriate behavior', value: 'behavior' },
+  { label: 'Safety concern', value: 'safety' },
+  { label: 'Scam / fraud', value: 'scam' },
+  { label: 'Other', value: 'other' },
 ];
 
 export default function ReportIssueScreen() {
@@ -46,16 +47,16 @@ export default function ReportIssueScreen() {
       <Text style={styles.title}>Report an Issue</Text>
 
       <Text style={styles.sectionLabel}>Issue Type</Text>
-      {ISSUE_TYPES.map(t => (
+      {ISSUE_TYPES.map(({ label, value }) => (
         <TouchableOpacity
-          key={t}
-          style={[styles.typeOption, type === t && styles.typeOptionSelected]}
-          onPress={() => setType(t)}
-          accessibilityLabel={t}
+          key={value}
+          style={[styles.typeOption, type === value && styles.typeOptionSelected]}
+          onPress={() => setType(value)}
+          accessibilityLabel={label}
           accessibilityRole="radio"
-          accessibilityState={{ selected: type === t }}
+          accessibilityState={{ selected: type === value }}
         >
-          <Text style={[styles.typeText, type === t && styles.typeTextSelected]}>{t}</Text>
+          <Text style={[styles.typeText, type === value && styles.typeTextSelected]}>{label}</Text>
         </TouchableOpacity>
       ))}
 

--- a/app/app/date/sos/[bookingId].tsx
+++ b/app/app/date/sos/[bookingId].tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { View, Text, StyleSheet, TouchableOpacity, Linking, Alert } from 'react-native';
 import { useLocalSearchParams, router } from 'expo-router';
+import * as Location from 'expo-location';
 import { activeDateApi } from '../../../src/services/activeDateApi';
 
 export default function SOSScreen() {
@@ -11,7 +12,18 @@ export default function SOSScreen() {
   const handleAlert = async () => {
     setLoading(true);
     try {
-      await activeDateApi.triggerSOS(bookingId);
+      // Attempt to get location — gracefully skip if denied
+      let coords: { lat: number; lon: number } | undefined;
+      try {
+        const { status } = await Location.requestForegroundPermissionsAsync();
+        if (status === 'granted') {
+          const pos = await Location.getCurrentPositionAsync({ accuracy: Location.Accuracy.Balanced });
+          coords = { lat: pos.coords.latitude, lon: pos.coords.longitude };
+        }
+      } catch {
+        // Location unavailable — continue SOS without coords
+      }
+      await activeDateApi.triggerSOS(bookingId, coords);
       setAlerted(true);
     } catch (e) {
       Alert.alert('Error', 'Failed to send alert. Please call 911 directly.');

--- a/app/src/services/activeDateApi.ts
+++ b/app/src/services/activeDateApi.ts
@@ -16,6 +16,8 @@ export interface ActiveBooking {
   activeDateEndedAt?: string;
   actualDurationHours?: number;
   sosTriggeredAt?: string;
+  sosTriggeredBy?: string;
+  safetyCheckinAt?: string;
   noShowReason?: string;
   extendRequestedHours?: number;
   extendRequestedAt?: string;

--- a/backend/daterabbit-api/src/bookings/bookings.service.ts
+++ b/backend/daterabbit-api/src/bookings/bookings.service.ts
@@ -6,6 +6,8 @@ import { DatePhoto } from './entities/date-photo.entity';
 import { SelfieVerification } from './entities/selfie-verification.entity';
 import { UsersService } from '../users/users.service';
 import { EmailService } from '../email/email.service';
+import { NotificationsService } from '../notifications/notifications.service';
+import { NotificationType } from '../notifications/entities/notification.entity';
 import { sanitizeText } from '../common/sanitize';
 
 @Injectable()
@@ -19,6 +21,7 @@ export class BookingsService {
     private selfieVerificationsRepository: Repository<SelfieVerification>,
     private usersService: UsersService,
     private emailService: EmailService,
+    private notificationsService: NotificationsService,
   ) {}
 
   async create(data: {
@@ -318,10 +321,37 @@ export class BookingsService {
     if (booking.seekerId !== userId && booking.companionId !== userId) {
       throw new HttpException('Unauthorized', HttpStatus.FORBIDDEN);
     }
-    await this.bookingsRepository.update(bookingId, {
+    const update: Partial<Booking> = {
       sosTriggeredAt: new Date(),
       sosTriggeredBy: userId,
-    });
+    };
+    if (lat !== undefined) update.sosLat = lat;
+    if (lon !== undefined) update.sosLon = lon;
+    await this.bookingsRepository.update(bookingId, update);
+
+    const triggeredBy = userId === booking.seekerId ? booking.seeker?.name || 'Seeker' : booking.companion?.name || 'Companion';
+    const locationNote = lat !== undefined && lon !== undefined ? ` Location: ${lat.toFixed(5)}, ${lon.toFixed(5)}.` : '';
+    const notifyData = { bookingId, triggeredBy: userId };
+
+    // Notify both parties (fire-and-forget)
+    const notifications = [
+      this.notificationsService.create({
+        userId: booking.seekerId,
+        type: NotificationType.SOS_ALERT,
+        title: 'SOS Alert Triggered',
+        body: `${triggeredBy} triggered an SOS alert for your date.${locationNote} Our team has been notified.`,
+        data: notifyData,
+      }),
+      this.notificationsService.create({
+        userId: booking.companionId,
+        type: NotificationType.SOS_ALERT,
+        title: 'SOS Alert Triggered',
+        body: `${triggeredBy} triggered an SOS alert for your date.${locationNote} Our team has been notified.`,
+        data: notifyData,
+      }),
+    ];
+    await Promise.all(notifications.map(p => p.catch(e => console.error('[SOS] notification error', e))));
+
     return (await this.findById(bookingId))!;
   }
 
@@ -451,6 +481,28 @@ export class BookingsService {
       reportIssueType: sanitizeText(issueType),
       reportIssueText: sanitizeText(issueText),
     });
+
+    // Notify both parties about the report (fire-and-forget)
+    const reporterName = userId === booking.seekerId ? booking.seeker?.name || 'Seeker' : booking.companion?.name || 'Companion';
+    const notifyData = { bookingId, issueType };
+    const notifications = [
+      this.notificationsService.create({
+        userId: booking.seekerId,
+        type: NotificationType.REPORT_ISSUE,
+        title: 'Issue Reported',
+        body: `${reporterName} filed a report (${issueType}) for your date. Our team will review it shortly.`,
+        data: notifyData,
+      }),
+      this.notificationsService.create({
+        userId: booking.companionId,
+        type: NotificationType.REPORT_ISSUE,
+        title: 'Issue Reported',
+        body: `${reporterName} filed a report (${issueType}) for your date. Our team will review it shortly.`,
+        data: notifyData,
+      }),
+    ];
+    await Promise.all(notifications.map(p => p.catch(e => console.error('[REPORT] notification error', e))));
+
     return this.findById(bookingId) as Promise<Booking>;
   }
 

--- a/backend/daterabbit-api/src/bookings/entities/booking.entity.ts
+++ b/backend/daterabbit-api/src/bookings/entities/booking.entity.ts
@@ -95,6 +95,12 @@ export class Booking {
   @Column({ nullable: true })
   sosTriggeredBy: string;
 
+  @Column({ type: 'decimal', precision: 10, scale: 6, nullable: true })
+  sosLat: number;
+
+  @Column({ type: 'decimal', precision: 10, scale: 6, nullable: true })
+  sosLon: number;
+
   @Column({ type: 'text', nullable: true })
   noShowReason: string;
 

--- a/backend/daterabbit-api/src/notifications/entities/notification.entity.ts
+++ b/backend/daterabbit-api/src/notifications/entities/notification.entity.ts
@@ -15,6 +15,9 @@ export enum NotificationType {
   BOOKING_COMPLETED = 'booking_completed',
   NEW_MESSAGE = 'new_message',
   NO_SHOW = 'no_show',
+  SOS_ALERT = 'sos_alert',
+  SAFETY_ALERT = 'safety_alert',
+  REPORT_ISSUE = 'report_issue',
 }
 
 @Entity('notifications')


### PR DESCRIPTION
## Summary
- **NotificationType enum**: add `SOS_ALERT`, `SAFETY_ALERT`, `REPORT_ISSUE` values
- **Booking entity**: add `sosLat`/`sosLon` nullable decimal columns to store SOS location
- **bookings.service**: `triggerSOS` saves geo coords + notifies both seeker and companion via `SOS_ALERT` notification
- **bookings.service**: `reportIssue` notifies both parties via `REPORT_ISSUE` notification
- **Frontend SOS screen**: requests location permission via `expo-location`, sends coords with alert (graceful fallback if denied)
- **Frontend Report screen**: fix issue type values to match backend validation (`behavior`/`safety`/`scam`/`other` instead of raw display labels that caused 400 errors)
- **Frontend Active Date screen**: safety check-in modal every 30 min, seeds timer from `safetyCheckinAt` backend field, has "I Need Help" shortcut to SOS screen
- **activeDateApi**: add `sosTriggeredBy` and `safetyCheckinAt` fields to `ActiveBooking` interface

## Test plan
- [ ] Trigger SOS → booking gets `sosTriggeredAt` + `sosLat`/`sosLon` in DB, both parties get SOS_ALERT notification
- [ ] Submit report with each type (behavior/safety/scam/other) → no 400 error, both parties get REPORT_ISSUE notification
- [ ] Stay on active date screen 30+ min → safety check-in modal appears
- [ ] Confirm "I'm OK" → `safetyCheckinAt` updated, modal dismisses
- [ ] Tap "I Need Help" in modal → navigates to SOS screen