### PR TITLE
fix: security headers missing — HSTS, X-Frame-Options, CSP

### DIFF
--- a/server/nginx-daterabbit.conf
+++ b/server/nginx-daterabbit.conf
@@ -11,6 +11,14 @@ server {
     root /var/www/daterabbit;
     index index.html;
 
+    # Security headers — applied at server level (inherited by locations without own add_header)
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header Permissions-Policy "camera=(), microphone=(), geolocation=(self)" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://daterabbit-api.smartlaunchhub.com; font-src 'self' data:; frame-ancestors 'none';" always;
+
     # API proxy to NestJS backend
     location /api/ {
         proxy_pass http://127.0.0.1:3004;
@@ -38,12 +46,20 @@ server {
         proxy_cache_bypass $http_upgrade;
     }
 
+    # nginx add_header inheritance: locations with their own add_header directives
+    # must repeat ALL security headers, as child add_header blocks override parent ones.
     location /_next/ {
         proxy_pass http://127.0.0.1:3005;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         expires 1y;
         add_header Cache-Control "public, immutable";
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Permissions-Policy "camera=(), microphone=(), geolocation=(self)" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://daterabbit-api.smartlaunchhub.com; font-src 'self' data:; frame-ancestors 'none';" always;
     }
 
     # Uploads served from backend
@@ -51,6 +67,12 @@ server {
         alias /var/www/daterabbit/api/uploads/;
         expires 30d;
         add_header Cache-Control "public, immutable";
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Permissions-Policy "camera=(), microphone=(), geolocation=(self)" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://daterabbit-api.smartlaunchhub.com; font-src 'self' data:; frame-ancestors 'none';" always;
     }
 
     # Expo static assets (long cache)
@@ -58,6 +80,12 @@ server {
         alias /var/www/daterabbit/_expo;
         expires 1y;
         add_header Cache-Control "public, immutable";
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Permissions-Policy "camera=(), microphone=(), geolocation=(self)" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://daterabbit-api.smartlaunchhub.com; font-src 'self' data:; frame-ancestors 'none';" always;
     }
 
     # SPA catch-all


### PR DESCRIPTION
## Summary
- Adds 6 missing security headers to nginx-daterabbit.conf: HSTS, X-Frame-Options, X-Content-Type-Options, Referrer-Policy, Permissions-Policy, Content-Security-Policy
- Fixes clickjacking and XSS vectors (p1 bug #1342)
- Security headers are repeated in `/_next/`, `/uploads/`, `/_expo` location blocks to work around nginx `add_header` inheritance — child blocks with own `add_header` do not inherit parent-level headers

## Test plan
- [ ] curl -I https://daterabbit.smartlaunchhub.com — expect all 6 security headers present
- [ ] curl -I https://daterabbit.smartlaunchhub.com/_expo/static/js/web/entry-b8682a27b64d4537e66a2c40c2df600d.js — expect security headers + Cache-Control
- [ ] App loads and works normally (CSP allows Expo unsafe-inline/unsafe-eval)

Closes #1342.