### PR TITLE
fix: strip console calls in production bundle

### DIFF
--- a/app/babel.config.js
+++ b/app/babel.config.js
@@ -1,0 +1,10 @@
+module.exports = function (api) {
+  api.cache(true);
+  const isProduction = api.env('production');
+  return {
+    presets: ['babel-preset-expo'],
+    plugins: [
+      isProduction && ['transform-remove-console'],
+    ].filter(Boolean),
+  };
+};

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -58,6 +58,7 @@
         "@testing-library/react-native": "^13.3.3",
         "@types/jest": "^30.0.0",
         "@types/react": "^18.3.12",
+        "babel-plugin-transform-remove-console": "^6.9.4",
         "jest-expo": "^52.0.6",
         "magnitude-test": "^0.3.13",
         "react-test-renderer": "^19.1.0",
@@ -11657,6 +11658,13 @@
       "dependencies": {
         "@babel/plugin-syntax-flow": "^7.12.1"
       }
+    },
+    "node_modules/babel-plugin-transform-remove-console": {
+      "version": "6.9.4",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-remove-console/-/babel-plugin-transform-remove-console-6.9.4.tgz",
+      "integrity": "sha512-88blrUrMX3SPiGkT1GnvVY8E/7A+k6oj3MNvUtTIxJflFzXTw1bHkuJ/y039ouhFMp2prRn5cQGzokViYi1dsg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/babel-preset-current-node-syntax": {
       "version": "1.2.0",

--- a/app/package.json
+++ b/app/package.json
@@ -69,6 +69,7 @@
     "@testing-library/react-native": "^13.3.3",
     "@types/jest": "^30.0.0",
     "@types/react": "^18.3.12",
+    "babel-plugin-transform-remove-console": "^6.9.4",
     "jest-expo": "^52.0.6",
     "magnitude-test": "^0.3.13",
     "react-test-renderer": "^19.1.0",


### PR DESCRIPTION
## Summary
- Adds `babel-plugin-transform-remove-console` to devDependencies
- Creates `babel.config.js` with plugin enabled **only in production env**
- Eliminates ~140 console.log/warn/error calls from production bundle (sourced from app code + bundled Expo internals)

## Details
Plugin is gated with `api.env('production')` so dev/test console output is unaffected. Base preset `babel-preset-expo` is preserved.

## Test plan
- [ ] Verify dev build still shows console output in browser/RN debugger
- [ ] Run `npx expo export --platform web` and confirm no `console.` in output JS

Closes #1344