### PR TITLE
fix: fix broken YAML in deploy.yml — OG inject via script file

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,17 +30,7 @@ jobs:
           cd app
           npm ci --legacy-peer-deps
           npx expo export --platform web --clear
-          python3 -c "
-import re
-with open('dist/index.html', 'r') as f:
-    html = f.read()
-og = '<meta name=\"description\" content=\"DateRabbit connects seekers with companions for memorable date experiences. Find, book, and enjoy amazing dates.\"><meta property=\"og:title\" content=\"DateRabbit — Find Your Perfect Date\"><meta property=\"og:description\" content=\"Connect with companions for memorable date experiences.\"><meta property=\"og:image\" content=\"https://daterabbit.smartlaunchhub.com/og-image.png\"><meta property=\"og:url\" content=\"https://daterabbit.smartlaunchhub.com\"><meta property=\"og:type\" content=\"website\"><meta name=\"twitter:card\" content=\"summary_large_image\"><meta name=\"twitter:title\" content=\"DateRabbit\"><meta name=\"twitter:description\" content=\"Connect with companions for memorable date experiences.\"><meta name=\"twitter:image\" content=\"https://daterabbit.smartlaunchhub.com/og-image.png\">'
-html = html.replace('<title>DateRabbit</title>', '<title>DateRabbit — Find Your Perfect Date</title>')
-html = html.replace('</head>', og + '</head>', 1)
-with open('dist/index.html', 'w') as f:
-    f.write(html)
-print('OG tags injected')
-"
+          python3 scripts/inject-og.py dist/index.html
           cat > dist/version.json << VEOF
           {
             "version": "$(git rev-parse --short HEAD)",
@@ -273,17 +263,7 @@ print('OG tags injected')
           cd app
           npm ci --legacy-peer-deps
           npx expo export --platform web --clear
-          python3 -c "
-import re
-with open('dist/index.html', 'r') as f:
-    html = f.read()
-og = '<meta name=\"description\" content=\"DateRabbit connects seekers with companions for memorable date experiences. Find, book, and enjoy amazing dates.\"><meta property=\"og:title\" content=\"DateRabbit — Find Your Perfect Date\"><meta property=\"og:description\" content=\"Connect with companions for memorable date experiences.\"><meta property=\"og:image\" content=\"https://daterabbit.smartlaunchhub.com/og-image.png\"><meta property=\"og:url\" content=\"https://daterabbit.smartlaunchhub.com\"><meta property=\"og:type\" content=\"website\"><meta name=\"twitter:card\" content=\"summary_large_image\"><meta name=\"twitter:title\" content=\"DateRabbit\"><meta name=\"twitter:description\" content=\"Connect with companions for memorable date experiences.\"><meta name=\"twitter:image\" content=\"https://daterabbit.smartlaunchhub.com/og-image.png\">'
-html = html.replace('<title>DateRabbit</title>', '<title>DateRabbit — Find Your Perfect Date</title>')
-html = html.replace('</head>', og + '</head>', 1)
-with open('dist/index.html', 'w') as f:
-    f.write(html)
-print('OG tags injected')
-"
+          python3 scripts/inject-og.py dist/index.html
           cat > dist/version.json << VEOF
           {
             "version": "$(git rev-parse --short HEAD)",

--- a/app/scripts/inject-og.py
+++ b/app/scripts/inject-og.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+"""Inject OG meta tags into the static Expo export index.html."""
+import sys
+
+OG_TAGS = (
+    '<meta name="description" content="DateRabbit connects seekers with companions'
+    ' for memorable date experiences. Find, book, and enjoy amazing dates.">'
+    '<meta property="og:title" content="DateRabbit \u2014 Find Your Perfect Date">'
+    '<meta property="og:description" content="Connect with companions for memorable date experiences.">'
+    '<meta property="og:image" content="https://daterabbit.smartlaunchhub.com/og-image.png">'
+    '<meta property="og:url" content="https://daterabbit.smartlaunchhub.com">'
+    '<meta property="og:type" content="website">'
+    '<meta name="twitter:card" content="summary_large_image">'
+    '<meta name="twitter:title" content="DateRabbit">'
+    '<meta name="twitter:description" content="Connect with companions for memorable date experiences.">'
+    '<meta name="twitter:image" content="https://daterabbit.smartlaunchhub.com/og-image.png">'
+)
+
+
+def inject(path):
+    with open(path, 'r', encoding='utf-8') as f:
+        html = f.read()
+    html = html.replace('<title>DateRabbit</title>', '<title>DateRabbit \u2014 Find Your Perfect Date</title>')
+    html = html.replace('</head>', OG_TAGS + '</head>', 1)
+    with open(path, 'w', encoding='utf-8') as f:
+        f.write(html)
+    print(f'OG tags injected into {path}')
+
+
+if __name__ == '__main__':
+    inject(sys.argv[1] if len(sys.argv) > 1 else 'dist/index.html')


### PR DESCRIPTION
## Summary

Emergency fix: the previous `python3 -c "..."` multiline inline block broke YAML parsing in GitHub Actions. GitHub reported "workflow file issue" and CI was completely broken.

- Replaced both broken occurrences (staging job + prod job) with a clean call: `python3 scripts/inject-og.py dist/index.html`
- Created `app/scripts/inject-og.py` — a standard Python file with no quoting/escaping issues
- OG tag injection logic is identical, just moved out of inline shell into a proper file

## Test plan
- [ ] CI parses the workflow file without errors
- [ ] `inject-og.py` runs after `expo export` and injects OG tags into `dist/index.html`