### PR TITLE
fix: manifest.json returns HTML — fix nginx + create file

### DIFF
--- a/app/public/manifest.json
+++ b/app/public/manifest.json
@@ -1,0 +1,10 @@
+{
+  "name": "DateRabbit",
+  "short_name": "DateRabbit",
+  "description": "Find your perfect date experience",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#0A0A0A",
+  "theme_color": "#FF2A5F",
+  "icons": [{"src": "/favicon.ico", "sizes": "any", "type": "image/x-icon"}]
+}

--- a/server/nginx-daterabbit.conf
+++ b/server/nginx-daterabbit.conf
@@ -60,6 +60,18 @@ server {
         add_header Cache-Control "public, immutable";
     }
 
+    # PWA manifest — exact match to prevent SPA catch-all from returning HTML
+    location = /manifest.json {
+        add_header Content-Type "application/manifest+json" always;
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+        add_header X-Frame-Options "SAMEORIGIN" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Permissions-Policy "camera=(), microphone=(), geolocation=(self)" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://daterabbit-api.smartlaunchhub.com; font-src 'self' data:; frame-ancestors 'none';" always;
+        try_files $uri =404;
+    }
+
     # SPA catch-all
     location / {
         try_files $uri $uri/ /index.html;


### PR DESCRIPTION
## Summary
- Adds exact-match `location = /manifest.json` in nginx before the SPA catch-all
- Sets `Content-Type: application/manifest+json` explicitly
- Creates `app/public/manifest.json` with minimal PWA manifest so Expo includes it in dist
- Adds security headers to the manifest location block

## Test plan
- [ ] `curl -sI https://daterabbit.smartlaunchhub.com/manifest.json | grep -i content-type` → `application/manifest+json`
- [ ] `curl -s https://daterabbit.smartlaunchhub.com/manifest.json | python3 -m json.tool` → valid JSON

Closes #1349