### PR TITLE
feat: Active Date Phase 1 — wire entry points from bookings tab

### DIFF
--- a/app/app/(tabs)/female/requests.tsx
+++ b/app/app/(tabs)/female/requests.tsx
@@ -243,6 +243,13 @@ function RequestCard({ request, type, colors, onAccept, onDecline, formatDate }:
           <Text style={[styles.ratingText, { color: colors.textSecondary }]}>
             {request.isPaid ? 'Payment received' : 'Awaiting payment'}
           </Text>
+          <Button
+            title="View Summary"
+            onPress={() => router.push(`/date/summary/${request.id}`)}
+            variant="outline"
+            size="sm"
+            style={{ marginTop: spacing.sm, alignSelf: 'stretch' }}
+          />
         </View>
       )}
     </Card>

--- a/app/app/(tabs)/male/bookings.tsx
+++ b/app/app/(tabs)/male/bookings.tsx
@@ -283,12 +283,21 @@ function BookingCard({ booking, type, colors, onCancel, formatDate }: BookingCar
               <Icon key={i} name="star" size={24} color={i < Number(companion.rating || 0) ? colors.accent : colors.border} />
             ))}
           </View>
-          <Button
-            title="Leave Review"
-            onPress={() => router.push(`/reviews/${booking.id}`)}
-            size="sm"
-            style={{ marginTop: spacing.sm }}
-          />
+          <View style={{ flexDirection: 'row', gap: spacing.sm, marginTop: spacing.sm }}>
+            <Button
+              title="View Summary"
+              onPress={() => router.push(`/date/summary/${booking.id}`)}
+              variant="outline"
+              size="sm"
+              style={{ flex: 1 }}
+            />
+            <Button
+              title="Leave Review"
+              onPress={() => router.push(`/reviews/${booking.id}`)}
+              size="sm"
+              style={{ flex: 1 }}
+            />
+          </View>
         </View>
       )}
     </Card>

--- a/app/src/services/api.ts
+++ b/app/src/services/api.ts
@@ -289,6 +289,8 @@ export type BookingStatus =
   | 'accepted'
   | 'declined'
   | 'confirmed'
+  | 'checkin_ready'
+  | 'active'
   | 'cancelled'
   | 'completed';
 


### PR DESCRIPTION
## Summary
- Add `active` and `checkin_ready` to `BookingStatus` type in `api.ts` (fixes pre-existing TS2367 errors)
- Add **View Summary** button to past bookings in seeker tab (`male/bookings.tsx`)
- Add **View Summary** button to completed requests in companion tab (`female/requests.tsx`)
- Seeker flow: **Start Date** → `/date/checkin/[id]`, **Resume Date** → `/date/active/[id]` (was already wired, confirmed working)
- Companion flow: **Start Date** → `/date/companion-checkin/[id]`, **Resume Date** → `/date/active/[id]` (was already wired, confirmed working)

All Active Date screens (checkin, companion-checkin, active, extend, extend-response, summary) were pre-built and fully functional. This PR only wires the entry points from the bookings/requests tabs.

## Test plan
- [ ] Login as seeker → Bookings tab → confirmed+paid booking for today → "Start Date" button visible → routes to `/date/checkin/[id]`
- [ ] Login as seeker → Bookings tab → active booking → "Resume Date" button visible → routes to `/date/active/[id]`
- [ ] Login as seeker → Bookings tab → Past tab → "View Summary" button visible → routes to `/date/summary/[id]`
- [ ] Login as companion → Requests tab → accepted+paid request for today → "Start Date" button visible → routes to `/date/companion-checkin/[id]`
- [ ] Login as companion → Requests tab → completed tab → "View Summary" button visible → routes to `/date/summary/[id]`

Closes #1357