### PR TITLE
feat: OG tags via expo-router/head in root layout

### DIFF
--- a/app/app/_layout.tsx
+++ b/app/app/_layout.tsx
@@ -1,4 +1,5 @@
 import { Stack, useRouter, useSegments, usePathname } from 'expo-router';
+import Head from 'expo-router/head';
 import { StatusBar } from 'expo-status-bar';
 import { Platform, View, ActivityIndicator, StyleSheet } from 'react-native';
 import { useAuthStore } from '../src/store/authStore';
@@ -190,6 +191,21 @@ export default function RootLayout() {
     <StripeProvider>
       <View style={styles.container}>
       <StatusBar style="dark" />
+      {Platform.OS === 'web' && (
+        <Head>
+          <title>DateRabbit — Find Your Perfect Date</title>
+          <meta name="description" content="DateRabbit connects seekers with companions for memorable date experiences. Find, book, and enjoy amazing dates." />
+          <meta property="og:title" content="DateRabbit — Find Your Perfect Date" />
+          <meta property="og:description" content="Connect with companions for memorable date experiences." />
+          <meta property="og:image" content="https://daterabbit.smartlaunchhub.com/og-image.png" />
+          <meta property="og:url" content="https://daterabbit.smartlaunchhub.com" />
+          <meta property="og:type" content="website" />
+          <meta name="twitter:card" content="summary_large_image" />
+          <meta name="twitter:title" content="DateRabbit" />
+          <meta name="twitter:description" content="Connect with companions for memorable date experiences." />
+          <meta name="twitter:image" content="https://daterabbit.smartlaunchhub.com/og-image.png" />
+        </Head>
+      )}
       <Stack
         screenOptions={{
           headerShown: false,


### PR DESCRIPTION
## Summary
- Uses `Head` component from `expo-router/head` (backed by `react-native-helmet-async`) to inject OG/Twitter meta tags at runtime
- `Platform.OS === 'web'` guard ensures zero native impact
- Replaces the `+html.tsx` approach which does not work in Expo 52 static export

## Tags added
- `<title>`, `description`, `og:title`, `og:description`, `og:image`, `og:url`, `og:type`
- `twitter:card`, `twitter:title`, `twitter:description`, `twitter:image`

## Test plan
- [ ] Deploy to staging, run: `curl -s https://daterabbit.smartlaunchhub.com | grep og:title`
- [ ] Check page title in browser tab
- [ ] Verify no native (iOS/Android) regressions

Closes #1345