### PR TITLE
feat: companion online status (last seen) in browse and profile

### DIFF
--- a/app/app/(tabs)/male/browse.tsx
+++ b/app/app/(tabs)/male/browse.tsx
@@ -11,6 +11,7 @@ import { EmptyState } from '../../../src/components/EmptyState';
 import { FilterModal, FilterOptions } from '../../../src/components/FilterModal';
 import { useTheme, colors, spacing, typography, borderRadius } from '../../../src/constants/theme';
 import { companionsApi, CompanionListItem } from '../../../src/services/api';
+import { formatLastSeen } from '../../../src/utils/formatLastSeen';
 import { showAlert } from '../../../src/utils/alert';
 
 import { useAuthStore } from '../../../src/store/authStore';
@@ -320,6 +321,17 @@ export default function BrowseScreen() {
                       </View>
                     )}
                   </View>
+                  {(() => {
+                    const status = formatLastSeen(companion.lastSeen);
+                    if (!status) return null;
+                    const isOnline = status === 'Online';
+                    return (
+                      <View style={styles.onlineStatusRow}>
+                        <View style={[styles.onlineDot, { backgroundColor: isOnline ? colors.success : colors.textSecondary + '60' }]} />
+                        <Text style={[styles.onlineText, { color: isOnline ? colors.success : colors.textSecondary }]}>{status}</Text>
+                      </View>
+                    );
+                  })()}
                 </View>
                 <View style={[styles.rateBox, { backgroundColor: colors.primary + '15' }]}>
                   <Text style={[styles.rateValue, { color: colors.primary }]}>${companion.hourlyRate ?? 0}</Text>
@@ -604,6 +616,21 @@ const styles = StyleSheet.create({
   },
   newBadgeText: {
     fontFamily: typography.fonts.bodySemiBold,
+    fontSize: typography.sizes.xs,
+  },
+  onlineStatusRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginTop: spacing.xs,
+    gap: spacing.xs,
+  },
+  onlineDot: {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+  },
+  onlineText: {
+    fontFamily: typography.fonts.body,
     fontSize: typography.sizes.xs,
   },
   rateBox: {

--- a/app/app/_layout.tsx
+++ b/app/app/_layout.tsx
@@ -1,8 +1,9 @@
 import { Stack, useRouter, useSegments, usePathname } from 'expo-router';
 import Head from 'expo-router/head';
 import { StatusBar } from 'expo-status-bar';
-import { Platform, View, ActivityIndicator, StyleSheet } from 'react-native';
+import { Platform, View, ActivityIndicator, StyleSheet, AppState } from 'react-native';
 import { useAuthStore } from '../src/store/authStore';
+import { usersApi } from '../src/services/api';
 import { useFonts } from 'expo-font';
 import {
   SpaceGrotesk_400Regular,
@@ -10,7 +11,7 @@ import {
   SpaceGrotesk_600SemiBold,
   SpaceGrotesk_700Bold,
 } from '@expo-google-fonts/space-grotesk';
-import { useEffect } from 'react';
+import { useEffect, useRef, useCallback } from 'react';
 import { colors } from '../src/constants/theme';
 import { StripeProvider } from '../src/components/StripeProvider';
 import { OfflineBanner } from '../src/components/OfflineBanner';
@@ -32,6 +33,39 @@ function useWebNetworkStatus() {
       window.removeEventListener('offline', handleOffline);
     };
   }, [setOffline, setOnline]);
+}
+
+// Send heartbeat to update lastSeen (debounced, max once per 60s)
+const HEARTBEAT_INTERVAL_MS = 60_000;
+
+function useHeartbeat() {
+  const { isAuthenticated } = useAuthStore();
+  const lastHeartbeatRef = useRef(0);
+
+  const sendHeartbeat = useCallback(() => {
+    if (!isAuthenticated) return;
+    const now = Date.now();
+    if (now - lastHeartbeatRef.current < HEARTBEAT_INTERVAL_MS) return;
+    lastHeartbeatRef.current = now;
+    usersApi.heartbeat().catch(() => {
+      // Silently ignore heartbeat failures
+    });
+  }, [isAuthenticated]);
+
+  useEffect(() => {
+    // Send on mount
+    sendHeartbeat();
+
+    // Listen for app returning to foreground (native only)
+    if (Platform.OS !== 'web') {
+      const subscription = AppState.addEventListener('change', (state) => {
+        if (state === 'active') {
+          sendHeartbeat();
+        }
+      });
+      return () => subscription.remove();
+    }
+  }, [sendHeartbeat]);
 }
 
 // Strip __EXPO_ROUTER_key from browser URL bar (Expo Router internal param)
