### PR TITLE
feat: pre-booking chat — seeker can message companion before booking

### DIFF
--- a/app/app/chat/[id].tsx
+++ b/app/app/chat/[id].tsx
@@ -27,7 +27,7 @@ interface FailedMessage {
 }
 
 export default function ChatScreen() {
-  const { id, name } = useLocalSearchParams<{ id: string; name: string }>();
+  const { id, name, preBooking } = useLocalSearchParams<{ id: string; name: string; preBooking?: string }>();
   const insets = useSafeAreaInsets();
   const { colors } = useTheme();
   const scrollViewRef = useRef<ScrollView>(null);
@@ -35,7 +35,7 @@ export default function ChatScreen() {
   const [failedMessages, setFailedMessages] = useState<FailedMessage[]>([])
 
   const { user } = useAuthStore();
-  const { messages, sendMessage, getMessages, fetchMessages, fetchChats, chats, isSending } = useMessagesStore();
+  const { messages, sendMessage, getMessages, fetchMessages, fetchChats, chats, isSending, preChatStatus, fetchPreChatStatus } = useMessagesStore();
   const { requireVerification } = useVerificationGate();
 
   // id param is the otherUser's id
@@ -46,6 +46,16 @@ export default function ChatScreen() {
   // Resolve companion name: prefer URL param, fall back to chat data
   const companionName = name || chat?.otherUser?.name || '';
 
+  const isPreBooking = preBooking === '1';
+  const isCompanion = user?.role === 'companion';
+
+  // Whether to show the pre-booking banner
+  const showPreBookingBanner = isPreBooking && preChatStatus && !preChatStatus.hasBooking && !preChatStatus.companionReplied;
+  // Whether input is disabled due to pre-chat limit
+  const preChatLimitReached = showPreBookingBanner && !preChatStatus.canSend;
+  // Whether companion sees "Pre-booking request" label
+  const showCompanionPreBookingLabel = isPreBooking && isCompanion && preChatStatus && !preChatStatus.hasBooking;
+
   // Poll messages every 5 seconds while screen is focused
   useFocusEffect(
     useCallback(() => {
@@ -53,14 +63,17 @@ export default function ChatScreen() {
       fetchMessages(otherUserId);
       // Ensure chats are loaded so companion name resolves from store
       if (!chat) fetchChats(true);
+      // Fetch pre-chat status if navigated from profile
+      if (isPreBooking) fetchPreChatStatus(otherUserId);
 
       // Poll every 5s silently (no loading spinner)
       const interval = setInterval(() => {
         fetchMessages(otherUserId, 1, true);
+        if (isPreBooking) fetchPreChatStatus(otherUserId);
       }, POLL_INTERVAL);
 
       return () => clearInterval(interval);
-    }, [otherUserId])
+    }, [otherUserId, isPreBooking])
   );
 
   useEffect(() => {
@@ -87,6 +100,8 @@ export default function ChatScreen() {
     setMessageText('');
     try {
       await sendMessage(otherUserId, text);
+      // Refresh pre-chat status so counter updates immediately
+      if (isPreBooking) fetchPreChatStatus(otherUserId);
     } catch {
       // Show failed message bubble with retry instead of alert
       const tempId = `failed-${Date.now()}`;
@@ -203,7 +218,11 @@ export default function ChatScreen() {
           <UserImage name={companionName} size={40} />
           <View style={styles.headerInfo}>
             <Text style={[styles.headerName, { color: colors.text }]}>{companionName}</Text>
-            <Text style={[styles.headerStatus, { color: colors.textSecondary }]}>Tap to view profile</Text>
+            {showCompanionPreBookingLabel ? (
+              <Text style={[styles.headerStatus, { color: colors.accent }]}>Pre-booking request</Text>
+            ) : (
+              <Text style={[styles.headerStatus, { color: colors.textSecondary }]}>Tap to view profile</Text>
+            )}
           </View>
         </TouchableOpacity>
 
@@ -217,6 +236,19 @@ export default function ChatScreen() {
           <Text style={[styles.bookButtonText, { color: colors.white }]}>Book</Text>
         </TouchableOpacity>
       </View>
+
+      {/* Pre-booking banner */}
+      {showPreBookingBanner && (
+        <View style={[styles.preBookingBanner, { backgroundColor: '#FFF3CD', borderBottomColor: '#FFEAA7' }]}>
+          <Icon name="message-circle" size={16} color="#856404" />
+          <Text style={styles.preBookingBannerText}>
+            {preChatLimitReached
+              ? 'Message limit reached. Book a date to continue chatting.'
+              : `Pre-booking conversation — ${preChatStatus.messagesLeft} message${preChatStatus.messagesLeft !== 1 ? 's' : ''} remaining`
+            }
+          </Text>
+        </View>
+      )}
 
       {/* Messages */}
       <ScrollView
@@ -362,35 +394,50 @@ export default function ChatScreen() {
       </ScrollView>
 
       {/* Input Area */}
-      <View style={[styles.inputContainer, { backgroundColor: colors.white, borderTopColor: colors.border, paddingBottom: insets.bottom || spacing.md }]}>
-        <View style={[styles.inputWrapper, { backgroundColor: colors.background }]}>
-          <TextInput
-            style={[styles.input, { color: colors.text }]}
-            placeholder="Type a message..."
-            placeholderTextColor={colors.textSecondary}
-            value={messageText}
-            onChangeText={setMessageText}
-            multiline
-            maxLength={1000}
-            testID="chat-message-input"
-          />
+      {preChatLimitReached ? (
+        <View style={[styles.inputContainer, { backgroundColor: colors.white, borderTopColor: colors.border, paddingBottom: insets.bottom || spacing.md }]}>
+          <TouchableOpacity
+            style={[styles.bookDateCta, { backgroundColor: colors.primary }]}
+            onPress={handleBook}
+            testID="chat-book-date-cta"
+            accessibilityLabel="Book a date to continue chatting"
+            accessibilityRole="button"
+          >
+            <Icon name="calendar" size={20} color={colors.white} />
+            <Text style={[styles.bookDateCtaText, { color: colors.white }]}>Book Date to Continue</Text>
+          </TouchableOpacity>
         </View>
+      ) : (
+        <View style={[styles.inputContainer, { backgroundColor: colors.white, borderTopColor: colors.border, paddingBottom: insets.bottom || spacing.md }]}>
+          <View style={[styles.inputWrapper, { backgroundColor: colors.background }]}>
+            <TextInput
+              style={[styles.input, { color: colors.text }]}
+              placeholder="Type a message..."
+              placeholderTextColor={colors.textSecondary}
+              value={messageText}
+              onChangeText={setMessageText}
+              multiline
+              maxLength={1000}
+              testID="chat-message-input"
+            />
+          </View>
 
-        <TouchableOpacity
-          style={[
-            styles.sendButton,
-            { backgroundColor: messageText.trim() ? colors.primary : colors.border }
-          ]}
-          onPress={handleSend}
-          disabled={!messageText.trim()}
-          testID="chat-send-btn"
-          accessibilityLabel="Send message"
-          accessibilityRole="button"
-          accessibilityState={{ disabled: !messageText.trim() }}
-        >
-          <Icon name="send" size={20} color={colors.white} />
-        </TouchableOpacity>
-      </View>
+          <TouchableOpacity
+            style={[
+              styles.sendButton,
+              { backgroundColor: messageText.trim() ? colors.primary : colors.border }
+            ]}
+            onPress={handleSend}
+            disabled={!messageText.trim()}
+            testID="chat-send-btn"
+            accessibilityLabel="Send message"
+            accessibilityRole="button"
+            accessibilityState={{ disabled: !messageText.trim() }}
+          >
+            <Icon name="send" size={20} color={colors.white} />
+          </TouchableOpacity>
+        </View>
+      )}
     </KeyboardAvoidingView>
   );
 }
@@ -530,5 +577,34 @@ const styles = StyleSheet.create({
     fontSize: typography.sizes.xs,
     marginTop: 4,
     marginRight: spacing.xs,
+  },
+  preBookingBanner: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+    borderBottomWidth: 1,
+    gap: spacing.sm,
+  },
+  preBookingBannerText: {
+    fontFamily: typography.fonts.bodyMedium,
+    fontSize: typography.sizes.sm,
+    color: '#856404',
+    flex: 1,
+  },
+  bookDateCta: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: spacing.md,
+    borderRadius: borderRadius.lg,
+    gap: spacing.sm,
+    minHeight: 44,
+  },
+  bookDateCtaText: {
+    fontFamily: typography.fonts.bodySemiBold,
+    fontSize: typography.sizes.md,
+    fontWeight: '600',
   },
 });

--- a/app/app/profile/[id].tsx
+++ b/app/app/profile/[id].tsx
@@ -240,7 +240,7 @@ export default function ProfileViewScreen() {
   };
 
   const handleMessage = () => {
-    router.push(`/chat/${profile.id}?name=${encodeURIComponent(profile.name)}`);
+    router.push(`/chat/${profile.id}?name=${encodeURIComponent(profile.name)}&preBooking=1`);
   };
 
   const handleShare = async () => {

--- a/app/src/services/api.ts
+++ b/app/src/services/api.ts
@@ -1,6 +1,6 @@
 // API Client for DateRabbit Backend
 import * as SecureStore from 'expo-secure-store';
-import type { Verification, VerificationReference } from '../types';
+import type { Verification, VerificationReference, PreChatStatus } from '../types';
 import { useNetworkStore } from '../store/networkStore';
 
 const API_BASE_URL = 'https://daterabbit-api.smartlaunchhub.com/api';
@@ -465,6 +465,9 @@ export const messagesApi = {
 
   getUnreadCount: () =>
     apiRequest<{ count: number }>('/messages/unread-count'),
+
+  getPreChatStatus: (userId: string) =>
+    apiRequest<PreChatStatus>(`/messages/${userId}/pre-chat`),
 };
 
 // Payments API

--- a/app/src/store/messagesStore.ts
+++ b/app/src/store/messagesStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import { messagesApi, Message, Chat, ApiError } from '../services/api';
+import type { PreChatStatus } from '../types';
 
 // Shared polling interval for all chat-related screens
 export const POLL_INTERVAL = 5000;
@@ -11,12 +12,14 @@ interface MessagesState {
   isSending: boolean;
   unreadCount: number;
   error: string | null;
+  preChatStatus: PreChatStatus | null;
 
   // Actions
   fetchChats: (silent?: boolean) => Promise<void>;
   fetchMessages: (otherUserId: string, page?: number, silent?: boolean) => Promise<void>;
   sendMessage: (otherUserId: string, content: string) => Promise<{ success: boolean; error?: string }>;
   refreshUnreadCount: () => Promise<void>;
+  fetchPreChatStatus: (otherUserId: string) => Promise<void>;
 
   // Utility
   getChat: (otherUserId: string) => Chat | undefined;
@@ -31,6 +34,7 @@ export const useMessagesStore = create<MessagesState>((set, get) => ({
   isSending: false,
   unreadCount: 0,
   error: null,
+  preChatStatus: null,
 
   fetchChats: async (silent = false) => {
     if (!silent) set({ isLoading: true, error: null });
@@ -132,6 +136,16 @@ export const useMessagesStore = create<MessagesState>((set, get) => ({
       set({ unreadCount: response.count });
     } catch {
       // Silent fail
+    }
+  },
+
+  fetchPreChatStatus: async (otherUserId) => {
+    try {
+      const status = await messagesApi.getPreChatStatus(otherUserId);
+      set({ preChatStatus: status });
+    } catch {
+      // Silent fail — pre-chat banner won't show
+      set({ preChatStatus: null });
     }
   },
 

--- a/app/src/types/index.ts
+++ b/app/src/types/index.ts
@@ -123,3 +123,11 @@ export interface Chat {
   lastMessageAt?: string;
   unreadCount?: number;
 }
+
+export interface PreChatStatus {
+  hasBooking: boolean;
+  companionReplied: boolean;
+  messageCount: number;
+  canSend: boolean;
+  messagesLeft: number;
+}

--- a/backend/daterabbit-api/src/messages/messages.controller.ts
+++ b/backend/daterabbit-api/src/messages/messages.controller.ts
@@ -54,6 +54,18 @@ export class MessagesController {
     return { unread: count };
   }
 
+  /**
+   * UC-037: Get pre-chat status (how many messages can be sent before booking).
+   * MUST be declared before @Get(':userId') to prevent route collision.
+   */
+  @Get(':userId/pre-chat')
+  async getPreChatStatus(
+    @Param('userId', ParseUUIDPipe) companionId: string,
+    @Request() req,
+  ) {
+    return this.messagesService.getPreChatStatus(req.user.id, companionId);
+  }
+
   @Get(':userId')
   async getMessages(
     @Param('userId', ParseUUIDPipe) otherUserId: string,
@@ -81,17 +93,6 @@ export class MessagesController {
     }));
   }
 
-  /**
-   * UC-037: Get pre-chat status (how many messages can be sent before booking).
-   */
-  @Get(':userId/pre-chat')
-  async getPreChatStatus(
-    @Param('userId', ParseUUIDPipe) companionId: string,
-    @Request() req,
-  ) {
-    return this.messagesService.getPreChatStatus(req.user.id, companionId);
-  }
-
   @Post(':userId')
   async sendMessage(
     @Param('userId', ParseUUIDPipe) receiverId: string,
@@ -116,9 +117,9 @@ export class MessagesController {
 
     // UC-037: Enforce pre-chat message limit
     const preChatStatus = await this.messagesService.getPreChatStatus(req.user.id, receiverId);
-    if (!preChatStatus.allowed) {
+    if (!preChatStatus.canSend) {
       throw new HttpException(
-        `Pre-chat limit reached (${preChatStatus.limit} messages). Create a booking to continue chatting.`,
+        'Pre-chat limit reached. Create a booking to continue chatting.',
         HttpStatus.FORBIDDEN,
       );
     }

--- a/backend/daterabbit-api/src/messages/messages.module.ts
+++ b/backend/daterabbit-api/src/messages/messages.module.ts
@@ -1,16 +1,18 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Message, Conversation } from './entities/message.entity';
 import { MessagesService } from './messages.service';
 import { MessagesController } from './messages.controller';
 import { UsersModule } from '../users/users.module';
 import { BookingsModule } from '../bookings/bookings.module';
+import { NotificationsModule } from '../notifications/notifications.module';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([Message, Conversation]),
     UsersModule,
     BookingsModule,
+    forwardRef(() => NotificationsModule),
   ],
   providers: [MessagesService],
   controllers: [MessagesController],

--- a/backend/daterabbit-api/src/messages/messages.service.ts
+++ b/backend/daterabbit-api/src/messages/messages.service.ts
@@ -3,6 +3,8 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Message, Conversation } from './entities/message.entity';
 import { BookingsService } from '../bookings/bookings.service';
+import { NotificationsService } from '../notifications/notifications.service';
+import { NotificationType } from '../notifications/entities/notification.entity';
 import { sanitizeText } from '../common/sanitize';
 
 // Max messages a seeker can send to a companion before booking
@@ -16,6 +18,7 @@ export class MessagesService {
     @InjectRepository(Conversation)
     private conversationsRepository: Repository<Conversation>,
     private bookingsService: BookingsService,
+    private notificationsService: NotificationsService,
   ) {}
 
   async getOrCreateConversation(user1Id: string, user2Id: string): Promise<Conversation> {
@@ -55,6 +58,19 @@ export class MessagesService {
       lastMessageId: saved.id,
       lastMessageAt: saved.createdAt,
     });
+
+    // Create notification for receiver (non-blocking)
+    try {
+      await this.notificationsService.create({
+        userId: receiverId,
+        type: NotificationType.NEW_MESSAGE,
+        title: 'New Message',
+        body: content.length > 100 ? content.slice(0, 100) + '...' : content,
+        data: { senderId, conversationId: conversation.id },
+      });
+    } catch {
+      // Notification failure must NOT break message delivery
+    }
 
     return saved;
   }
@@ -97,29 +113,47 @@ export class MessagesService {
 
   /**
    * UC-037: Check if seeker can send pre-chat message to companion.
-   * Returns { allowed, sent, limit } indicating whether the seeker
-   * can still send messages before creating a booking.
+   * Returns status indicating whether the seeker can send messages
+   * before creating a booking. Limit is lifted when companion replies.
    */
   async getPreChatStatus(
-    senderId: string,
-    receiverId: string,
-  ): Promise<{ allowed: boolean; sent: number; limit: number }> {
+    seekerId: string,
+    companionId: string,
+  ): Promise<{
+    hasBooking: boolean;
+    companionReplied: boolean;
+    messageCount: number;
+    canSend: boolean;
+    messagesLeft: number;
+  }> {
     // Check if any booking exists between these users
-    const hasBooking = await this.bookingsService.hasAnyBooking(senderId, receiverId);
+    const hasBooking = await this.bookingsService.hasAnyBooking(seekerId, companionId);
     if (hasBooking) {
-      // No limit if a booking already exists
-      return { allowed: true, sent: 0, limit: PRE_CHAT_LIMIT };
+      return { hasBooking: true, companionReplied: false, messageCount: 0, canSend: true, messagesLeft: PRE_CHAT_LIMIT };
     }
 
-    // Count messages sent by this sender to this receiver
-    const sent = await this.messagesRepository.count({
-      where: { senderId, receiverId },
+    // Check if companion has replied (companion sent message to seeker)
+    const companionReplyCount = await this.messagesRepository.count({
+      where: { senderId: companionId, receiverId: seekerId },
+    });
+    const companionReplied = companionReplyCount > 0;
+
+    if (companionReplied) {
+      // Companion replied — no limit applies
+      return { hasBooking: false, companionReplied: true, messageCount: 0, canSend: true, messagesLeft: PRE_CHAT_LIMIT };
+    }
+
+    // Count messages sent by seeker to companion
+    const messageCount = await this.messagesRepository.count({
+      where: { senderId: seekerId, receiverId: companionId },
     });
 
     return {
-      allowed: sent < PRE_CHAT_LIMIT,
-      sent,
-      limit: PRE_CHAT_LIMIT,
+      hasBooking: false,
+      companionReplied: false,
+      messageCount,
+      canSend: messageCount < PRE_CHAT_LIMIT,
+      messagesLeft: Math.max(0, PRE_CHAT_LIMIT - messageCount),
     };
   }
 }


### PR DESCRIPTION
## Summary
- Seeker can message companion before booking (3 message limit)
- Limit lifted automatically when companion replies
- Yellow banner shows remaining message count in pre-booking chat
- Input replaced with "Book Date" CTA when limit reached
- Companion sees "Pre-booking request" label in chat header
- NEW_MESSAGE notification created on every sent message

## Changes
- **Backend**: `getPreChatStatus` returns enriched response with `companionReplied` check
- **Backend**: Route order fix — `GET :userId/pre-chat` before `GET :userId` wildcard
- **Backend**: NotificationsModule imported into MessagesModule for NEW_MESSAGE notifications
- **Frontend**: Profile Message button passes `?preBooking=1` query param
- **Frontend**: Chat screen shows pre-booking banner, counter, and Book Date CTA
- **Frontend**: messagesStore gains `preChatStatus` state + `fetchPreChatStatus` action
- **Frontend**: `PreChatStatus` type added to types/index.ts

## Test plan
- [ ] Open companion profile → tap Message → chat opens with yellow banner "3 messages remaining"
- [ ] Send 3 messages → input replaced with "Book Date to Continue" CTA
- [ ] As companion: reply to seeker → banner disappears, unlimited messaging
- [ ] Navigate to chat from messages list (no preBooking param) → no banner shown
- [ ] Companion sees "Pre-booking request" in header when viewing pre-booking chat