### PR TITLE
fix: babel.config.js — remove api.cache(true) that breaks Expo build

### DIFF
--- a/app/babel.config.js
+++ b/app/babel.config.js
@@ -1,5 +1,4 @@
 module.exports = function (api) {
-  api.cache(true);
   const isProduction = api.env('production');
   return {
     presets: ['babel-preset-expo'],


### PR DESCRIPTION
Removes api.cache(true) call that conflicts with babel-preset-expo's own cache configuration. This caused 'Caching has already been configured with .never or .forever()' error breaking all CI builds.