@@ -169,6 +203,8 @@ export default function RootLayout() {
   useCleanUrl();
   // Track web browser online/offline events
   useWebNetworkStatus();
+  // Send heartbeat to update online status
+  useHeartbeat();
 
   // Load Neo-Brutalism font
   const [fontsLoaded] = useFonts({

--- a/app/app/profile/[id].tsx
+++ b/app/app/profile/[id].tsx
@@ -25,6 +25,7 @@ import { useTheme, spacing, typography, borderRadius, colors } from '../../src/c
 import { useFavoritesStore } from '../../src/store/favoritesStore';
 import { useAuthStore } from '../../src/store/authStore';
 import { usersApi, companionsApi, CompanionDetail } from '../../src/services/api';
+import { formatLastSeen } from '../../src/utils/formatLastSeen';
 import * as Haptics from 'expo-haptics';
 
 // Max width for photo container — prevents giant hero on wide screens
@@ -45,6 +46,7 @@ interface ProfileData {
   languages?: string[];
   availability?: string;
   responseTime?: string;
+  lastSeen?: string | null;
   reviews: { id: string; name: string; rating: number; text: string; date: string }[];
 }
 
@@ -63,6 +65,7 @@ const defaultProfile: ProfileData = {
   languages: ['English'],
   availability: 'Available for booking',
   responseTime: 'Varies',
+  lastSeen: null,
   reviews: [],
 };
 
@@ -159,6 +162,7 @@ export default function ProfileViewScreen() {
           languages: data.languages || ['English'],
           availability: 'Available for booking',
           responseTime: 'Varies',
+          lastSeen: (data as any).lastSeen || null,
           reviews: (data as any).reviews || [],
         });
       } catch (err: any) {
@@ -405,6 +409,17 @@ export default function ProfileViewScreen() {
               <Icon name="map-pin" size={16} color={colors.textSecondary} />
               <Text style={[styles.location, { color: colors.textSecondary }]}> {profile.location}</Text>
             </View>
+            {(() => {
+              const status = formatLastSeen(profile.lastSeen);
+              if (!status) return null;
+              const isOnline = status === 'Online';
+              return (
+                <View style={styles.onlineStatusRow}>
+                  <View style={[styles.onlineDot, { backgroundColor: isOnline ? colors.success : colors.textSecondary + '60' }]} />
+                  <Text style={[styles.onlineText, { color: isOnline ? colors.success : colors.textSecondary }]}>{status}</Text>
+                </View>
+              );
+            })()}
 
             <View style={styles.statsRow}>
               <View style={styles.stat}>
@@ -992,6 +1007,21 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     marginTop: spacing.xs,
+  },
+  onlineStatusRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginTop: spacing.xs,
+    gap: spacing.xs,
+  },
+  onlineDot: {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+  },
+  onlineText: {
+    fontFamily: typography.fonts.body,
+    fontSize: typography.sizes.sm,
   },
   location: {
     fontFamily: typography.fonts.body,

--- a/app/src/services/api.ts
+++ b/app/src/services/api.ts
@@ -130,6 +130,9 @@ export const authApi = {
 
 // Users API
 export const usersApi = {
+  heartbeat: () =>
+    apiRequest<{ success: boolean }>('/users/heartbeat', { method: 'PATCH' }),
+
   getMe: () =>
     apiRequest<User>('/users/me'),
 
@@ -243,6 +246,7 @@ export interface CompanionListItem {
   primaryPhoto?: string;
   distance?: number;
   shortBio?: string;
+  lastSeen?: string | null;
 }
 
 export interface CompanionDetail extends CompanionListItem {
@@ -251,6 +255,7 @@ export interface CompanionDetail extends CompanionListItem {
   interests?: string[];
   languages?: string[];
   reviews?: { id: string; name: string; rating: number; text: string; date: string }[];
+  lastSeen?: string | null;
   createdAt: string;
 }
 

--- a/app/src/utils/formatLastSeen.ts
+++ b/app/src/utils/formatLastSeen.ts
@@ -1,0 +1,15 @@
+/**
+ * Format a lastSeen ISO timestamp into a human-readable online status string.
+ * Returns null when lastSeen is not available (user never sent a heartbeat).
+ */
+export function formatLastSeen(lastSeen: string | null | undefined): string | null {
+  if (!lastSeen) return null;
+  const diff = Date.now() - new Date(lastSeen).getTime();
+  const minutes = Math.floor(diff / 60000);
+  if (minutes < 5) return 'Online';
+  if (minutes < 60) return `${minutes} min ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  if (hours < 48) return 'Yesterday';
+  return 'Long ago';
+}

--- a/backend/daterabbit-api/src/companions/companions.controller.ts
+++ b/backend/daterabbit-api/src/companions/companions.controller.ts
@@ -71,6 +71,7 @@ export class CompanionsController {
         reviewCount: c.reviewCount || 0,
         isVerified: c.isVerified || false,
         distance: c.distance != null ? Math.round(c.distance * 10) / 10 : undefined,
+        lastSeen: c.lastSeen ? c.lastSeen.toISOString() : null,
       })),
       total,
       page: currentPage,
@@ -100,6 +101,7 @@ export class CompanionsController {
       rating: user.rating ? Number(user.rating) : null,
       reviewCount: user.reviewCount || 0,
       isVerified: user.isVerified || false,
+      lastSeen: user.lastSeen ? user.lastSeen.toISOString() : null,
       reviews: reviews.map((r) => ({
         id: r.id,
         name: r.reviewer?.name || 'Anonymous',

--- a/backend/daterabbit-api/src/users/entities/user.entity.ts
+++ b/backend/daterabbit-api/src/users/entities/user.entity.ts
@@ -103,6 +103,9 @@ export class User {
     payments: boolean;
   };
 
+  @Column({ type: 'timestamp', nullable: true })
+  lastSeen: Date;
+
   @Column({ nullable: true })
   otpCode: string;
 

--- a/backend/daterabbit-api/src/users/users.controller.ts
+++ b/backend/daterabbit-api/src/users/users.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Post, Put, Delete, Body, UseGuards, Request, Param, BadRequestException, ParseUUIDPipe, UseInterceptors, UploadedFile } from '@nestjs/common';
+import { Controller, Get, Post, Put, Patch, Delete, Body, UseGuards, Request, Param, BadRequestException, ParseUUIDPipe, UseInterceptors, UploadedFile } from '@nestjs/common';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { UsersService } from './users.service';
 import { UploadsService } from '../uploads/uploads.service';
@@ -11,6 +11,13 @@ export class UsersController {
     private usersService: UsersService,
     private uploadsService: UploadsService,
   ) {}
+
+  @UseGuards(JwtAuthGuard)
+  @Patch('heartbeat')
+  async heartbeat(@Request() req) {
+    await this.usersService.updateLastSeen(req.user.id);
+    return { success: true };
+  }
 
   @UseGuards(JwtAuthGuard)
   @Get('me')
@@ -174,6 +181,7 @@ export class UsersController {
       rating: user.rating,
       reviewCount: user.reviewCount,
       isVerified: user.isVerified,
+      lastSeen: user.lastSeen ? user.lastSeen.toISOString() : null,
     };
   }
 }

--- a/backend/daterabbit-api/src/users/users.service.ts
+++ b/backend/daterabbit-api/src/users/users.service.ts
@@ -43,6 +43,10 @@ export class UsersService {
     return this.findById(id);
   }
 
+  async updateLastSeen(userId: string): Promise<void> {
+    await this.usersRepository.update(userId, { lastSeen: new Date() });
+  }
+
   async setOtp(userId: string, code: string, expiresAt: Date): Promise<void> {
     await this.usersRepository.update(userId, {
       otpCode: code,


### PR DESCRIPTION
## Summary
- Adds `lastSeen` timestamp column to User entity (TypeORM synchronize handles migration)
- New `PATCH /users/heartbeat` endpoint updates lastSeen for authenticated users
- `lastSeen` included in companions list, detail, and public profile API responses
- Frontend heartbeat in `_layout.tsx` fires on mount + AppState foreground (debounced 60s)
- `formatLastSeen` utility: Online / Xm ago / Xh ago / Yesterday / Long ago
- Green dot + status text in browse companion cards and profile header
- Null lastSeen = no badge shown (graceful degradation)

## Test plan
- [ ] Open app as authenticated user, verify heartbeat PATCH fires in network tab
- [ ] Browse page: companion cards show green dot + "Online" for recently active users
- [ ] Profile page: online status badge visible below location
- [ ] Companions with null lastSeen show no badge
- [ ] Background/foreground app: heartbeat fires again after 60s debounce