### PR TITLE
fix: clear auth state on getMe failure after OTP verify

### DIFF
--- a/app/src/store/authStore.ts
+++ b/app/src/store/authStore.ts
@@ -201,16 +201,15 @@ export const useAuthStore = create<AuthState>()(
               useFavoritesStore.getState().syncFromServer();
             }
           } catch {
-            // Could not fetch profile, but we have token - assume existing user
+            // Could not fetch profile - clear token and reset auth state
+            await setToken(null);
             set({
-              authStep: 'authenticated',
-              isAuthenticated: true,
-              hasCompletedOnboarding: true,
-              hasSeenOnboarding: true,
+              isAuthenticated: false,
+              user: null,
+              authStep: 'idle',
               isLoading: false,
+              error: 'Failed to load profile. Please try again.',
             });
-            // Sync favorites from server
-            useFavoritesStore.getState().syncFromServer();
           }
           return { success: true };
         } catch (err) {


### PR DESCRIPTION
In verifyCode catch block, when getMe() fails after successful OTP: clear token, set isAuthenticated=false. Previously set isAuthenticated=true with user=null, causing crashes on user.role/user.name access in downstream screens.