### PR TITLE
fix: add double-tap protection for booking creation

### DIFF
--- a/app/app/booking/[id].tsx
+++ b/app/app/booking/[id].tsx
@@ -69,7 +69,7 @@ export default function BookingScreen() {
   const insets = useSafeAreaInsets();
   const { colors } = useTheme();
 
-  const { createBooking } = useBookingsStore();
+  const { createBooking, isCreatingBooking } = useBookingsStore();
   const { requireVerification } = useVerificationGate();
 
   const availableDates = generateDates();
@@ -82,7 +82,6 @@ export default function BookingScreen() {
   const [selectedTime, setSelectedTime] = useState<string | null>(null);
   const [location, setLocation] = useState('');
   const [notes, setNotes] = useState('');
-  const [isSubmitting, setIsSubmitting] = useState(false);
   const [companionPackages, setCompanionPackages] = useState<DatePackage[]>([]);
   const [selectedPackage, setSelectedPackage] = useState<DatePackage | null>(null);
 
@@ -167,8 +166,6 @@ export default function BookingScreen() {
       return;
     }
 
-    setIsSubmitting(true);
-
     // Combine selected date and time slot into a single ISO dateTime string
     const dateTime = (() => {
       const base = new Date(selectedDate!);
@@ -194,8 +191,6 @@ export default function BookingScreen() {
       notes,
       ...(selectedPackage ? { packageId: selectedPackage.id } : {}),
     });
-
-    setIsSubmitting(false);
 
     if (!result.success) {
       showAlert('Error', result.error || 'Failed to send request');
@@ -537,10 +532,10 @@ export default function BookingScreen() {
           <Text style={[styles.bottomLabel, { color: colors.textSecondary }]}>Total</Text>
         </View>
         <Button
-          title={isSubmitting ? 'Sending...' : 'Send Request'}
+          title={isCreatingBooking ? 'Sending...' : 'Send Request'}
           onPress={handleSubmit}
-          loading={isSubmitting}
-          disabled={!isValid || isSubmitting}
+          loading={isCreatingBooking}
+          disabled={!isValid || isCreatingBooking}
           style={styles.submitButton}
           testID="booking-submit-btn"
         />

--- a/app/src/store/bookingsStore.ts
+++ b/app/src/store/bookingsStore.ts
@@ -8,6 +8,7 @@ interface BookingsState {
   requests: Booking[]; // For companions - incoming requests
   total: number;
   isLoading: boolean;
+  isCreatingBooking: boolean;
   error: string | null;
   currentFilter: BookingFilter;
 
@@ -38,22 +39,29 @@ export const useBookingsStore = create<BookingsState>((set, get) => ({
   requests: [],
   total: 0,
   isLoading: false,
+  isCreatingBooking: false,
   error: null,
   currentFilter: 'all',
 
   createBooking: async (data) => {
-    set({ isLoading: true, error: null });
+    // Guard against concurrent calls (double-tap protection)
+    if (get().isCreatingBooking) {
+      return { success: false, error: 'Booking creation already in progress' };
+    }
+
+    set({ isCreatingBooking: true, isLoading: true, error: null });
 
     try {
       const booking = await bookingsApi.create(data);
       set((state) => ({
         bookings: [booking, ...state.bookings],
         isLoading: false,
+        isCreatingBooking: false,
       }));
       return { success: true, booking };
     } catch (err) {
       const message = err instanceof ApiError ? err.message : 'Failed to create booking';
-      set({ error: message, isLoading: false });
+      set({ error: message, isLoading: false, isCreatingBooking: false });
       return { success: false, error: message };
     }
   },

--- a/backend/daterabbit-api/src/bookings/bookings.service.ts
+++ b/backend/daterabbit-api/src/bookings/bookings.service.ts
@@ -70,6 +70,24 @@ export class BookingsService {
       totalPrice = (companion.hourlyRate || 100) * duration;
     }
 
+    // Check for exact duplicate: same seeker + companion + dateTime with active status
+    const duplicate = await this.bookingsRepository
+      .createQueryBuilder('b')
+      .where('b.seekerId = :seekerId', { seekerId: data.seekerId })
+      .andWhere('b.companionId = :companionId', { companionId: data.companionId })
+      .andWhere('b.dateTime = :dateTime', { dateTime: new Date(data.dateTime) })
+      .andWhere('b.status IN (:...statuses)', {
+        statuses: [BookingStatus.PENDING, BookingStatus.CONFIRMED, BookingStatus.PAID],
+      })
+      .getOne();
+
+    if (duplicate) {
+      throw new HttpException(
+        'A booking request for this companion at the same time already exists',
+        HttpStatus.CONFLICT,
+      );
+    }
+
     // Check for overlapping bookings for this companion (race condition guard)
     const bookingStart = new Date(data.dateTime);
     const bookingEnd = new Date(bookingStart.getTime() + duration * 60 * 60 * 1000);


### PR DESCRIPTION
## Summary
- Adds `isCreatingBooking` guard in `bookingsStore` to prevent concurrent `createBooking` calls (double-tap protection)
- Wires guard into `booking/[id].tsx` button, replacing local `isSubmitting` state
- Adds server-side duplicate detection (same seeker+companion+dateTime with active status) — throws 409 CONFLICT if found

## Test plan
- Double-tap the Book button on a companion profile — only 1 booking should be created
- Button shows "Sending..." and is disabled during in-flight request
- Server rejects second identical request with 409 if client-side guard is bypassed