### PR TITLE
fix: set default minRating filter to 0 (show all companions)

### DIFF
--- a/app/app/(tabs)/male/browse.tsx
+++ b/app/app/(tabs)/male/browse.tsx
@@ -21,7 +21,7 @@ const quickFilters = ['All', 'Nearby', 'Top Rated', 'New'];
 const defaultFilterOptions: FilterOptions = {
   priceRange: [50, 200],
   maxDistance: 25,
-  minRating: 4.0,
+  minRating: 0.0,
   availability: 'any',
   ageRange: [21, 45],
   sortBy: 'recommended',

--- a/app/src/components/FilterModal.tsx
+++ b/app/src/components/FilterModal.tsx
@@ -31,7 +31,7 @@ interface FilterModalProps {
 const defaultFilters: FilterOptions = {
   priceRange: [50, 200],
   maxDistance: 25,
-  minRating: 4.0,
+  minRating: 0.0,
   availability: 'any',
   ageRange: [21, 45],
   sortBy: 'recommended',


### PR DESCRIPTION
## Summary
- Default filter state had `minRating: 4.0`, meaning browse opened with 4+ star filter pre-applied
- Changed to `0.0` in both `FilterModal.tsx` (defaultFilters) and `browse.tsx` (defaultFilterOptions)
- Browse now shows all companions by default; users opt-in to rating filter

## Files changed
- `app/src/components/FilterModal.tsx` line 34: `minRating: 4.0` → `0.0`
- `app/app/(tabs)/male/browse.tsx` line 24: `minRating: 4.0` → `0.0`

## Test plan
- Open filter modal on browse tab → rating slider starts at 0 (not 4)
- All companions visible by default
- Slider still works: dragging up filters to higher ratings

🤖 Generated with [Claude Code](https://claude.com/claude-code)