### PR TITLE
fix: persist notification toggles to server

### DIFF
--- a/app/app/settings/notifications.tsx
+++ b/app/app/settings/notifications.tsx
@@ -29,12 +29,13 @@ export default function NotificationsSettingsScreen() {
   const { user, updateProfile } = useAuthStore();
 
   const [permissionStatus, setPermissionStatus] = useState<'granted' | 'denied' | 'undetermined'>('undetermined');
+  const prefs = user?.notificationPreferences ?? { bookings: true, messages: true, reminders: true, payments: true };
   const [masterEnabled, setMasterEnabled] = useState(user?.notificationsEnabled ?? true);
   const [settings, setSettings] = useState<NotificationSetting[]>([
-    { id: 'bookings', title: 'Booking Updates', description: 'New requests, acceptances, and cancellations', enabled: true },
-    { id: 'messages', title: 'New Messages', description: 'When someone sends you a message', enabled: true },
-    { id: 'reminders', title: 'Date Reminders', description: 'Reminders before upcoming dates', enabled: true },
-    { id: 'payments', title: 'Payment Updates', description: 'Payment confirmations and earnings', enabled: true },
+    { id: 'bookings', title: 'Booking Updates', description: 'New requests, acceptances, and cancellations', enabled: prefs.bookings },
+    { id: 'messages', title: 'New Messages', description: 'When someone sends you a message', enabled: prefs.messages },
+    { id: 'reminders', title: 'Date Reminders', description: 'Reminders before upcoming dates', enabled: prefs.reminders },
+    { id: 'payments', title: 'Payment Updates', description: 'Payment confirmations and earnings', enabled: prefs.payments },
   ]);
 
   useEffect(() => {
@@ -63,14 +64,31 @@ export default function NotificationsSettingsScreen() {
   };
 
   const toggleMaster = async (value: boolean) => {
+    const prev = masterEnabled;
     setMasterEnabled(value);
-    await updateProfile({ notificationsEnabled: value });
+    const result = await updateProfile({ notificationsEnabled: value });
+    if (!result.success) {
+      setMasterEnabled(prev);
+      showAlert('Error', result.error || 'Failed to update notification settings.');
+    }
   };
 
-  const toggleSetting = (id: string) => {
-    setSettings(prev =>
-      prev.map(s => (s.id === id ? { ...s, enabled: !s.enabled } : s))
-    );
+  const toggleSetting = async (id: string) => {
+    const prevSettings = [...settings];
+    const updated = settings.map(s => (s.id === id ? { ...s, enabled: !s.enabled } : s));
+    setSettings(updated);
+
+    const newPrefs = {
+      bookings: updated.find(s => s.id === 'bookings')!.enabled,
+      messages: updated.find(s => s.id === 'messages')!.enabled,
+      reminders: updated.find(s => s.id === 'reminders')!.enabled,
+      payments: updated.find(s => s.id === 'payments')!.enabled,
+    };
+    const result = await updateProfile({ notificationPreferences: newPrefs });
+    if (!result.success) {
+      setSettings(prevSettings);
+      showAlert('Error', result.error || 'Failed to update notification preferences.');
+    }
   };
 
   return (

--- a/app/src/services/api.ts
+++ b/app/src/services/api.ts
@@ -700,5 +700,11 @@ export interface User {
   stripeOnboardingComplete?: boolean;
   expoPushToken?: string;
   notificationsEnabled?: boolean;
+  notificationPreferences?: {
+    bookings: boolean;
+    messages: boolean;
+    reminders: boolean;
+    payments: boolean;
+  };
   createdAt: string;
 }

--- a/app/src/store/authStore.ts
+++ b/app/src/store/authStore.ts
@@ -27,6 +27,12 @@ interface ProfileUpdateData {
   hourlyRate?: number;
   notificationsEnabled?: boolean;
   expoPushToken?: string;
+  notificationPreferences?: {
+    bookings: boolean;
+    messages: boolean;
+    reminders: boolean;
+    payments: boolean;
+  };
 }
 
 interface AuthState {
@@ -86,6 +92,7 @@ function mapApiUserToUser(apiUser: ApiUser): User {
     longitude: apiUser.longitude,
     notificationsEnabled: apiUser.notificationsEnabled,
     expoPushToken: apiUser.expoPushToken,
+    notificationPreferences: apiUser.notificationPreferences,
     createdAt: apiUser.createdAt,
   };
 }

--- a/app/src/types/index.ts
+++ b/app/src/types/index.ts
@@ -43,6 +43,12 @@ export interface User {
   stripeOnboardingComplete?: boolean;
   expoPushToken?: string;
   notificationsEnabled?: boolean;
+  notificationPreferences?: {
+    bookings: boolean;
+    messages: boolean;
+    reminders: boolean;
+    payments: boolean;
+  };
   latitude?: number;
   longitude?: number;
   createdAt: string;

--- a/backend/daterabbit-api/src/users/dto/update-user.dto.ts
+++ b/backend/daterabbit-api/src/users/dto/update-user.dto.ts
@@ -3,6 +3,7 @@ import {
   IsBoolean,
   IsInt,
   IsNumber,
+  IsObject,
   IsOptional,
   IsString,
   IsUUID,
@@ -71,4 +72,22 @@ export class UpdateUserDto {
   @Max(9999, { message: 'hourlyRate must be less than 10000' })
   @Type(() => Number)
   hourlyRate?: number;
+
+  @IsOptional()
+  @IsBoolean()
+  notificationsEnabled?: boolean;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(200)
+  expoPushToken?: string;
+
+  @IsOptional()
+  @IsObject()
+  notificationPreferences?: {
+    bookings: boolean;
+    messages: boolean;
+    reminders: boolean;
+    payments: boolean;
+  };
 }

--- a/backend/daterabbit-api/src/users/entities/user.entity.ts
+++ b/backend/daterabbit-api/src/users/entities/user.entity.ts
@@ -89,6 +89,20 @@ export class User {
   @Column({ nullable: true })
   stripeCustomerId: string;
 
+  @Column({ default: true })
+  notificationsEnabled: boolean;
+
+  @Column({ type: 'varchar', nullable: true })
+  expoPushToken: string;
+
+  @Column({ type: 'simple-json', nullable: true })
+  notificationPreferences: {
+    bookings: boolean;
+    messages: boolean;
+    reminders: boolean;
+    payments: boolean;
+  };
+
   @Column({ nullable: true })
   otpCode: string;
 

--- a/backend/daterabbit-api/src/users/users.controller.ts
+++ b/backend/daterabbit-api/src/users/users.controller.ts
@@ -27,7 +27,7 @@ export class UsersController {
   @UseGuards(JwtAuthGuard)
   @Put('me')
   async updateProfile(@Request() req, @Body() body: UpdateUserDto) {
-    const { name, age, location, bio, photos, hourlyRate } = body;
+    const { name, age, location, bio, photos, hourlyRate, notificationsEnabled, expoPushToken, notificationPreferences } = body;
 
     // Validate hourlyRate if provided
     if (hourlyRate !== undefined && hourlyRate !== null) {
@@ -49,6 +49,9 @@ export class UsersController {
       bio,
       photos,
       hourlyRate,
+      notificationsEnabled,
+      expoPushToken,
+      notificationPreferences,
     });
     if (!updated) {
       return { error: 'User not found' };


### PR DESCRIPTION
## Summary
- Adds 3 missing DB columns (`notificationsEnabled`, `expoPushToken`, `notificationPreferences`) to user entity
- Fixes backend controller to accept and store notification fields (previously silently dropped)
- Wires frontend notification toggles to API with optimistic UI revert on error

## Files changed
- `backend/.../user.entity.ts` — 3 new columns
- `backend/.../update-user.dto.ts` — 3 new validated fields
- `backend/.../users.controller.ts` — destructure + pass new fields
- `app/.../notifications.tsx` — init from server, persist on toggle
- `app/src/types/index.ts` — notificationPreferences on User
- `app/src/services/api.ts` — notificationPreferences on User
- `app/src/store/authStore.ts` — notificationPreferences in ProfileUpdateData + mapApiUserToUser

## Test plan
- [ ] Toggle a notification type, restart app, verify setting persisted
- [ ] Toggle master switch off/on, verify persisted across restart
- [ ] Simulate API error (offline), verify toggle reverts with error alert
- [ ] Verify existing profile update (name, bio, etc.) still works

Closes #1350