### PR TITLE
fix: remove unstable_enablePackageExports — web white screen

### DIFF
--- a/app/metro.config.js
+++ b/app/metro.config.js
@@ -2,8 +2,4 @@ const { getDefaultConfig } = require('expo/metro-config');
 
 const config = getDefaultConfig(__dirname);
 
-// Enable package.json "exports" field resolution for better tree-shaking
-// and to allow bundlers to pick the correct ESM entry points.
-config.resolver.unstable_enablePackageExports = true;
-
 module.exports = config;


### PR DESCRIPTION
## Summary

- Removes `unstable_enablePackageExports = true` from `metro.config.js`
- This flag caused Metro to resolve ESM package entries containing `import.meta.env` into a non-module bundle
- Browser throws `Cannot use import.meta outside a module` and React never mounts — resulting in a white screen on web

## Root cause

With `unstable_enablePackageExports` enabled, Metro follows the `exports` field in `package.json` and picks up ESM entry points. Those entry points use `import.meta.env` (Vite-style), which is invalid in a CommonJS/IIFE bundle. The browser rejects the script and the app never renders.

## Test plan

- [ ] Load https://daterabbit.smartlaunchhub.com after deploy
- [ ] Confirm no white screen (app renders login screen)
- [ ] Confirm no `Cannot use import.meta outside a module` error in browser console
- [ ] curl deployed bundle and confirm no `import.meta` occurrences