### PR TITLE
feat: date packages — companion packages from templates, seeker selects on booking

### DIFF
--- a/app/app/booking/[id].tsx
+++ b/app/app/booking/[id].tsx
@@ -17,7 +17,7 @@ import { Icon } from '../../src/components/Icon';
 import { UserImage } from '../../src/components/UserImage';
 import { useTheme, spacing, typography, borderRadius } from '../../src/constants/theme';
 import { useBookingsStore } from '../../src/store/bookingsStore';
-import { companionsApi, CompanionDetail } from '../../src/services/api';
+import { companionsApi, CompanionDetail, packagesApi, DatePackage } from '../../src/services/api';
 import { showAlert, showConfirm } from '../../src/utils/alert';
 import { useVerificationGate } from '../../src/hooks/useVerificationGate';
 
@@ -65,7 +65,7 @@ const timeSlots = [
 ];
 
 export default function BookingScreen() {
-  const { id } = useLocalSearchParams<{ id: string }>();
+  const { id, packageId: initialPackageId } = useLocalSearchParams<{ id: string; packageId?: string }>();
   const insets = useSafeAreaInsets();
   const { colors } = useTheme();
 
@@ -83,6 +83,8 @@ export default function BookingScreen() {
   const [location, setLocation] = useState('');
   const [notes, setNotes] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [companionPackages, setCompanionPackages] = useState<DatePackage[]>([]);
+  const [selectedPackage, setSelectedPackage] = useState<DatePackage | null>(null);
 
   useEffect(() => {
     if (!id) return;
@@ -91,6 +93,20 @@ export default function BookingScreen() {
       .then((data) => setCompanion(data))
       .catch(() => showAlert('Error', 'Could not load companion profile.'))
       .finally(() => setIsLoadingCompanion(false));
+
+    // Load companion packages
+    packagesApi.getCompanionPackages(id).then((pkgs) => {
+      setCompanionPackages(pkgs);
+      // Auto-select package if passed via URL
+      if (initialPackageId) {
+        const match = pkgs.find((p) => p.id === initialPackageId);
+        if (match) {
+          setSelectedPackage(match);
+          setSelectedActivity(match.template?.defaultActivity || null);
+          setSelectedDuration(match.template?.defaultDuration || 2);
+        }
+      }
+    }).catch(() => {});
   }, [id]);
 
   // Check if user has entered any data worth confirming before leaving
@@ -136,7 +152,8 @@ export default function BookingScreen() {
 
   const serviceFee = 0.15; // 15% platform fee
   const hourlyRate = companion?.hourlyRate ?? 0;
-  const subtotal = hourlyRate * selectedDuration;
+  const isPackageBooking = !!selectedPackage;
+  const subtotal = isPackageBooking ? Number(selectedPackage!.price) : hourlyRate * selectedDuration;
   const fee = Math.round(subtotal * serviceFee);
   const total = subtotal + fee;
 
@@ -175,6 +192,7 @@ export default function BookingScreen() {
       duration: selectedDuration,
       location,
       notes,
+      ...(selectedPackage ? { packageId: selectedPackage.id } : {}),
     });
 
     setIsSubmitting(false);
@@ -225,6 +243,77 @@ export default function BookingScreen() {
             </View>
           </View>
         </Card>
+
+        {/* Package Selection */}
+        {companionPackages.length > 0 && (
+          <View style={styles.section}>
+            <Text style={[styles.sectionTitle, { color: colors.text }]}>Choose a Package (optional)</Text>
+            <ScrollView horizontal showsHorizontalScrollIndicator={false} style={{ marginHorizontal: -spacing.lg, paddingHorizontal: spacing.lg }}>
+              {selectedPackage && (
+                <TouchableOpacity
+                  style={[
+                    styles.packageCard,
+                    { backgroundColor: colors.surface, borderColor: colors.border },
+                  ]}
+                  onPress={() => {
+                    setSelectedPackage(null);
+                    setSelectedActivity(null);
+                    setSelectedDuration(2);
+                  }}
+                >
+                  <Icon name="x" size={20} color={colors.textSecondary} />
+                  <Text style={[styles.packageCardLabel, { color: colors.textSecondary }]}>No package</Text>
+                </TouchableOpacity>
+              )}
+              {companionPackages.map((pkg) => {
+                const isSelected = selectedPackage?.id === pkg.id;
+                return (
+                  <TouchableOpacity
+                    key={pkg.id}
+                    style={[
+                      styles.packageCard,
+                      { backgroundColor: colors.white, borderColor: colors.border },
+                      isSelected && { borderColor: colors.primary, backgroundColor: colors.primary + '10' },
+                    ]}
+                    onPress={() => {
+                      if (isSelected) {
+                        setSelectedPackage(null);
+                        setSelectedActivity(null);
+                        setSelectedDuration(2);
+                      } else {
+                        setSelectedPackage(pkg);
+                        setSelectedActivity(pkg.template?.defaultActivity || null);
+                        setSelectedDuration(pkg.template?.defaultDuration || 2);
+                      }
+                    }}
+                    accessibilityLabel={`${pkg.template?.name} package, $${Number(pkg.price)} total`}
+                    accessibilityRole="button"
+                    accessibilityState={{ selected: isSelected }}
+                  >
+                    <Icon name={pkg.template?.icon || 'package'} size={24} color={isSelected ? colors.primary : colors.textSecondary} />
+                    <Text style={[styles.packageCardLabel, { color: colors.text }, isSelected && { color: colors.primary }]}>
+                      {pkg.template?.name}
+                    </Text>
+                    <Text style={[styles.packageCardDuration, { color: colors.textSecondary }, isSelected && { color: colors.primary }]}>
+                      {pkg.template?.defaultDuration}h
+                    </Text>
+                    <Text style={[styles.packageCardPrice, { color: colors.primary }]}>
+                      ${Number(pkg.price)} total
+                    </Text>
+                  </TouchableOpacity>
+                );
+              })}
+            </ScrollView>
+            {selectedPackage && (
+              <View style={[styles.packageNote, { backgroundColor: colors.primary + '10' }]}>
+                <Icon name="info" size={14} color={colors.primary} />
+                <Text style={[styles.packageNoteText, { color: colors.primary }]}>
+                  Package selected: {selectedPackage.template?.defaultDuration}h {selectedPackage.template?.defaultActivity}. Price is fixed at ${Number(selectedPackage.price)}.
+                </Text>
+              </View>
+            )}
+          </View>
+        )}
 
         {/* Activity Selection */}
         <View style={styles.section}>
@@ -421,7 +510,9 @@ export default function BookingScreen() {
           <Text style={[styles.summaryTitle, { color: colors.text }]}>Price Summary</Text>
           <View style={styles.summaryRow}>
             <Text style={[styles.summaryLabel, { color: colors.textSecondary }]}>
-              ${hourlyRate} × {selectedDuration} hours
+              {isPackageBooking
+                ? `${selectedPackage!.template?.name} (${selectedPackage!.template?.defaultDuration}h)`
+                : `$${hourlyRate} x ${selectedDuration} hours`}
             </Text>
             <Text style={[styles.summaryValue, { color: colors.text }]}>${subtotal}</Text>
           </View>
@@ -702,5 +793,46 @@ const styles = StyleSheet.create({
   submitButton: {
     flex: 1,
     marginLeft: spacing.lg,
+  },
+  packageCard: {
+    padding: spacing.md,
+    borderRadius: borderRadius.lg,
+    borderWidth: 2,
+    marginRight: spacing.sm,
+    alignItems: 'center',
+    minWidth: 120,
+    minHeight: 100,
+    justifyContent: 'center',
+  },
+  packageCardLabel: {
+    fontFamily: typography.fonts.bodyMedium,
+    fontSize: typography.sizes.sm,
+    fontWeight: '500',
+    marginTop: spacing.xs,
+    textAlign: 'center',
+  },
+  packageCardDuration: {
+    fontFamily: typography.fonts.body,
+    fontSize: typography.sizes.xs,
+    marginTop: 2,
+  },
+  packageCardPrice: {
+    fontFamily: typography.fonts.heading,
+    fontSize: typography.sizes.md,
+    fontWeight: '700',
+    marginTop: spacing.xs,
+  },
+  packageNote: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    padding: spacing.sm,
+    borderRadius: borderRadius.sm,
+    marginTop: spacing.sm,
+    gap: spacing.xs,
+  },
+  packageNoteText: {
+    fontFamily: typography.fonts.body,
+    fontSize: typography.sizes.sm,
+    flex: 1,
   },
 });

--- a/app/app/profile/[id].tsx
+++ b/app/app/profile/[id].tsx
@@ -24,7 +24,7 @@ import { UserImage } from '../../src/components/UserImage';
 import { useTheme, spacing, typography, borderRadius, colors } from '../../src/constants/theme';
 import { useFavoritesStore } from '../../src/store/favoritesStore';
 import { useAuthStore } from '../../src/store/authStore';
-import { usersApi, companionsApi, CompanionDetail } from '../../src/services/api';
+import { usersApi, companionsApi, CompanionDetail, packagesApi, DatePackage } from '../../src/services/api';
 import { formatLastSeen } from '../../src/utils/formatLastSeen';
 import * as Haptics from 'expo-haptics';
 
@@ -105,6 +105,7 @@ export default function ProfileViewScreen() {
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [currentPhotoIndex, setCurrentPhotoIndex] = useState(0);
+  const [datePackages, setDatePackages] = useState<DatePackage[]>([]);
   const [photoModalVisible, setPhotoModalVisible] = useState(false);
 
   const { favorites, toggleFavorite } = useFavoritesStore();
@@ -165,6 +166,9 @@ export default function ProfileViewScreen() {
           lastSeen: (data as any).lastSeen || null,
           reviews: (data as any).reviews || [],
         });
+
+        // Fetch companion's date packages (fire-and-forget for profile load)
+        packagesApi.getCompanionPackages(id).then(setDatePackages).catch(() => {});
       } catch (err: any) {
         console.error('Failed to fetch profile:', err);
         setError(err.message || 'Failed to load profile');
@@ -172,7 +176,7 @@ export default function ProfileViewScreen() {
         setIsLoading(false);
       }
     };
-    
+
     fetchProfile();
   }, [id]);
 
@@ -441,6 +445,45 @@ export default function ProfileViewScreen() {
               </View>
             </View>
           </View>
+
+          {/* Date Packages */}
+          {datePackages.length > 0 && (
+            <Card style={styles.section}>
+              <Text style={[styles.sectionTitle, { color: colors.text }]}>Date Packages</Text>
+              {datePackages.map((pkg) => (
+                <TouchableOpacity
+                  key={pkg.id}
+                  style={[styles.packageItem, { borderBottomColor: colors.border }]}
+                  onPress={() => {
+                    if (!isAuthenticated) {
+                      showAlert('Sign In Required', 'Please sign in to book a date.');
+                      router.push('/(auth)/welcome');
+                      return;
+                    }
+                    router.push(`/booking/${profile.id}?packageId=${pkg.id}`);
+                  }}
+                  accessibilityLabel={`${pkg.template?.name} package, $${Number(pkg.price)} total`}
+                  accessibilityRole="button"
+                >
+                  <View style={[styles.packageIconWrap, { backgroundColor: colors.primary + '15' }]}>
+                    <Icon name={pkg.template?.icon || 'package'} size={20} color={colors.primary} />
+                  </View>
+                  <View style={styles.packageDetails}>
+                    <Text style={[styles.packageTitle, { color: colors.text }]}>
+                      {pkg.template?.name || 'Package'}
+                    </Text>
+                    <Text style={[styles.packageMeta, { color: colors.textSecondary }]}>
+                      {pkg.template?.defaultDuration}h — {pkg.customDescription || pkg.template?.description}
+                    </Text>
+                  </View>
+                  <View style={styles.packagePriceWrap}>
+                    <Text style={[styles.packagePriceText, { color: colors.primary }]}>${Number(pkg.price)}</Text>
+                    <Text style={[styles.packagePriceLabel, { color: colors.textSecondary }]}>total</Text>
+                  </View>
+                </TouchableOpacity>
+              ))}
+            </Card>
+          )}
 
           {/* Bio */}
           {profile.bio ? (
@@ -1075,6 +1118,46 @@ const styles = StyleSheet.create({
   },
   section: {
     marginBottom: spacing.md,
+  },
+  packageItem: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: spacing.md,
+    borderBottomWidth: 1,
+  },
+  packageIconWrap: {
+    width: 40,
+    height: 40,
+    borderRadius: 10,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginRight: spacing.md,
+  },
+  packageDetails: {
+    flex: 1,
+  },
+  packageTitle: {
+    fontFamily: typography.fonts.bodySemiBold,
+    fontSize: typography.sizes.md,
+    fontWeight: '600',
+  },
+  packageMeta: {
+    fontFamily: typography.fonts.body,
+    fontSize: typography.sizes.sm,
+    marginTop: 2,
+  },
+  packagePriceWrap: {
+    alignItems: 'flex-end',
+    marginLeft: spacing.sm,
+  },
+  packagePriceText: {
+    fontFamily: typography.fonts.heading,
+    fontSize: typography.sizes.lg,
+    fontWeight: '700',
+  },
+  packagePriceLabel: {
+    fontFamily: typography.fonts.body,
+    fontSize: typography.sizes.xs,
   },
   sectionHeader: {
     flexDirection: 'row',

--- a/app/app/settings/index.tsx
+++ b/app/app/settings/index.tsx
@@ -119,6 +119,18 @@ export default function SettingsScreen() {
                 />
               </>
             )}
+            {user?.role === 'companion' && (
+              <>
+                <View style={[styles.divider, { backgroundColor: colors.divider }]} />
+                <SettingsMenuItem
+                  icon="package"
+                  label="My Packages"
+                  description="Create date packages with fixed pricing"
+                  onPress={() => router.push('/settings/my-packages')}
+                  colors={colors}
+                />
+              </>
+            )}
           </Card>
         </View>
 

--- a/app/app/settings/my-packages.tsx
+++ b/app/app/settings/my-packages.tsx
@@ -1,0 +1,497 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  ScrollView,
+  TouchableOpacity,
+  TextInput,
+  ActivityIndicator,
+  Alert,
+  RefreshControl,
+} from 'react-native';
+import { router } from 'expo-router';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { Icon } from '../../src/components/Icon';
+import { Card } from '../../src/components/Card';
+import { Button } from '../../src/components/Button';
+import { useTheme, spacing, typography, borderRadius } from '../../src/constants/theme';
+import { packagesApi, DatePackageTemplate, DatePackage } from '../../src/services/api';
+
+export default function MyPackagesScreen() {
+  const insets = useSafeAreaInsets();
+  const { colors } = useTheme();
+
+  const [templates, setTemplates] = useState<DatePackageTemplate[]>([]);
+  const [packages, setPackages] = useState<DatePackage[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+
+  // Create form state
+  const [selectedTemplateId, setSelectedTemplateId] = useState<string | null>(null);
+  const [price, setPrice] = useState('');
+  const [customDescription, setCustomDescription] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  // Edit mode
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editPrice, setEditPrice] = useState('');
+  const [editDescription, setEditDescription] = useState('');
+
+  const fetchData = useCallback(async () => {
+    try {
+      const [t, p] = await Promise.all([
+        packagesApi.getTemplates(),
+        packagesApi.getMyPackages(),
+      ]);
+      setTemplates(t);
+      setPackages(p);
+    } catch (err: any) {
+      Alert.alert('Error', err.message || 'Failed to load packages');
+    } finally {
+      setIsLoading(false);
+      setRefreshing(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  const onRefresh = () => {
+    setRefreshing(true);
+    fetchData();
+  };
+
+  // Templates that the companion hasn't created a package for yet
+  const availableTemplates = templates.filter(
+    (t) => !packages.some((p) => p.templateId === t.id),
+  );
+
+  const handleCreate = async () => {
+    if (!selectedTemplateId || !price) {
+      Alert.alert('Missing Info', 'Select a template and set a price.');
+      return;
+    }
+    const priceNum = parseFloat(price);
+    if (isNaN(priceNum) || priceNum <= 0) {
+      Alert.alert('Invalid Price', 'Price must be a positive number.');
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      await packagesApi.createPackage({
+        templateId: selectedTemplateId,
+        price: priceNum,
+        customDescription: customDescription.trim() || undefined,
+      });
+      setSelectedTemplateId(null);
+      setPrice('');
+      setCustomDescription('');
+      fetchData();
+    } catch (err: any) {
+      Alert.alert('Error', err.message || 'Failed to create package');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleUpdate = async (id: string) => {
+    const priceNum = parseFloat(editPrice);
+    if (isNaN(priceNum) || priceNum <= 0) {
+      Alert.alert('Invalid Price', 'Price must be a positive number.');
+      return;
+    }
+    try {
+      await packagesApi.updatePackage(id, {
+        price: priceNum,
+        customDescription: editDescription.trim() || undefined,
+      });
+      setEditingId(null);
+      fetchData();
+    } catch (err: any) {
+      Alert.alert('Error', err.message || 'Failed to update package');
+    }
+  };
+
+  const handleDelete = (id: string) => {
+    Alert.alert('Delete Package', 'Are you sure you want to delete this package?', [
+      { text: 'Cancel', style: 'cancel' },
+      {
+        text: 'Delete',
+        style: 'destructive',
+        onPress: async () => {
+          try {
+            await packagesApi.deletePackage(id);
+            fetchData();
+          } catch (err: any) {
+            Alert.alert('Error', err.message || 'Failed to delete');
+          }
+        },
+      },
+    ]);
+  };
+
+  const handleToggleActive = async (pkg: DatePackage) => {
+    try {
+      await packagesApi.updatePackage(pkg.id, { isActive: !pkg.isActive });
+      fetchData();
+    } catch (err: any) {
+      Alert.alert('Error', err.message || 'Failed to update');
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <View style={[styles.container, { backgroundColor: colors.background, justifyContent: 'center', alignItems: 'center' }]}>
+        <ActivityIndicator size="large" color={colors.primary} />
+      </View>
+    );
+  }
+
+  return (
+    <View style={[styles.container, { backgroundColor: colors.background }]}>
+      <View style={[styles.header, { paddingTop: insets.top + spacing.sm, backgroundColor: colors.white, borderBottomColor: colors.border }]}>
+        <TouchableOpacity style={[styles.backButton, { backgroundColor: colors.surface }]} onPress={() => router.back()}>
+          <Icon name="arrow-left" size={24} color={colors.text} />
+        </TouchableOpacity>
+        <Text style={[styles.headerTitle, { color: colors.text }]}>My Packages</Text>
+        <View style={{ width: 44 }} />
+      </View>
+
+      <ScrollView
+        style={styles.scrollView}
+        contentContainerStyle={styles.content}
+        refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} />}
+      >
+        {/* Existing packages */}
+        {packages.length > 0 && (
+          <View style={styles.section}>
+            <Text style={[styles.sectionTitle, { color: colors.text }]}>Your Packages</Text>
+            {packages.map((pkg) => {
+              const isEditing = editingId === pkg.id;
+              return (
+                <Card key={pkg.id} style={styles.packageCard}>
+                  <View style={styles.packageHeader}>
+                    <View style={[styles.packageIcon, { backgroundColor: colors.primary + '15' }]}>
+                      <Icon name={pkg.template?.icon || 'package'} size={20} color={colors.primary} />
+                    </View>
+                    <View style={styles.packageInfo}>
+                      <Text style={[styles.packageName, { color: colors.text }]}>
+                        {pkg.template?.name || 'Package'}
+                      </Text>
+                      <Text style={[styles.packageDuration, { color: colors.textSecondary }]}>
+                        {pkg.template?.defaultDuration}h {pkg.template?.defaultActivity}
+                      </Text>
+                    </View>
+                    <View style={styles.packageActions}>
+                      {!isEditing && (
+                        <>
+                          <Text style={[styles.packagePrice, { color: colors.primary }]}>${Number(pkg.price)}</Text>
+                          {!pkg.isActive && (
+                            <Text style={[styles.inactiveBadge, { color: colors.textSecondary }]}>Inactive</Text>
+                          )}
+                        </>
+                      )}
+                    </View>
+                  </View>
+                  {pkg.customDescription && !isEditing ? (
+                    <Text style={[styles.customDesc, { color: colors.textSecondary }]}>{pkg.customDescription}</Text>
+                  ) : null}
+
+                  {isEditing ? (
+                    <View style={styles.editForm}>
+                      <TextInput
+                        style={[styles.input, { backgroundColor: colors.surface, borderColor: colors.border, color: colors.text }]}
+                        placeholder="Price ($)"
+                        value={editPrice}
+                        onChangeText={setEditPrice}
+                        keyboardType="numeric"
+                        placeholderTextColor={colors.textSecondary}
+                      />
+                      <TextInput
+                        style={[styles.input, styles.textArea, { backgroundColor: colors.surface, borderColor: colors.border, color: colors.text }]}
+                        placeholder="Custom description (optional)"
+                        value={editDescription}
+                        onChangeText={setEditDescription}
+                        multiline
+                        placeholderTextColor={colors.textSecondary}
+                      />
+                      <View style={styles.editButtons}>
+                        <Button title="Save" onPress={() => handleUpdate(pkg.id)} style={{ flex: 1 }} />
+                        <Button title="Cancel" variant="outline" onPress={() => setEditingId(null)} style={{ flex: 1 }} />
+                      </View>
+                    </View>
+                  ) : (
+                    <View style={styles.actionRow}>
+                      <TouchableOpacity
+                        style={[styles.actionBtn, { backgroundColor: colors.surface }]}
+                        onPress={() => {
+                          setEditingId(pkg.id);
+                          setEditPrice(String(Number(pkg.price)));
+                          setEditDescription(pkg.customDescription || '');
+                        }}
+                      >
+                        <Icon name="edit-2" size={16} color={colors.primary} />
+                        <Text style={[styles.actionText, { color: colors.primary }]}>Edit</Text>
+                      </TouchableOpacity>
+                      <TouchableOpacity
+                        style={[styles.actionBtn, { backgroundColor: colors.surface }]}
+                        onPress={() => handleToggleActive(pkg)}
+                      >
+                        <Icon name={pkg.isActive ? 'eye-off' : 'eye'} size={16} color={colors.textSecondary} />
+                        <Text style={[styles.actionText, { color: colors.textSecondary }]}>
+                          {pkg.isActive ? 'Deactivate' : 'Activate'}
+                        </Text>
+                      </TouchableOpacity>
+                      <TouchableOpacity
+                        style={[styles.actionBtn, { backgroundColor: colors.surface }]}
+                        onPress={() => handleDelete(pkg.id)}
+                      >
+                        <Icon name="trash-2" size={16} color={colors.error} />
+                        <Text style={[styles.actionText, { color: colors.error }]}>Delete</Text>
+                      </TouchableOpacity>
+                    </View>
+                  )}
+                </Card>
+              );
+            })}
+          </View>
+        )}
+
+        {/* Create new package */}
+        {availableTemplates.length > 0 && (
+          <View style={styles.section}>
+            <Text style={[styles.sectionTitle, { color: colors.text }]}>Add a Package</Text>
+            <Text style={[styles.sectionDesc, { color: colors.textSecondary }]}>
+              Choose a template and set your total price. Seekers see this as a fixed-price option.
+            </Text>
+
+            {availableTemplates.map((t) => {
+              const isSelected = selectedTemplateId === t.id;
+              return (
+                <TouchableOpacity
+                  key={t.id}
+                  style={[
+                    styles.templateCard,
+                    { backgroundColor: colors.white, borderColor: colors.border },
+                    isSelected && { borderColor: colors.primary, backgroundColor: colors.primary + '10' },
+                  ]}
+                  onPress={() => setSelectedTemplateId(isSelected ? null : t.id)}
+                >
+                  <View style={[styles.templateIcon, { backgroundColor: colors.primary + '15' }]}>
+                    <Icon name={t.icon || 'package'} size={24} color={colors.primary} />
+                  </View>
+                  <View style={styles.templateInfo}>
+                    <Text style={[styles.templateName, { color: colors.text }]}>{t.name}</Text>
+                    <Text style={[styles.templateDesc, { color: colors.textSecondary }]}>
+                      {t.defaultDuration}h — {t.description}
+                    </Text>
+                  </View>
+                  <View style={[
+                    styles.radio,
+                    { borderColor: isSelected ? colors.primary : colors.border },
+                  ]}>
+                    {isSelected && <View style={[styles.radioInner, { backgroundColor: colors.primary }]} />}
+                  </View>
+                </TouchableOpacity>
+              );
+            })}
+
+            {selectedTemplateId && (
+              <View style={styles.createForm}>
+                <TextInput
+                  style={[styles.input, { backgroundColor: colors.white, borderColor: colors.border, color: colors.text }]}
+                  placeholder="Your price for this package ($)"
+                  value={price}
+                  onChangeText={setPrice}
+                  keyboardType="numeric"
+                  placeholderTextColor={colors.textSecondary}
+                />
+                <TextInput
+                  style={[styles.input, styles.textArea, { backgroundColor: colors.white, borderColor: colors.border, color: colors.text }]}
+                  placeholder="Custom description (optional)"
+                  value={customDescription}
+                  onChangeText={setCustomDescription}
+                  multiline
+                  placeholderTextColor={colors.textSecondary}
+                />
+                <Button
+                  title={isSubmitting ? 'Creating...' : 'Create Package'}
+                  onPress={handleCreate}
+                  loading={isSubmitting}
+                  disabled={isSubmitting}
+                  fullWidth
+                />
+              </View>
+            )}
+          </View>
+        )}
+
+        {packages.length === 0 && availableTemplates.length === 0 && (
+          <View style={{ alignItems: 'center', paddingVertical: spacing.xxl }}>
+            <Icon name="package" size={48} color={colors.textSecondary} />
+            <Text style={[styles.emptyText, { color: colors.textSecondary }]}>No templates available</Text>
+          </View>
+        )}
+
+        <View style={{ height: spacing.xxl }} />
+      </ScrollView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: spacing.lg,
+    paddingBottom: spacing.md,
+    borderBottomWidth: 1,
+  },
+  backButton: {
+    width: 44,
+    height: 44,
+    borderRadius: 22,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  headerTitle: {
+    fontFamily: typography.fonts.heading,
+    fontSize: typography.sizes.lg,
+    fontWeight: '600',
+  },
+  scrollView: { flex: 1 },
+  content: { padding: spacing.lg },
+  section: { marginBottom: spacing.xl },
+  sectionTitle: {
+    fontFamily: typography.fonts.heading,
+    fontSize: typography.sizes.lg,
+    fontWeight: '600',
+    marginBottom: spacing.sm,
+  },
+  sectionDesc: {
+    fontFamily: typography.fonts.body,
+    fontSize: typography.sizes.sm,
+    marginBottom: spacing.md,
+  },
+  packageCard: { marginBottom: spacing.md },
+  packageHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  packageIcon: {
+    width: 40,
+    height: 40,
+    borderRadius: 10,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginRight: spacing.md,
+  },
+  packageInfo: { flex: 1 },
+  packageName: {
+    fontFamily: typography.fonts.bodySemiBold,
+    fontSize: typography.sizes.md,
+    fontWeight: '600',
+  },
+  packageDuration: {
+    fontFamily: typography.fonts.body,
+    fontSize: typography.sizes.sm,
+  },
+  packageActions: { alignItems: 'flex-end' },
+  packagePrice: {
+    fontFamily: typography.fonts.heading,
+    fontSize: typography.sizes.xl,
+    fontWeight: '700',
+  },
+  inactiveBadge: {
+    fontFamily: typography.fonts.body,
+    fontSize: typography.sizes.xs,
+  },
+  customDesc: {
+    fontFamily: typography.fonts.body,
+    fontSize: typography.sizes.sm,
+    marginTop: spacing.sm,
+  },
+  actionRow: {
+    flexDirection: 'row',
+    gap: spacing.sm,
+    marginTop: spacing.md,
+  },
+  actionBtn: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+    borderRadius: borderRadius.sm,
+    gap: spacing.xs,
+  },
+  actionText: {
+    fontFamily: typography.fonts.bodyMedium,
+    fontSize: typography.sizes.sm,
+    fontWeight: '500',
+  },
+  editForm: { marginTop: spacing.md, gap: spacing.sm },
+  editButtons: { flexDirection: 'row', gap: spacing.sm },
+  templateCard: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    padding: spacing.md,
+    borderRadius: borderRadius.lg,
+    borderWidth: 2,
+    marginBottom: spacing.sm,
+  },
+  templateIcon: {
+    width: 44,
+    height: 44,
+    borderRadius: 12,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginRight: spacing.md,
+  },
+  templateInfo: { flex: 1 },
+  templateName: {
+    fontFamily: typography.fonts.bodySemiBold,
+    fontSize: typography.sizes.md,
+    fontWeight: '600',
+  },
+  templateDesc: {
+    fontFamily: typography.fonts.body,
+    fontSize: typography.sizes.sm,
+    marginTop: 2,
+  },
+  radio: {
+    width: 22,
+    height: 22,
+    borderRadius: 11,
+    borderWidth: 2,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  radioInner: {
+    width: 12,
+    height: 12,
+    borderRadius: 6,
+  },
+  createForm: { marginTop: spacing.md, gap: spacing.sm },
+  input: {
+    borderWidth: 1,
+    borderRadius: borderRadius.lg,
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.md,
+    fontSize: typography.sizes.md,
+    minHeight: 48,
+  },
+  textArea: {
+    minHeight: 80,
+    textAlignVertical: 'top',
+  },
+  emptyText: {
+    fontFamily: typography.fonts.body,
+    fontSize: typography.sizes.md,
+    marginTop: spacing.md,
+  },
+});

--- a/app/src/services/api.ts
+++ b/app/src/services/api.ts
@@ -338,6 +338,7 @@ export interface CreateBookingData {
   latitude?: number;
   longitude?: number;
   notes?: string;
+  packageId?: string;
 }
 
 export const bookingsApi = {
@@ -702,6 +703,59 @@ export const referralApi = {
 
   getMyStats: () =>
     apiRequest<{ invited: number; credited: number }>('/referral/my-stats'),
+};
+
+// Packages API
+export interface DatePackageTemplate {
+  id: string;
+  slug: string;
+  name: string;
+  nameRu: string;
+  description: string;
+  descriptionRu: string;
+  defaultDuration: number;
+  defaultActivity: string;
+  icon: string;
+}
+
+export interface DatePackage {
+  id: string;
+  companionId: string;
+  templateId: string;
+  price: number;
+  customDescription?: string;
+  isActive: boolean;
+  template?: DatePackageTemplate;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export const packagesApi = {
+  getTemplates: () =>
+    apiRequest<DatePackageTemplate[]>('/packages/templates'),
+
+  getCompanionPackages: (companionId: string) =>
+    apiRequest<DatePackage[]>(`/packages/companion/${companionId}`),
+
+  getMyPackages: () =>
+    apiRequest<DatePackage[]>('/packages/my'),
+
+  createPackage: (data: { templateId: string; price: number; customDescription?: string }) =>
+    apiRequest<DatePackage>('/packages/my', {
+      method: 'POST',
+      body: data,
+    }),
+
+  updatePackage: (id: string, data: { price?: number; customDescription?: string; isActive?: boolean }) =>
+    apiRequest<DatePackage>(`/packages/my/${id}`, {
+      method: 'PUT',
+      body: data,
+    }),
+
+  deletePackage: (id: string) =>
+    apiRequest<{ success: boolean }>(`/packages/my/${id}`, {
+      method: 'DELETE',
+    }),
 };
 
 // Types

--- a/backend/daterabbit-api/src/app.module.ts
+++ b/backend/daterabbit-api/src/app.module.ts
@@ -16,6 +16,7 @@ import { AdminModule } from './admin/admin.module';
 import { NotificationsModule } from './notifications/notifications.module';
 import { CalendarModule } from './calendar/calendar.module';
 import { ReferralModule } from './referral/referral.module';
+import { PackagesModule } from './packages/packages.module';
 
 @Module({
   imports: [
@@ -64,6 +65,7 @@ import { ReferralModule } from './referral/referral.module';
     NotificationsModule,
     CalendarModule,
     ReferralModule,
+    PackagesModule,
   ],
   providers: [
     {

--- a/backend/daterabbit-api/src/bookings/bookings.controller.ts
+++ b/backend/daterabbit-api/src/bookings/bookings.controller.ts
@@ -31,6 +31,7 @@ export class BookingsController {
       activity: string;
       location?: string;
       notes?: string;
+      packageId?: string;
     },
   ) {
     if (!body.companionId || !body.dateTime || !body.duration || !body.activity) {
@@ -73,6 +74,7 @@ export class BookingsController {
       activity: body.activity as ActivityType,
       location: body.location,
       notes: body.notes,
+      packageId: body.packageId,
     });
 
     return booking;
@@ -459,6 +461,7 @@ export class BookingsController {
       extendApproved: booking.extendApproved !== null && booking.extendApproved !== undefined ? booking.extendApproved : undefined,
       reportIssueType: booking.reportIssueType || undefined,
       reportIssueText: booking.reportIssueText || undefined,
+      packageId: booking.packageId || undefined,
       selfieVerified: booking.selfieVerified || false,
       seeker: booking.seeker ? {
         id: booking.seeker.id,

--- a/backend/daterabbit-api/src/bookings/bookings.module.ts
+++ b/backend/daterabbit-api/src/bookings/bookings.module.ts
@@ -15,6 +15,7 @@ import { NotificationsModule } from '../notifications/notifications.module';
 import { ReferralModule } from '../referral/referral.module';
 import { UploadsModule } from '../uploads/uploads.module';
 import { ReviewsModule } from '../reviews/reviews.module';
+import { PackagesModule } from '../packages/packages.module';
 
 @Module({
   imports: [
@@ -30,6 +31,7 @@ import { ReviewsModule } from '../reviews/reviews.module';
     ReferralModule,
     UploadsModule,
     forwardRef(() => ReviewsModule),
+    PackagesModule,
   ],
   providers: [BookingsService, BookingsCron],
   controllers: [BookingsController],

--- a/backend/daterabbit-api/src/bookings/bookings.service.ts
+++ b/backend/daterabbit-api/src/bookings/bookings.service.ts
@@ -10,6 +10,7 @@ import { NotificationsService } from '../notifications/notifications.service';
 import { NotificationType } from '../notifications/entities/notification.entity';
 import { ReferralService } from '../referral/referral.service';
 import { sanitizeText } from '../common/sanitize';
+import { PackagesService } from '../packages/packages.service';
 
 @Injectable()
 export class BookingsService {
@@ -25,6 +26,7 @@ export class BookingsService {
     private notificationsService: NotificationsService,
     @Inject(forwardRef(() => ReferralService))
     private referralService: ReferralService,
+    private packagesService: PackagesService,
   ) {}
 
   async create(data: {
@@ -35,15 +37,42 @@ export class BookingsService {
     activity: ActivityType;
     location?: string;
     notes?: string;
+    packageId?: string;
   }): Promise<Booking> {
     const companion = await this.usersService.findById(data.companionId);
     if (!companion) {
       throw new HttpException('Companion not found', HttpStatus.NOT_FOUND);
     }
 
+    // If packageId provided, validate and override price/duration/activity
+    let totalPrice: number;
+    let duration = data.duration;
+    let activity = data.activity;
+    let packageId: string | undefined;
+
+    if (data.packageId) {
+      const pkg = await this.packagesService.findById(data.packageId);
+      if (!pkg) {
+        throw new HttpException('Package not found', HttpStatus.NOT_FOUND);
+      }
+      if (pkg.companionId !== data.companionId) {
+        throw new HttpException('Package does not belong to this companion', HttpStatus.BAD_REQUEST);
+      }
+      if (!pkg.isActive) {
+        throw new HttpException('Package is not active', HttpStatus.BAD_REQUEST);
+      }
+      // Package price is TOTAL (not hourly)
+      totalPrice = Number(pkg.price);
+      duration = pkg.template.defaultDuration;
+      activity = pkg.template.defaultActivity;
+      packageId = data.packageId;
+    } else {
+      totalPrice = (companion.hourlyRate || 100) * duration;
+    }
+
     // Check for overlapping bookings for this companion (race condition guard)
     const bookingStart = new Date(data.dateTime);
-    const bookingEnd = new Date(bookingStart.getTime() + data.duration * 60 * 60 * 1000);
+    const bookingEnd = new Date(bookingStart.getTime() + duration * 60 * 60 * 1000);
 
     const existing = await this.bookingsRepository
       .createQueryBuilder('b')
@@ -65,10 +94,11 @@ export class BookingsService {
       );
     }
 
-    const totalPrice = (companion.hourlyRate || 100) * data.duration;
-
     const booking = this.bookingsRepository.create({
       ...data,
+      duration,
+      activity,
+      packageId,
       notes: data.notes ? sanitizeText(data.notes) : data.notes,
       location: data.location ? sanitizeText(data.location) : data.location,
       totalPrice,

--- a/backend/daterabbit-api/src/bookings/entities/booking.entity.ts
+++ b/backend/daterabbit-api/src/bookings/entities/booking.entity.ts
@@ -125,6 +125,9 @@ export class Booking {
   @Column({ nullable: true })
   reportIssueType: string;
 
+  @Column({ nullable: true })
+  packageId: string;
+
   @Column({ type: 'boolean', default: false })
   selfieVerified: boolean;
 

--- a/backend/daterabbit-api/src/packages/entities/date-package-template.entity.ts
+++ b/backend/daterabbit-api/src/packages/entities/date-package-template.entity.ts
@@ -1,0 +1,50 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { ActivityType } from '../../bookings/entities/booking.entity';
+
+@Entity('date_package_templates')
+export class DatePackageTemplate {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ unique: true })
+  slug: string;
+
+  @Column()
+  name: string;
+
+  @Column()
+  nameRu: string;
+
+  @Column({ type: 'text' })
+  description: string;
+
+  @Column({ type: 'text' })
+  descriptionRu: string;
+
+  @Column({ type: 'int' })
+  defaultDuration: number; // hours
+
+  @Column({ type: 'enum', enum: ActivityType })
+  defaultActivity: ActivityType;
+
+  @Column({ default: '' })
+  icon: string;
+
+  @Column({ default: true })
+  isActive: boolean;
+
+  @Column({ type: 'int', default: 0 })
+  order: number;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/backend/daterabbit-api/src/packages/entities/date-package.entity.ts
+++ b/backend/daterabbit-api/src/packages/entities/date-package.entity.ts
@@ -1,0 +1,46 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  ManyToOne,
+  JoinColumn,
+} from 'typeorm';
+import { User } from '../../users/entities/user.entity';
+import { DatePackageTemplate } from './date-package-template.entity';
+
+@Entity('date_packages')
+export class DatePackage {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  companionId: string;
+
+  @ManyToOne(() => User)
+  @JoinColumn({ name: 'companionId' })
+  companion: User;
+
+  @Column()
+  templateId: string;
+
+  @ManyToOne(() => DatePackageTemplate)
+  @JoinColumn({ name: 'templateId' })
+  template: DatePackageTemplate;
+
+  @Column({ type: 'decimal', precision: 10, scale: 2 })
+  price: number;
+
+  @Column({ type: 'text', nullable: true })
+  customDescription: string | null;
+
+  @Column({ default: true })
+  isActive: boolean;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/backend/daterabbit-api/src/packages/packages.controller.ts
+++ b/backend/daterabbit-api/src/packages/packages.controller.ts
@@ -1,0 +1,98 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Put,
+  Delete,
+  Body,
+  Param,
+  UseGuards,
+  Request,
+  HttpException,
+  HttpStatus,
+  ParseUUIDPipe,
+} from '@nestjs/common';
+import { PackagesService } from './packages.service';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+
+@Controller('packages')
+@UseGuards(JwtAuthGuard)
+export class PackagesController {
+  constructor(private packagesService: PackagesService) {}
+
+  @Get('templates')
+  async getTemplates() {
+    return this.packagesService.getTemplates();
+  }
+
+  @Get('companion/:id')
+  async getCompanionPackages(@Param('id', ParseUUIDPipe) id: string) {
+    const packages = await this.packagesService.getCompanionPackages(id);
+    return packages.map((p) => this.formatPackage(p));
+  }
+
+  @Get('my')
+  async getMyPackages(@Request() req) {
+    const packages = await this.packagesService.getMyPackages(req.user.id);
+    return packages.map((p) => this.formatPackage(p));
+  }
+
+  @Post('my')
+  async createPackage(
+    @Request() req,
+    @Body() body: { templateId: string; price: number; customDescription?: string },
+  ) {
+    if (!body.templateId || body.price === undefined) {
+      throw new HttpException('templateId and price are required', HttpStatus.BAD_REQUEST);
+    }
+    const pkg = await this.packagesService.createPackage({
+      companionId: req.user.id,
+      templateId: body.templateId,
+      price: body.price,
+      customDescription: body.customDescription,
+    });
+    return this.formatPackage(pkg);
+  }
+
+  @Put('my/:id')
+  async updatePackage(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Request() req,
+    @Body() body: { price?: number; customDescription?: string; isActive?: boolean },
+  ) {
+    const pkg = await this.packagesService.updatePackage(id, req.user.id, body);
+    return this.formatPackage(pkg);
+  }
+
+  @Delete('my/:id')
+  async deletePackage(@Param('id', ParseUUIDPipe) id: string, @Request() req) {
+    await this.packagesService.deletePackage(id, req.user.id);
+    return { success: true };
+  }
+
+  private formatPackage(pkg: any) {
+    return {
+      id: pkg.id,
+      companionId: pkg.companionId,
+      templateId: pkg.templateId,
+      price: pkg.price,
+      customDescription: pkg.customDescription || undefined,
+      isActive: pkg.isActive,
+      template: pkg.template
+        ? {
+            id: pkg.template.id,
+            slug: pkg.template.slug,
+            name: pkg.template.name,
+            nameRu: pkg.template.nameRu,
+            description: pkg.template.description,
+            descriptionRu: pkg.template.descriptionRu,
+            defaultDuration: pkg.template.defaultDuration,
+            defaultActivity: pkg.template.defaultActivity,
+            icon: pkg.template.icon,
+          }
+        : undefined,
+      createdAt: pkg.createdAt,
+      updatedAt: pkg.updatedAt,
+    };
+  }
+}

--- a/backend/daterabbit-api/src/packages/packages.module.ts
+++ b/backend/daterabbit-api/src/packages/packages.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { DatePackageTemplate } from './entities/date-package-template.entity';
+import { DatePackage } from './entities/date-package.entity';
+import { PackagesService } from './packages.service';
+import { PackagesController } from './packages.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([DatePackageTemplate, DatePackage])],
+  providers: [PackagesService],
+  controllers: [PackagesController],
+  exports: [PackagesService],
+})
+export class PackagesModule {}

--- a/backend/daterabbit-api/src/packages/packages.service.ts
+++ b/backend/daterabbit-api/src/packages/packages.service.ts
@@ -1,0 +1,185 @@
+import { Injectable, HttpException, HttpStatus, OnModuleInit } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { DatePackageTemplate } from './entities/date-package-template.entity';
+import { DatePackage } from './entities/date-package.entity';
+import { ActivityType } from '../bookings/entities/booking.entity';
+
+const SEED_TEMPLATES = [
+  {
+    slug: 'coffee-date',
+    name: 'Coffee Date',
+    nameRu: 'Кофе-свидание',
+    description: 'A relaxed coffee meetup — perfect for a first date or casual conversation.',
+    descriptionRu: 'Расслабленная встреча за кофе — идеально для первого свидания или непринуждённой беседы.',
+    defaultDuration: 2,
+    defaultActivity: ActivityType.COFFEE,
+    icon: 'coffee',
+    order: 1,
+  },
+  {
+    slug: 'evening-dinner',
+    name: 'Evening + Dinner',
+    nameRu: 'Вечер + Ужин',
+    description: 'An elegant evening out with dinner — great for a special night.',
+    descriptionRu: 'Элегантный вечер с ужином — отличный выбор для особого вечера.',
+    defaultDuration: 4,
+    defaultActivity: ActivityType.DINNER,
+    icon: 'utensils',
+    order: 2,
+  },
+  {
+    slug: 'full-day',
+    name: 'Full Day Adventure',
+    nameRu: 'Приключение на весь день',
+    description: 'A full-day experience — explore the city, visit museums, enjoy meals together.',
+    descriptionRu: 'Впечатления на весь день — прогулки по городу, музеи, совместные трапезы.',
+    defaultDuration: 8,
+    defaultActivity: ActivityType.WALK,
+    icon: 'sun',
+    order: 3,
+  },
+];
+
+@Injectable()
+export class PackagesService implements OnModuleInit {
+  constructor(
+    @InjectRepository(DatePackageTemplate)
+    private templatesRepository: Repository<DatePackageTemplate>,
+    @InjectRepository(DatePackage)
+    private packagesRepository: Repository<DatePackage>,
+  ) {}
+
+  async onModuleInit(): Promise<void> {
+    for (const seed of SEED_TEMPLATES) {
+      const existing = await this.templatesRepository.findOne({
+        where: { slug: seed.slug },
+      });
+      if (existing) {
+        await this.templatesRepository.update(existing.id, seed);
+      } else {
+        await this.templatesRepository.save(this.templatesRepository.create(seed));
+      }
+    }
+  }
+
+  async getTemplates(): Promise<DatePackageTemplate[]> {
+    return this.templatesRepository.find({
+      where: { isActive: true },
+      order: { order: 'ASC' },
+    });
+  }
+
+  async getCompanionPackages(companionId: string): Promise<DatePackage[]> {
+    return this.packagesRepository.find({
+      where: { companionId, isActive: true },
+      relations: ['template'],
+      order: { createdAt: 'DESC' },
+    });
+  }
+
+  async getMyPackages(userId: string): Promise<DatePackage[]> {
+    return this.packagesRepository.find({
+      where: { companionId: userId },
+      relations: ['template'],
+      order: { createdAt: 'DESC' },
+    });
+  }
+
+  async createPackage(data: {
+    companionId: string;
+    templateId: string;
+    price: number;
+    customDescription?: string;
+  }): Promise<DatePackage> {
+    const template = await this.templatesRepository.findOne({
+      where: { id: data.templateId, isActive: true },
+    });
+    if (!template) {
+      throw new HttpException('Template not found', HttpStatus.NOT_FOUND);
+    }
+
+    if (typeof data.price !== 'number' || data.price <= 0) {
+      throw new HttpException('Price must be a positive number', HttpStatus.BAD_REQUEST);
+    }
+
+    // Check if companion already has a package for this template
+    const existing = await this.packagesRepository.findOne({
+      where: { companionId: data.companionId, templateId: data.templateId },
+    });
+    if (existing) {
+      throw new HttpException(
+        'You already have a package for this template. Update or delete it first.',
+        HttpStatus.CONFLICT,
+      );
+    }
+
+    const pkg = this.packagesRepository.create({
+      companionId: data.companionId,
+      templateId: data.templateId,
+      price: data.price,
+      customDescription: data.customDescription || null,
+    });
+    const saved = await this.packagesRepository.save(pkg);
+    return this.packagesRepository.findOne({
+      where: { id: saved.id },
+      relations: ['template'],
+    }) as Promise<DatePackage>;
+  }
+
+  async updatePackage(
+    packageId: string,
+    userId: string,
+    data: { price?: number; customDescription?: string; isActive?: boolean },
+  ): Promise<DatePackage> {
+    const pkg = await this.packagesRepository.findOne({
+      where: { id: packageId },
+      relations: ['template'],
+    });
+    if (!pkg) {
+      throw new HttpException('Package not found', HttpStatus.NOT_FOUND);
+    }
+    if (pkg.companionId !== userId) {
+      throw new HttpException('Unauthorized', HttpStatus.FORBIDDEN);
+    }
+
+    if (data.price !== undefined) {
+      if (typeof data.price !== 'number' || data.price <= 0) {
+        throw new HttpException('Price must be a positive number', HttpStatus.BAD_REQUEST);
+      }
+      pkg.price = data.price;
+    }
+    if (data.customDescription !== undefined) {
+      pkg.customDescription = data.customDescription || null;
+    }
+    if (data.isActive !== undefined) {
+      pkg.isActive = data.isActive;
+    }
+
+    await this.packagesRepository.save(pkg);
+    return this.packagesRepository.findOne({
+      where: { id: packageId },
+      relations: ['template'],
+    }) as Promise<DatePackage>;
+  }
+
+  async deletePackage(packageId: string, userId: string): Promise<void> {
+    const pkg = await this.packagesRepository.findOne({
+      where: { id: packageId },
+    });
+    if (!pkg) {
+      throw new HttpException('Package not found', HttpStatus.NOT_FOUND);
+    }
+    if (pkg.companionId !== userId) {
+      throw new HttpException('Unauthorized', HttpStatus.FORBIDDEN);
+    }
+    await this.packagesRepository.remove(pkg);
+  }
+
+  async findById(id: string): Promise<DatePackage | null> {
+    return this.packagesRepository.findOne({
+      where: { id },
+      relations: ['template'],
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- Full date package system: 3 platform templates (Coffee 2h, Evening+Dinner 4h, Full Day 8h)
- Companion creates packages with custom price from templates, manages via Settings > My Packages
- Packages shown on companion profile page as cards
- Seeker can select package during booking — auto-fills duration, activity, uses package total price
- Backend validates package ownership and isActive before allowing booking

## Files (15)
**Backend new:** PackagesModule (entities, service, controller, module)
**Backend modified:** app.module, booking entity (+packageId), bookings service/controller/module
**Frontend new:** my-packages.tsx (settings screen)
**Frontend modified:** api.ts (types+methods), profile/[id].tsx (packages section), booking/[id].tsx (package selection), settings/index.tsx (menu item)

## Test plan
- [ ] GET /packages/templates returns 3 templates
- [ ] Companion creates a package via POST /packages/my
- [ ] Package appears on companion profile page
- [ ] Seeker selects package during booking, price is fixed total
- [ ] Booking with packageId validates companion ownership + isActive
- [ ] Settings > My Packages: create, edit, delete, toggle active