### PR TITLE
perf: JS bundle splitting — lazy routes, defer Stripe

### DIFF
--- a/app/app/chat/_layout.tsx
+++ b/app/app/chat/_layout.tsx
@@ -1,0 +1,29 @@
+import React, { Suspense } from 'react';
+import { ActivityIndicator, View, StyleSheet } from 'react-native';
+import { Slot } from 'expo-router';
+import { colors } from '../../src/constants/theme';
+
+function LoadingFallback() {
+  return (
+    <View style={styles.container}>
+      <ActivityIndicator size="large" color={colors.primary} />
+    </View>
+  );
+}
+
+export default function ChatLayout() {
+  return (
+    <Suspense fallback={<LoadingFallback />}>
+      <Slot />
+    </Suspense>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: colors.background,
+  },
+});

--- a/app/app/payment/_layout.tsx
+++ b/app/app/payment/_layout.tsx
@@ -1,0 +1,29 @@
+import React, { Suspense } from 'react';
+import { ActivityIndicator, View, StyleSheet } from 'react-native';
+import { Slot } from 'expo-router';
+import { colors } from '../../src/constants/theme';
+
+function LoadingFallback() {
+  return (
+    <View style={styles.container}>
+      <ActivityIndicator size="large" color={colors.primary} />
+    </View>
+  );
+}
+
+export default function PaymentLayout() {
+  return (
+    <Suspense fallback={<LoadingFallback />}>
+      <Slot />
+    </Suspense>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: colors.background,
+  },
+});

--- a/app/app/reviews/_layout.tsx
+++ b/app/app/reviews/_layout.tsx
@@ -1,0 +1,29 @@
+import React, { Suspense } from 'react';
+import { ActivityIndicator, View, StyleSheet } from 'react-native';
+import { Slot } from 'expo-router';
+import { colors } from '../../src/constants/theme';
+
+function LoadingFallback() {
+  return (
+    <View style={styles.container}>
+      <ActivityIndicator size="large" color={colors.primary} />
+    </View>
+  );
+}
+
+export default function ReviewsLayout() {
+  return (
+    <Suspense fallback={<LoadingFallback />}>
+      <Slot />
+    </Suspense>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: colors.background,
+  },
+});

--- a/app/app/settings/_layout.tsx
+++ b/app/app/settings/_layout.tsx
@@ -1,0 +1,29 @@
+import React, { Suspense } from 'react';
+import { ActivityIndicator, View, StyleSheet } from 'react-native';
+import { Slot } from 'expo-router';
+import { colors } from '../../src/constants/theme';
+
+function LoadingFallback() {
+  return (
+    <View style={styles.container}>
+      <ActivityIndicator size="large" color={colors.primary} />
+    </View>
+  );
+}
+
+export default function SettingsLayout() {
+  return (
+    <Suspense fallback={<LoadingFallback />}>
+      <Slot />
+    </Suspense>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: colors.background,
+  },
+});

--- a/app/app/stripe/_layout.tsx
+++ b/app/app/stripe/_layout.tsx
@@ -1,0 +1,29 @@
+import React, { Suspense } from 'react';
+import { ActivityIndicator, View, StyleSheet } from 'react-native';
+import { Slot } from 'expo-router';
+import { colors } from '../../src/constants/theme';
+
+function LoadingFallback() {
+  return (
+    <View style={styles.container}>
+      <ActivityIndicator size="large" color={colors.primary} />
+    </View>
+  );
+}
+
+export default function StripeLayout() {
+  return (
+    <Suspense fallback={<LoadingFallback />}>
+      <Slot />
+    </Suspense>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: colors.background,
+  },
+});

--- a/app/metro.config.js
+++ b/app/metro.config.js
@@ -2,4 +2,8 @@ const { getDefaultConfig } = require('expo/metro-config');
 
 const config = getDefaultConfig(__dirname);
 
+// Enable package.json "exports" field resolution for better tree-shaking
+// and to allow bundlers to pick the correct ESM entry points.
+config.resolver.unstable_enablePackageExports = true;
+
 module.exports = config;

--- a/app/src/components/StripeProviderWeb.tsx
+++ b/app/src/components/StripeProviderWeb.tsx
@@ -1,24 +1,31 @@
-import React from 'react';
-import { loadStripe } from '@stripe/stripe-js';
+import React, { useState, useEffect } from 'react';
+import { loadStripe, Stripe } from '@stripe/stripe-js';
 import { Elements } from '@stripe/react-stripe-js';
 import Constants from 'expo-constants';
-
-const publishableKey =
-  Constants.expoConfig?.extra?.stripePublishableKey ||
-  process.env.EXPO_PUBLIC_STRIPE_PUBLISHABLE_KEY ||
-  '';
-
-if (!publishableKey) {
-  console.warn('[Stripe] EXPO_PUBLIC_STRIPE_PUBLISHABLE_KEY is not set. Stripe will not be initialized.');
-}
-
-const stripePromise = publishableKey ? loadStripe(publishableKey) : null;
 
 interface Props {
   children: React.ReactNode;
 }
 
 export default function StripeProviderWeb({ children }: Props) {
+  const [stripePromise, setStripePromise] = useState<Promise<Stripe | null> | null>(null);
+
+  useEffect(() => {
+    // Defer Stripe SDK initialization until after first paint to avoid
+    // blocking the initial bundle parse/execute on page load.
+    const publishableKey =
+      Constants.expoConfig?.extra?.stripePublishableKey ||
+      process.env.EXPO_PUBLIC_STRIPE_PUBLISHABLE_KEY ||
+      '';
+
+    if (!publishableKey) {
+      console.warn('[Stripe] EXPO_PUBLIC_STRIPE_PUBLISHABLE_KEY is not set. Stripe will not be initialized.');
+      return;
+    }
+
+    setStripePromise(loadStripe(publishableKey));
+  }, []);
+
   return (
     <Elements stripe={stripePromise}>
       {children}


### PR DESCRIPTION
## Summary
- Add `<Suspense>` + `<Slot>` layouts to 5 heavy route groups: `payment/`, `stripe/`, `chat/`, `reviews/`, `settings/` — enables Expo Router web chunk splitting per route group
- Defer `loadStripe()` call into `useEffect` in `StripeProviderWeb.tsx` so Stripe SDK does not block initial bundle parse/execute on first page load
- Enable `unstable_enablePackageExports: true` in `metro.config.js` for better ESM tree-shaking via `package.json` exports field

## Test plan
- [ ] `cd app && npx expo export --platform web` — verify multiple JS chunks appear in `dist/_expo/static/js/web/`
- [ ] Entry chunk size should be reduced vs baseline 3.8MB
- [ ] Navigate to /payment, /chat, /settings on staging — confirm screens load correctly with loading indicator during chunk fetch
- [ ] No regressions on auth, onboarding, main tabs

Closes #1343