### PR TITLE
fix: Stripe payment methods — save cards via SetupIntent

### DIFF
--- a/app/app/settings/payment-methods.tsx
+++ b/app/app/settings/payment-methods.tsx
@@ -1,26 +1,147 @@
-import React from 'react';
+import React, { useEffect, useState, useCallback, Platform } from 'react';
 import {
   View,
   Text,
   StyleSheet,
   ScrollView,
   TouchableOpacity,
+  ActivityIndicator,
+  Modal,
 } from 'react-native';
 import { router } from 'expo-router';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Icon } from '../../src/components/Icon';
 import { Card } from '../../src/components/Card';
 import { Button } from '../../src/components/Button';
+import { StripeSetupForm } from '../../src/components/StripeSetupForm';
+import { paymentsApi, ApiError } from '../../src/services/api';
 import { useTheme, spacing, typography, borderRadius } from '../../src/constants/theme';
+import { showAlert } from '../../src/utils/alert';
+
+interface SavedCard {
+  id: string;
+  brand: string;
+  last4: string;
+  expMonth: number;
+  expYear: number;
+}
+
+function formatBrand(brand: string): string {
+  const map: Record<string, string> = {
+    visa: 'Visa',
+    mastercard: 'Mastercard',
+    amex: 'American Express',
+    discover: 'Discover',
+    diners: 'Diners Club',
+    jcb: 'JCB',
+    unionpay: 'UnionPay',
+  };
+  return map[brand.toLowerCase()] ?? brand;
+}
 
 export default function PaymentMethodsScreen() {
   const insets = useSafeAreaInsets();
   const { colors } = useTheme();
 
+  const [cards, setCards] = useState<SavedCard[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+  const [showAddModal, setShowAddModal] = useState(false);
+  const [setupClientSecret, setSetupClientSecret] = useState<string | null>(null);
+  const [setupLoading, setSetupLoading] = useState(false);
+
+  const fetchCards = useCallback(async () => {
+    setLoading(true);
+    try {
+      const result = await paymentsApi.listPaymentMethods();
+      setCards(result.paymentMethods);
+    } catch (err) {
+      const msg = err instanceof ApiError ? err.message : 'Failed to load payment methods';
+      showAlert('Error', msg);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchCards();
+  }, [fetchCards]);
+
+  const handleAddCard = async () => {
+    if (Platform.OS !== 'web') {
+      showAlert(
+        'Web Required',
+        'Please open DateRabbit in your browser to add a payment method.',
+      );
+      return;
+    }
+    setSetupLoading(true);
+    try {
+      const { clientSecret } = await paymentsApi.createSetupIntent();
+      setSetupClientSecret(clientSecret);
+      setShowAddModal(true);
+    } catch (err) {
+      const msg = err instanceof ApiError ? err.message : 'Failed to initialize card setup';
+      showAlert('Error', msg);
+    } finally {
+      setSetupLoading(false);
+    }
+  };
+
+  const handleSetupSuccess = async () => {
+    setShowAddModal(false);
+    setSetupClientSecret(null);
+    await fetchCards();
+    showAlert('Card Saved', 'Your payment method has been saved successfully.');
+  };
+
+  const handleSetupCancel = () => {
+    setShowAddModal(false);
+    setSetupClientSecret(null);
+  };
+
+  const handleDelete = (card: SavedCard) => {
+    showAlert(
+      'Remove Card',
+      `Remove ${formatBrand(card.brand)} ending in ${card.last4}?`,
+      [
+        { text: 'Cancel', style: 'cancel' },
+        {
+          text: 'Remove',
+          style: 'destructive',
+          onPress: async () => {
+            setDeletingId(card.id);
+            try {
+              await paymentsApi.deletePaymentMethod(card.id);
+              setCards((prev) => prev.filter((c) => c.id !== card.id));
+            } catch (err) {
+              const msg = err instanceof ApiError ? err.message : 'Failed to remove card';
+              showAlert('Error', msg);
+            } finally {
+              setDeletingId(null);
+            }
+          },
+        },
+      ],
+    );
+  };
+
   return (
     <View style={[styles.container, { backgroundColor: colors.background }]}>
-      <View style={[styles.header, { paddingTop: insets.top + spacing.sm, backgroundColor: colors.white, borderBottomColor: colors.border }]}>
-        <TouchableOpacity style={[styles.backButton, { backgroundColor: colors.surface }]} onPress={() => router.back()}
+      {/* Header */}
+      <View
+        style={[
+          styles.header,
+          {
+            paddingTop: insets.top + spacing.sm,
+            backgroundColor: colors.white,
+            borderBottomColor: colors.border,
+          },
+        ]}
+      >
+        <TouchableOpacity
+          style={[styles.backButton, { backgroundColor: colors.surface }]}
+          onPress={() => router.back()}
           accessibilityLabel="Go back"
           accessibilityRole="button"
         >
@@ -31,24 +152,74 @@ export default function PaymentMethodsScreen() {
       </View>
 
       <ScrollView style={styles.scrollView} contentContainerStyle={styles.content}>
-        {/* Empty state */}
-        <Card style={styles.emptyCard}>
-          <View style={[styles.emptyIconContainer, { backgroundColor: colors.primary + '15' }]}>
-            <Icon name="credit-card" size={40} color={colors.primary} />
+        {loading ? (
+          <View style={styles.loadingContainer}>
+            <ActivityIndicator size="large" color={colors.primary} />
+            <Text style={[styles.loadingText, { color: colors.textSecondary }]}>
+              Loading payment methods...
+            </Text>
           </View>
-          <Text style={[styles.emptyTitle, { color: colors.text }]}>No Payment Methods</Text>
-          <Text style={[styles.emptyDescription, { color: colors.textSecondary }]}>
-            Add a credit or debit card to easily pay for date bookings.
-          </Text>
-        </Card>
+        ) : cards.length === 0 ? (
+          /* Empty state */
+          <Card style={styles.emptyCard}>
+            <View
+              style={[styles.emptyIconContainer, { backgroundColor: colors.primary + '15' }]}
+            >
+              <Icon name="credit-card" size={40} color={colors.primary} />
+            </View>
+            <Text style={[styles.emptyTitle, { color: colors.text }]}>No Payment Methods</Text>
+            <Text style={[styles.emptyDescription, { color: colors.textSecondary }]}>
+              Add a credit or debit card to easily pay for date bookings.
+            </Text>
+          </Card>
+        ) : (
+          /* Card list */
+          <View style={styles.cardList}>
+            {cards.map((card) => (
+              <Card key={card.id} style={styles.cardItem}>
+                <View style={styles.cardRow}>
+                  <View
+                    style={[
+                      styles.cardIconContainer,
+                      { backgroundColor: colors.primary + '15' },
+                    ]}
+                  >
+                    <Icon name="credit-card" size={24} color={colors.primary} />
+                  </View>
+                  <View style={styles.cardInfo}>
+                    <Text style={[styles.cardBrand, { color: colors.text }]}>
+                      {formatBrand(card.brand)}
+                    </Text>
+                    <Text style={[styles.cardDetails, { color: colors.textSecondary }]}>
+                      {'\u2022\u2022\u2022\u2022'} {card.last4} &middot; Expires {card.expMonth}/{String(card.expYear).slice(-2)}
+                    </Text>
+                  </View>
+                  <TouchableOpacity
+                    style={[styles.deleteButton, { backgroundColor: colors.error + '15' }]}
+                    onPress={() => handleDelete(card)}
+                    disabled={deletingId === card.id}
+                    accessibilityLabel={`Remove ${formatBrand(card.brand)} ending in ${card.last4}`}
+                    accessibilityRole="button"
+                  >
+                    {deletingId === card.id ? (
+                      <ActivityIndicator size="small" color={colors.error} />
+                    ) : (
+                      <Icon name="trash" size={18} color={colors.error} />
+                    )}
+                  </TouchableOpacity>
+                </View>
+              </Card>
+            ))}
+          </View>
+        )}
 
         <Button
-          title="Add Payment Method"
-          onPress={() => {
-            // TODO: integrate with Stripe payment method setup
-          }}
+          title={setupLoading ? 'Setting up...' : 'Add Payment Method'}
+          onPress={handleAddCard}
           fullWidth
           size="lg"
+          disabled={setupLoading}
+          style={{ marginTop: cards.length > 0 ? spacing.md : spacing.xl }}
         />
 
         <View style={styles.infoSection}>
@@ -69,6 +240,50 @@ export default function PaymentMethodsScreen() {
           </Card>
         </View>
       </ScrollView>
+
+      {/* Add Card Modal */}
+      <Modal
+        visible={showAddModal}
+        animationType="slide"
+        transparent
+        onRequestClose={handleSetupCancel}
+      >
+        <View style={styles.modalOverlay}>
+          <View
+            style={[
+              styles.modalContent,
+              {
+                backgroundColor: colors.white,
+                borderColor: colors.border,
+                paddingBottom: insets.bottom + spacing.lg,
+              },
+            ]}
+          >
+            <View style={styles.modalHeader}>
+              <Text style={[styles.modalTitle, { color: colors.text }]}>Add Payment Method</Text>
+              <TouchableOpacity
+                onPress={handleSetupCancel}
+                style={[styles.modalCloseButton, { backgroundColor: colors.surface }]}
+                accessibilityLabel="Close"
+                accessibilityRole="button"
+              >
+                <Icon name="x" size={20} color={colors.text} />
+              </TouchableOpacity>
+            </View>
+
+            {setupClientSecret ? (
+              <StripeSetupForm
+                clientSecret={setupClientSecret}
+                onSuccess={handleSetupSuccess}
+                onError={(msg) => showAlert('Error', msg)}
+                onCancel={handleSetupCancel}
+              />
+            ) : (
+              <ActivityIndicator size="large" color={colors.primary} />
+            )}
+          </View>
+        </View>
+      </Modal>
     </View>
   );
 }
@@ -103,6 +318,15 @@ const styles = StyleSheet.create({
   content: {
     padding: spacing.lg,
   },
+  loadingContainer: {
+    alignItems: 'center',
+    paddingVertical: spacing.xxl,
+    gap: spacing.md,
+  },
+  loadingText: {
+    fontFamily: typography.fonts.body,
+    fontSize: typography.sizes.md,
+  },
   emptyCard: {
     alignItems: 'center',
     paddingVertical: spacing.xxl,
@@ -128,6 +352,45 @@ const styles = StyleSheet.create({
     lineHeight: 22,
     paddingHorizontal: spacing.lg,
   },
+  cardList: {
+    gap: spacing.sm,
+    marginBottom: spacing.sm,
+  },
+  cardItem: {
+    paddingVertical: spacing.sm,
+  },
+  cardRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.md,
+  },
+  cardIconContainer: {
+    width: 44,
+    height: 44,
+    borderRadius: borderRadius.md,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  cardInfo: {
+    flex: 1,
+  },
+  cardBrand: {
+    fontFamily: typography.fonts.heading,
+    fontSize: typography.sizes.md,
+    fontWeight: '600',
+    marginBottom: 2,
+  },
+  cardDetails: {
+    fontFamily: typography.fonts.body,
+    fontSize: typography.sizes.sm,
+  },
+  deleteButton: {
+    width: 36,
+    height: 36,
+    borderRadius: borderRadius.sm,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
   infoSection: {
     marginTop: spacing.xl,
   },
@@ -146,5 +409,34 @@ const styles = StyleSheet.create({
   infoDivider: {
     height: 1,
     marginVertical: spacing.xs,
+  },
+  modalOverlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.5)',
+    justifyContent: 'flex-end',
+  },
+  modalContent: {
+    borderTopLeftRadius: borderRadius.xl,
+    borderTopRightRadius: borderRadius.xl,
+    borderWidth: 1,
+    padding: spacing.lg,
+    gap: spacing.lg,
+  },
+  modalHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  modalTitle: {
+    fontFamily: typography.fonts.heading,
+    fontSize: typography.sizes.lg,
+    fontWeight: '600',
+  },
+  modalCloseButton: {
+    width: 36,
+    height: 36,
+    borderRadius: 18,
+    alignItems: 'center',
+    justifyContent: 'center',
   },
 });

--- a/app/src/components/StripeSetupForm.tsx
+++ b/app/src/components/StripeSetupForm.tsx
@@ -1,0 +1,226 @@
+import React, { useState } from 'react';
+import { View, Text, StyleSheet, ActivityIndicator, Platform } from 'react-native';
+import { useTheme, spacing, typography, borderRadius } from '../constants/theme';
+
+interface StripeSetupFormProps {
+  clientSecret: string;
+  onSuccess: () => void;
+  onError?: (error: string) => void;
+  onCancel?: () => void;
+}
+
+// Native fallback — SetupIntent UI is web-only
+function NativeFallback() {
+  const { colors } = useTheme();
+  return (
+    <View style={styles.fallback}>
+      <Text style={[styles.fallbackText, { color: colors.textSecondary }]}>
+        Open DateRabbit in your browser to manage payment methods.
+      </Text>
+    </View>
+  );
+}
+
+function WebSetupForm({ clientSecret, onSuccess, onError, onCancel }: StripeSetupFormProps) {
+  const { colors } = useTheme();
+  const [isProcessing, setIsProcessing] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const {
+    useStripe,
+    useElements,
+    PaymentElement,
+  } = require('@stripe/react-stripe-js');
+  const { loadStripe } = require('@stripe/stripe-js');
+  const { Elements } = require('@stripe/react-stripe-js');
+  const Constants = require('expo-constants').default;
+
+  const publishableKey =
+    Constants.expoConfig?.extra?.stripePublishableKey ||
+    process.env.EXPO_PUBLIC_STRIPE_PUBLISHABLE_KEY ||
+    '';
+
+  if (!publishableKey) {
+    return (
+      <View style={styles.fallback}>
+        <Text style={[styles.fallbackText, { color: colors.textSecondary }]}>
+          Payment is not available. Stripe key is missing.
+        </Text>
+      </View>
+    );
+  }
+
+  const stripePromise = loadStripe(publishableKey);
+
+  return (
+    <Elements stripe={stripePromise} options={{ clientSecret }}>
+      <InnerSetupForm
+        onSuccess={onSuccess}
+        onError={onError}
+        onCancel={onCancel}
+      />
+    </Elements>
+  );
+}
+
+function InnerSetupForm({
+  onSuccess,
+  onError,
+  onCancel,
+}: Omit<StripeSetupFormProps, 'clientSecret'>) {
+  const { colors } = useTheme();
+  const [isProcessing, setIsProcessing] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const { useStripe, useElements, PaymentElement } = require('@stripe/react-stripe-js');
+  const stripe = useStripe();
+  const elements = useElements();
+
+  const handleSubmit = async () => {
+    if (!stripe || !elements) return;
+
+    setIsProcessing(true);
+    setErrorMessage(null);
+
+    const { error } = await stripe.confirmSetup({
+      elements,
+      confirmParams: {
+        return_url: 'https://daterabbit.smartlaunchhub.com/stripe/return',
+      },
+      redirect: 'if_required',
+    });
+
+    if (error) {
+      const msg = error.message || 'Failed to save card';
+      setErrorMessage(msg);
+      onError?.(msg);
+      setIsProcessing(false);
+    } else {
+      onSuccess();
+    }
+  };
+
+  return (
+    <View style={styles.formContainer}>
+      <PaymentElement />
+
+      {errorMessage && (
+        <View
+          style={[
+            styles.errorBox,
+            { backgroundColor: colors.error + '15', borderColor: colors.error },
+          ]}
+        >
+          <Text style={[styles.errorText, { color: colors.error }]}>{errorMessage}</Text>
+        </View>
+      )}
+
+      <View style={styles.buttonRow}>
+        {onCancel && (
+          <View
+            // @ts-ignore web-only onClick
+            onClick={!isProcessing ? onCancel : undefined}
+            style={[
+              styles.cancelButton,
+              { borderColor: colors.border, backgroundColor: colors.surface },
+            ]}
+          >
+            <Text style={[styles.cancelButtonText, { color: colors.text }]}>Cancel</Text>
+          </View>
+        )}
+
+        <View
+          // @ts-ignore web-only onClick
+          onClick={!isProcessing ? handleSubmit : undefined}
+          style={[
+            styles.saveButton,
+            {
+              backgroundColor: isProcessing ? colors.textMuted : colors.primary,
+              borderColor: colors.text,
+              flex: onCancel ? 1 : undefined,
+            },
+          ]}
+        >
+          {isProcessing ? (
+            <ActivityIndicator color="#fff" size="small" />
+          ) : (
+            <Text style={styles.saveButtonText}>Save Card</Text>
+          )}
+        </View>
+      </View>
+    </View>
+  );
+}
+
+export function StripeSetupForm(props: StripeSetupFormProps) {
+  if (Platform.OS !== 'web') {
+    return <NativeFallback />;
+  }
+  return <WebSetupForm {...props} />;
+}
+
+const styles = StyleSheet.create({
+  formContainer: {
+    gap: spacing.md,
+  },
+  buttonRow: {
+    flexDirection: 'row',
+    gap: spacing.md,
+    marginTop: spacing.sm,
+  },
+  errorBox: {
+    padding: spacing.md,
+    borderRadius: borderRadius.md,
+    borderWidth: 2,
+  },
+  errorText: {
+    fontFamily: typography.fonts.body,
+    fontSize: typography.sizes.sm,
+  },
+  saveButton: {
+    flex: 1,
+    paddingVertical: spacing.md,
+    borderRadius: borderRadius.md,
+    borderWidth: 3,
+    alignItems: 'center',
+    justifyContent: 'center',
+    minHeight: 52,
+    shadowColor: '#000',
+    shadowOffset: { width: 4, height: 4 },
+    shadowOpacity: 1,
+    shadowRadius: 0,
+    cursor: 'pointer',
+  } as any,
+  saveButtonText: {
+    fontFamily: typography.fonts.heading,
+    fontSize: typography.sizes.lg,
+    color: '#fff',
+    textTransform: 'uppercase',
+    letterSpacing: 1,
+  },
+  cancelButton: {
+    paddingVertical: spacing.md,
+    paddingHorizontal: spacing.xl,
+    borderRadius: borderRadius.md,
+    borderWidth: 3,
+    alignItems: 'center',
+    justifyContent: 'center',
+    minHeight: 52,
+    cursor: 'pointer',
+  } as any,
+  cancelButtonText: {
+    fontFamily: typography.fonts.heading,
+    fontSize: typography.sizes.lg,
+    textTransform: 'uppercase',
+    letterSpacing: 1,
+  },
+  fallback: {
+    padding: spacing.xl,
+    alignItems: 'center',
+  },
+  fallbackText: {
+    fontFamily: typography.fonts.body,
+    fontSize: typography.sizes.md,
+    textAlign: 'center',
+  },
+});

--- a/app/src/services/api.ts
+++ b/app/src/services/api.ts
@@ -525,6 +525,27 @@ export const paymentsApi = {
         createdAt: string;
       }[];
     }>(`/payments/payouts/history?limit=${limit}`),
+
+  createSetupIntent: () =>
+    apiRequest<{ clientSecret: string }>('/payments/methods/setup', {
+      method: 'POST',
+    }),
+
+  listPaymentMethods: () =>
+    apiRequest<{
+      paymentMethods: {
+        id: string;
+        brand: string;
+        last4: string;
+        expMonth: number;
+        expYear: number;
+      }[];
+    }>('/payments/methods'),
+
+  deletePaymentMethod: (paymentMethodId: string) =>
+    apiRequest<{ success: boolean }>(`/payments/methods/${paymentMethodId}`, {
+      method: 'DELETE',
+    }),
 };
 
 // Calendar API

--- a/backend/daterabbit-api/src/payments/payments.controller.ts
+++ b/backend/daterabbit-api/src/payments/payments.controller.ts
@@ -2,6 +2,7 @@ import {
   Controller,
   Get,
   Post,
+  Delete,
   Body,
   Param,
   Query,
@@ -93,6 +94,29 @@ export class PaymentsController {
     @Query('limit') limit = 10,
   ) {
     return this.paymentsService.getPayoutHistory(req.user.id, +limit);
+  }
+
+  // --- Payment Methods ---
+
+  @Post('methods/setup')
+  @UseGuards(JwtAuthGuard)
+  async createSetupIntent(@Request() req) {
+    return this.paymentsService.createSetupIntent(req.user.id);
+  }
+
+  @Get('methods')
+  @UseGuards(JwtAuthGuard)
+  async listPaymentMethods(@Request() req) {
+    return this.paymentsService.listPaymentMethods(req.user.id);
+  }
+
+  @Delete('methods/:paymentMethodId')
+  @UseGuards(JwtAuthGuard)
+  async deletePaymentMethod(
+    @Request() req,
+    @Param('paymentMethodId') paymentMethodId: string,
+  ) {
+    return this.paymentsService.deletePaymentMethod(req.user.id, paymentMethodId);
   }
 }
 

--- a/backend/daterabbit-api/src/payments/payments.service.ts
+++ b/backend/daterabbit-api/src/payments/payments.service.ts
@@ -395,6 +395,91 @@ export class PaymentsService {
     };
   }
 
+  // --- Payment Methods (saved cards via SetupIntent) ---
+
+  private async getOrCreateStripeCustomer(userId: string): Promise<string> {
+    this.ensureStripe();
+    const user = await this.usersRepo.findOne({ where: { id: userId } });
+    if (!user) throw new HttpException('User not found', HttpStatus.NOT_FOUND);
+
+    if (user.stripeCustomerId) {
+      return user.stripeCustomerId;
+    }
+
+    const customer = await this.stripe.customers.create({
+      email: user.email,
+      name: user.name,
+      metadata: { userId: user.id },
+    });
+
+    await this.usersRepo.update(userId, { stripeCustomerId: customer.id });
+    return customer.id;
+  }
+
+  async createSetupIntent(userId: string): Promise<{ clientSecret: string }> {
+    this.ensureStripe();
+    const customerId = await this.getOrCreateStripeCustomer(userId);
+
+    const setupIntent = await this.stripe.setupIntents.create({
+      customer: customerId,
+      payment_method_types: ['card'],
+      usage: 'off_session',
+    });
+
+    return { clientSecret: setupIntent.client_secret! };
+  }
+
+  async listPaymentMethods(userId: string): Promise<{
+    paymentMethods: {
+      id: string;
+      brand: string;
+      last4: string;
+      expMonth: number;
+      expYear: number;
+    }[];
+  }> {
+    this.ensureStripe();
+    const user = await this.usersRepo.findOne({ where: { id: userId } });
+    if (!user?.stripeCustomerId) {
+      return { paymentMethods: [] };
+    }
+
+    const pms = await this.stripe.paymentMethods.list({
+      customer: user.stripeCustomerId,
+      type: 'card',
+    });
+
+    return {
+      paymentMethods: pms.data.map((pm) => ({
+        id: pm.id,
+        brand: pm.card?.brand ?? 'unknown',
+        last4: pm.card?.last4 ?? '****',
+        expMonth: pm.card?.exp_month ?? 0,
+        expYear: pm.card?.exp_year ?? 0,
+      })),
+    };
+  }
+
+  async deletePaymentMethod(
+    userId: string,
+    paymentMethodId: string,
+  ): Promise<{ success: boolean }> {
+    this.ensureStripe();
+    const user = await this.usersRepo.findOne({ where: { id: userId } });
+    if (!user?.stripeCustomerId) {
+      throw new HttpException('No payment account found', HttpStatus.NOT_FOUND);
+    }
+
+    // Verify ownership: PM must belong to this user's customer (IDOR protection)
+    const pm = await this.stripe.paymentMethods.retrieve(paymentMethodId);
+    if (pm.customer !== user.stripeCustomerId) {
+      throw new HttpException('Payment method not found', HttpStatus.NOT_FOUND);
+    }
+
+    await this.stripe.paymentMethods.detach(paymentMethodId);
+    return { success: true };
+  }
+
   // --- Webhooks ---
 
   async handleWebhook(payload: Buffer, signature: string): Promise<void> {

--- a/backend/daterabbit-api/src/users/entities/user.entity.ts
+++ b/backend/daterabbit-api/src/users/entities/user.entity.ts
@@ -87,6 +87,9 @@ export class User {
   stripeOnboardingComplete: boolean;
 
   @Column({ nullable: true })
+  stripeCustomerId: string;
+
+  @Column({ nullable: true })
   otpCode: string;
 
   @Column({ nullable: true })


### PR DESCRIPTION
## Summary

- Adds `stripeCustomerId` nullable column to User entity (mirrors `stripeAccountId` pattern, synced via TypeORM `synchronize` in non-prod)
- Implements full SetupIntent flow on backend: `getOrCreateStripeCustomer`, `createSetupIntent`, `listPaymentMethods`, `deletePaymentMethod` with IDOR protection
- New endpoints: `POST /payments/methods/setup`, `GET /payments/methods`, `DELETE /payments/methods/:id` (all JWT-guarded)
- Frontend: replaces TODO stub with real UI — card list with brand/last4/expiry, loading/empty states, delete with confirm dialog, bottom-sheet modal for Add Card
- `StripeSetupForm` component is web-only; native shows "open in browser" fallback

## Test plan

- [ ] Navigate to Settings → Payment Methods — see loading then empty state
- [ ] Click "Add Payment Method" on web — Stripe card form appears in modal
- [ ] Enter test card `4242 4242 4242 4242` — card appears in list after save
- [ ] Click trash icon → confirm dialog → card removed from list
- [ ] On native — "Add Payment Method" shows "open in browser" alert
- [ ] `GET /payments/methods` returns cards; `DELETE` with wrong PM ID returns 404

Closes #1346