### PR TITLE
feat: companion sees private seeker rating on booking requests

### DIFF
--- a/app/app/(tabs)/female/requests.tsx
+++ b/app/app/(tabs)/female/requests.tsx
@@ -166,6 +166,17 @@ function RequestCard({ request, type, colors, onAccept, onDecline, formatDate }:
         <UserImage name={seeker.name} uri={seeker.photo} size={56} />
         <View style={styles.cardInfo}>
           <Text style={[styles.cardName, { color: colors.text }]}>{seeker.name}</Text>
+          {request.seekerRating && request.seekerRating.count > 0 && (
+            <View style={styles.seekerRatingRow}>
+              <Text style={styles.seekerRatingStars}>
+                {'★'.repeat(Math.round(request.seekerRating.average))}
+                {'☆'.repeat(5 - Math.round(request.seekerRating.average))}
+              </Text>
+              <Text style={[styles.seekerRatingCount, { color: colors.textSecondary }]}>
+                ({request.seekerRating.count})
+              </Text>
+            </View>
+          )}
           <Text style={[styles.cardActivity, { color: colors.text }]}>{request.activity || 'Date'}</Text>
           <Text style={[styles.cardDate, { color: colors.textSecondary }]}>{formatDate(request.date)} • {request.duration}h</Text>
         </View>
@@ -307,6 +318,20 @@ const styles = StyleSheet.create({
   cardName: {
     fontFamily: typography.fonts.bodySemiBold,
     fontSize: typography.sizes.md,
+  },
+  seekerRatingRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginTop: 2,
+    gap: 4,
+  },
+  seekerRatingStars: {
+    fontSize: typography.sizes.sm,
+    color: '#FF2A5F',
+  },
+  seekerRatingCount: {
+    fontFamily: typography.fonts.body,
+    fontSize: typography.sizes.xs,
   },
   cardActivity: {
     fontFamily: typography.fonts.body,

--- a/app/app/date/summary/[bookingId].tsx
+++ b/app/app/date/summary/[bookingId].tsx
@@ -73,26 +73,24 @@ export default function DateSummaryScreen() {
         </View>
       )}
 
-      {/* Star rating prompt — for seekers only */}
-      {!isCompanion && (
-        <View style={styles.ratingSection}>
-          <Text style={styles.sectionTitle}>How was your date?</Text>
-          <View style={styles.starsRow}>
-            {STARS.map(star => (
-              <TouchableOpacity
-                key={star}
-                onPress={() => setRating(star)}
-                accessibilityLabel={`Rate ${star} star${star > 1 ? 's' : ''}`}
-                accessibilityRole="button"
-              >
-                <Text style={[styles.star, rating >= star && styles.starActive]}>
-                  {rating >= star ? '★' : '☆'}
-                </Text>
-              </TouchableOpacity>
-            ))}
-          </View>
+      {/* Star rating prompt — both seekers and companions can rate */}
+      <View style={styles.ratingSection}>
+        <Text style={styles.sectionTitle}>How was your date?</Text>
+        <View style={styles.starsRow}>
+          {STARS.map(star => (
+            <TouchableOpacity
+              key={star}
+              onPress={() => setRating(star)}
+              accessibilityLabel={`Rate ${star} star${star > 1 ? 's' : ''}`}
+              accessibilityRole="button"
+            >
+              <Text style={[styles.star, rating >= star && styles.starActive]}>
+                {rating >= star ? '★' : '☆'}
+              </Text>
+            </TouchableOpacity>
+          ))}
         </View>
-      )}
+      </View>
 
       {photos.length > 0 && (
         <View style={styles.photosSection}>

--- a/app/src/services/api.ts
+++ b/app/src/services/api.ts
@@ -325,6 +325,7 @@ export interface Booking {
     photo?: string;
     rating: number;
   };
+  seekerRating?: { average: number; count: number } | null;
   createdAt: string;
 }
 

--- a/backend/daterabbit-api/src/bookings/bookings.controller.ts
+++ b/backend/daterabbit-api/src/bookings/bookings.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Post, Put, Body, Param, Query, UseGuards, Request, HttpException, HttpStatus, ParseUUIDPipe, UseInterceptors, UploadedFile, BadRequestException } from '@nestjs/common';
+import { Controller, Get, Post, Put, Body, Param, Query, UseGuards, Request, HttpException, HttpStatus, ParseUUIDPipe, UseInterceptors, UploadedFile, BadRequestException, Inject, forwardRef } from '@nestjs/common';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { BookingsService } from './bookings.service';
 import { PaymentsService } from '../payments/payments.service';
@@ -7,6 +7,7 @@ import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { BookingStatus, ActivityType } from './entities/booking.entity';
 import { NotificationsService } from '../notifications/notifications.service';
 import { NotificationType } from '../notifications/entities/notification.entity';
+import { ReviewsService } from '../reviews/reviews.service';
 
 @Controller('bookings')
 @UseGuards(JwtAuthGuard)
@@ -16,6 +17,8 @@ export class BookingsController {
     private paymentsService: PaymentsService,
     private notificationsService: NotificationsService,
     private uploadsService: UploadsService,
+    @Inject(forwardRef(() => ReviewsService))
+    private reviewsService: ReviewsService,
   ) {}
 
   @Post()
@@ -107,8 +110,21 @@ export class BookingsController {
 
   @Get('requests')
   async getPendingRequests(@Request() req) {
-    const requests = await this.bookingsService.getPendingRequests(req.user.id);
-    return requests.map((b) => this.formatBooking(b));
+    const companionId = req.user.id;
+    const requests = await this.bookingsService.getPendingRequests(companionId);
+
+    // Batch-query seeker ratings to avoid N+1
+    const seekerIds = [...new Set(requests.map((b) => b.seekerId).filter(Boolean))];
+    const ratingsMap = await this.reviewsService.getSeekerPrivateRatingsBatch(companionId, seekerIds);
+
+    return requests.map((b) => {
+      const formatted = this.formatBooking(b);
+      const seekerRating = ratingsMap.get(b.seekerId);
+      return {
+        ...formatted,
+        seekerRating: seekerRating && seekerRating.count > 0 ? seekerRating : null,
+      };
+    });
   }
 
   @Get('active')

--- a/backend/daterabbit-api/src/bookings/bookings.module.ts
+++ b/backend/daterabbit-api/src/bookings/bookings.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { MulterModule } from '@nestjs/platform-express';
 import * as multer from 'multer';
@@ -13,6 +13,7 @@ import { EmailModule } from '../email/email.module';
 import { PaymentsModule } from '../payments/payments.module';
 import { NotificationsModule } from '../notifications/notifications.module';
 import { UploadsModule } from '../uploads/uploads.module';
+import { ReviewsModule } from '../reviews/reviews.module';
 
 @Module({
   imports: [
@@ -26,6 +27,7 @@ import { UploadsModule } from '../uploads/uploads.module';
     PaymentsModule,
     NotificationsModule,
     UploadsModule,
+    forwardRef(() => ReviewsModule),
   ],
   providers: [BookingsService, BookingsCron],
   controllers: [BookingsController],

--- a/backend/daterabbit-api/src/reviews/reviews.controller.ts
+++ b/backend/daterabbit-api/src/reviews/reviews.controller.ts
@@ -8,6 +8,7 @@ import {
   UseGuards,
   Request,
   ParseUUIDPipe,
+  ForbiddenException,
 } from '@nestjs/common';
 import { ReviewsService } from './reviews.service';
 import { CreateReviewDto } from './dto/create-review.dto';
@@ -39,8 +40,32 @@ export class ReviewsController {
     };
   }
 
+  /**
+   * GET /reviews/seeker-rating/:seekerId
+   * Returns this companion's private rating of a specific seeker.
+   * 403 if caller IS the seeker (seekers cannot see their own private rating).
+   */
+  @Get('seeker-rating/:seekerId')
+  @UseGuards(JwtAuthGuard)
+  async getSeekerPrivateRating(
+    @Request() req,
+    @Param('seekerId', new ParseUUIDPipe()) seekerId: string,
+  ) {
+    if (req.user.id === seekerId) {
+      throw new ForbiddenException('Cannot view your own private rating');
+    }
+    return this.reviewsService.getSeekerPrivateRating(req.user.id, seekerId);
+  }
+
+  /**
+   * GET /reviews/users/:userId
+   * Privacy: when a seeker views their own reviews, hide companion->seeker reviews
+   * (those are private and only visible to the companion who left them).
+   */
   @Get('users/:userId')
+  @UseGuards(JwtAuthGuard)
   async getReviewsForUser(
+    @Request() req,
     @Param('userId', new ParseUUIDPipe()) userId: string,
     @Query('page') page = 1,
     @Query('limit') limit = 20,
@@ -51,8 +76,15 @@ export class ReviewsController {
       +limit,
     );
 
+    // If the caller is viewing their own reviews, filter out companion->seeker reviews
+    // (private ratings that only the reviewing companion should see)
+    const isOwnProfile = req.user.id === userId;
+    const filtered = isOwnProfile
+      ? reviews.filter((r) => r.reviewer?.role !== 'companion')
+      : reviews;
+
     return {
-      reviews: reviews.map((r) => ({
+      reviews: filtered.map((r) => ({
         id: r.id,
         rating: r.rating,
         comment: r.comment,
@@ -61,9 +93,9 @@ export class ReviewsController {
           : undefined,
         createdAt: r.createdAt,
       })),
-      total,
+      total: filtered.length,
       page: +page,
-      totalPages: Math.ceil(total / +limit),
+      totalPages: Math.ceil(filtered.length / +limit),
     };
   }
 }

--- a/backend/daterabbit-api/src/reviews/reviews.service.ts
+++ b/backend/daterabbit-api/src/reviews/reviews.service.ts
@@ -91,6 +91,59 @@ export class ReviewsService {
     }
   }
 
+  /**
+   * Get a companion's private rating of a specific seeker.
+   * Returns only reviews where this companion reviewed this seeker.
+   */
+  async getSeekerPrivateRating(
+    companionId: string,
+    seekerId: string,
+  ): Promise<{ average: number; count: number }> {
+    const result = await this.reviewsRepo
+      .createQueryBuilder('review')
+      .select('AVG(review.rating)', 'avg')
+      .addSelect('COUNT(*)', 'count')
+      .where('review.reviewerId = :companionId', { companionId })
+      .andWhere('review.revieweeId = :seekerId', { seekerId })
+      .getRawOne();
+
+    return {
+      average: parseFloat(result.avg) || 0,
+      count: parseInt(result.count) || 0,
+    };
+  }
+
+  /**
+   * Batch-query companion's private ratings for multiple seekers.
+   * Returns a map of seekerId -> { average, count }.
+   */
+  async getSeekerPrivateRatingsBatch(
+    companionId: string,
+    seekerIds: string[],
+  ): Promise<Map<string, { average: number; count: number }>> {
+    const map = new Map<string, { average: number; count: number }>();
+    if (seekerIds.length === 0) return map;
+
+    const results = await this.reviewsRepo
+      .createQueryBuilder('review')
+      .select('review.revieweeId', 'seekerId')
+      .addSelect('AVG(review.rating)', 'avg')
+      .addSelect('COUNT(*)', 'count')
+      .where('review.reviewerId = :companionId', { companionId })
+      .andWhere('review.revieweeId IN (:...seekerIds)', { seekerIds })
+      .groupBy('review.revieweeId')
+      .getRawMany();
+
+    for (const row of results) {
+      map.set(row.seekerId, {
+        average: parseFloat(row.avg) || 0,
+        count: parseInt(row.count) || 0,
+      });
+    }
+
+    return map;
+  }
+
   private async updateUserRating(userId: string): Promise<void> {
     const result = await this.reviewsRepo
       .createQueryBuilder('review')


### PR DESCRIPTION
## Summary
- Companions see their own past ratings of a seeker on new booking request cards (stars + count)
- New `GET /reviews/seeker-rating/:seekerId` endpoint with 403 for self-access
- Privacy fix: `GET /reviews/users/:userId` hides companion->seeker reviews from seekers
- Batch-query optimization prevents N+1 on pending requests
- Both seekers and companions can now rate from date summary screen

## Test plan
- [ ] Companion with past review of seeker sees stars on new request card
- [ ] Companion with no past reviews sees no rating badge
- [ ] Seeker calls `GET /reviews/seeker-rating/{ownId}` -> 403
- [ ] Seeker views own reviews -> companion->seeker reviews hidden
- [ ] Companion sees rating prompt on date summary screen