### PR TITLE
feat: browse filters — add Newest First sort, fix minRating min to 0

### DIFF
--- a/app/app/(tabs)/male/browse.tsx
+++ b/app/app/(tabs)/male/browse.tsx
@@ -99,6 +99,7 @@ export default function BrowseScreen() {
         'price_high': 'price_high',
         'rating': 'rating',
         'distance': 'distance',
+        'new': 'new',
       };
 
       let sortBy: 'recommended' | 'price_low' | 'price_high' | 'rating' | 'distance' | 'new' =

--- a/app/src/components/FilterModal.tsx
+++ b/app/src/components/FilterModal.tsx
@@ -18,7 +18,7 @@ export interface FilterOptions {
   minRating: number;
   availability: 'any' | 'today' | 'this_week' | 'weekend';
   ageRange: [number, number];
-  sortBy: 'recommended' | 'price_low' | 'price_high' | 'rating' | 'distance';
+  sortBy: 'recommended' | 'price_low' | 'price_high' | 'rating' | 'distance' | 'new';
 }
 
 interface FilterModalProps {
@@ -50,6 +50,7 @@ const sortOptions = [
   { value: 'price_high', label: 'Price: High to Low' },
   { value: 'rating', label: 'Highest Rated' },
   { value: 'distance', label: 'Nearest First' },
+  { value: 'new', label: 'Newest First' },
 ] as const;
 
 export function FilterModal({
@@ -177,7 +178,7 @@ export function FilterModal({
             </View>
             <Slider
               style={styles.slider}
-              minimumValue={3.0}
+              minimumValue={0.0}
               maximumValue={5.0}
               step={0.1}
               value={filters.minRating}


### PR DESCRIPTION
## Summary
- Adds 'Newest First' sort option to FilterModal Sort By section
- Fixes minRating slider to start at 0.0 (was 3.0), allowing "any rating" selection
- Extends `FilterOptions.sortBy` type union to include `'new'`
- Adds `'new': 'new'` to `sortByMap` in browse.tsx so the selection reaches the API

All other advanced filters (age range, distance, min rating, price range) were already fully implemented and wired to the API.

Closes #1353

## Test plan
- [ ] Open Filter modal in Browse tab
- [ ] Sort By section shows "Newest First" option, selecting it applies `sortBy=new` to API call
- [ ] Minimum Rating slider starts at 0.0 (was stuck at 3.0 minimum)
- [ ] No TypeScript errors introduced in changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)