### PR TITLE
fix: add expo-clipboard dependency

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -22,6 +22,7 @@
         "@stripe/react-stripe-js": "^5.6.0",
         "@stripe/stripe-js": "^8.8.0",
         "expo": "52",
+        "expo-clipboard": "^55.0.9",
         "expo-constants": "~17.0.8",
         "expo-font": "~13.0.4",
         "expo-haptics": "~14.0.1",
@@ -14686,6 +14687,17 @@
         "invariant": "^2.2.4",
         "md5-file": "^3.2.3"
       },
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/expo-clipboard": {
+      "version": "55.0.9",
+      "resolved": "https://registry.npmjs.org/expo-clipboard/-/expo-clipboard-55.0.9.tgz",
+      "integrity": "sha512-WJ9ougE8fEDu3/RV5Vz3gE5aNgnj1C0WByXCz3WUj8y/06bJyaIUDMq8FDLv3n0AO3guiErmkUunsD0EzSDUUw==",
+      "license": "MIT",
       "peerDependencies": {
         "expo": "*",
         "react": "*",

--- a/app/package.json
+++ b/app/package.json
@@ -33,6 +33,7 @@
     "@stripe/react-stripe-js": "^5.6.0",
     "@stripe/stripe-js": "^8.8.0",
     "expo": "52",
+    "expo-clipboard": "^55.0.9",
     "expo-constants": "~17.0.8",
     "expo-font": "~13.0.4",
     "expo-haptics": "~14.0.1",


### PR DESCRIPTION
Referral screen imports expo-clipboard but it was missing from package.json. Fixes CI failure blocking 4 commits from deploying.