### PR TITLE
feat: activity type filter in browse

### DIFF
--- a/app/app/(tabs)/male/browse.tsx
+++ b/app/app/(tabs)/male/browse.tsx
@@ -27,6 +27,7 @@ const defaultFilterOptions: FilterOptions = {
   availability: 'any',
   ageRange: [21, 45],
   sortBy: 'recommended',
+  activityTypes: [],
 };
 
 export default function BrowseScreen() {
@@ -128,6 +129,7 @@ export default function BrowseScreen() {
         latitude: userLocation?.latitude,
         longitude: userLocation?.longitude,
         search: searchQuery.trim() || undefined,
+        activityTypes: appliedFilters.activityTypes.length > 0 ? appliedFilters.activityTypes : undefined,
       });
 
       // Only update state if this is still the latest fetch (prevents stale overwrites)
@@ -180,6 +182,7 @@ export default function BrowseScreen() {
     if (appliedFilters.ageRange[0] !== defaultFilterOptions.ageRange[0] ||
         appliedFilters.ageRange[1] !== defaultFilterOptions.ageRange[1]) count++;
     if (appliedFilters.sortBy !== defaultFilterOptions.sortBy) count++;
+    if (appliedFilters.activityTypes.length > 0) count++;
     return count;
   }, [appliedFilters]);
 

--- a/app/src/components/FilterModal.tsx
+++ b/app/src/components/FilterModal.tsx
@@ -11,6 +11,7 @@ import Slider from '@react-native-community/slider';
 import { X, Star } from 'lucide-react-native';
 import { Button } from './Button';
 import { colors, spacing, typography, borderRadius } from '../constants/theme';
+import { ActivityType } from '../types';
 
 export interface FilterOptions {
   priceRange: [number, number];
@@ -19,6 +20,7 @@ export interface FilterOptions {
   availability: 'any' | 'today' | 'this_week' | 'weekend';
   ageRange: [number, number];
   sortBy: 'recommended' | 'price_low' | 'price_high' | 'rating' | 'distance' | 'new';
+  activityTypes: ActivityType[];
 }
 
 interface FilterModalProps {
@@ -35,7 +37,18 @@ const defaultFilters: FilterOptions = {
   availability: 'any',
   ageRange: [21, 45],
   sortBy: 'recommended',
+  activityTypes: [],
 };
+
+const activityTypeOptions: { value: ActivityType; label: string }[] = [
+  { value: ActivityType.COFFEE, label: 'Coffee' },
+  { value: ActivityType.DINNER, label: 'Dinner' },
+  { value: ActivityType.DRINKS, label: 'Drinks' },
+  { value: ActivityType.EVENTS, label: 'Events' },
+  { value: ActivityType.MUSEUMS, label: 'Museums' },
+  { value: ActivityType.WALK, label: 'Walk' },
+  { value: ActivityType.OTHER, label: 'Other' },
+];
 
 const availabilityOptions = [
   { value: 'any', label: 'Any time' },
@@ -258,6 +271,35 @@ export function FilterModal({
                   </Text>
                 </TouchableOpacity>
               ))}
+            </View>
+          </View>
+
+          {/* Activity Type */}
+          <View style={styles.section}>
+            <Text style={styles.sectionTitle}>Activity Type</Text>
+            <View style={styles.chipGroup}>
+              {activityTypeOptions.map((option) => {
+                const isSelected = filters.activityTypes.includes(option.value);
+                return (
+                  <TouchableOpacity
+                    key={option.value}
+                    style={[styles.chip, isSelected && styles.chipActive]}
+                    onPress={() => {
+                      const next = isSelected
+                        ? filters.activityTypes.filter((t) => t !== option.value)
+                        : [...filters.activityTypes, option.value];
+                      updateFilter('activityTypes', next);
+                    }}
+                    accessibilityLabel={option.label}
+                    accessibilityRole="checkbox"
+                    accessibilityState={{ checked: isSelected }}
+                  >
+                    <Text style={[styles.chipText, isSelected && styles.chipTextActive]}>
+                      {option.label}
+                    </Text>
+                  </TouchableOpacity>
+                );
+              })}
             </View>
           </View>
 

--- a/app/src/services/api.ts
+++ b/app/src/services/api.ts
@@ -232,6 +232,7 @@ export interface SearchCompanionsParams {
   search?: string;
   page?: number;
   limit?: number;
+  activityTypes?: string[];
 }
 
 export interface CompanionListItem {
@@ -269,11 +270,16 @@ export interface CompanionsResponse {
 export const companionsApi = {
   search: (params: SearchCompanionsParams = {}) => {
     const query = new URLSearchParams();
-    Object.entries(params).forEach(([key, value]) => {
+    const { activityTypes, ...rest } = params;
+    Object.entries(rest).forEach(([key, value]) => {
       if (value !== undefined) {
         query.append(key, String(value));
       }
     });
+    // Serialize activityTypes as a single comma-separated param (only if non-empty)
+    if (activityTypes && activityTypes.length > 0) {
+      query.append('activityTypes', activityTypes.join(','));
+    }
     return apiRequest<CompanionsResponse>(`/companions?${query}`);
   },
 

--- a/app/src/types/index.ts
+++ b/app/src/types/index.ts
@@ -1,5 +1,15 @@
 export type UserRole = 'seeker' | 'companion';
 
+export enum ActivityType {
+  COFFEE = 'coffee',
+  DINNER = 'dinner',
+  DRINKS = 'drinks',
+  EVENTS = 'events',
+  MUSEUMS = 'museums',
+  WALK = 'walk',
+  OTHER = 'other',
+}
+
 export type VerificationStatus = 'not_started' | 'in_progress' | 'pending_review' | 'approved' | 'rejected';
 export type VerificationType = 'seeker' | 'companion';
 

--- a/backend/daterabbit-api/src/companions/companions.controller.ts
+++ b/backend/daterabbit-api/src/companions/companions.controller.ts
@@ -24,6 +24,7 @@ export class CompanionsController {
     @Query('ageMax') ageMax?: string,
     @Query('sortBy') sortBy?: string,
     @Query('search') search?: string,
+    @Query('activityTypes') activityTypesRaw?: string,
     @Query('limit') limit?: string,
     @Query('offset') offset?: string,
     @Query('page') page?: string,
@@ -36,6 +37,12 @@ export class CompanionsController {
       : offset
         ? parseInt(offset)
         : 0;
+
+    // Parse activityTypes from comma-separated string (e.g. "coffee,dinner")
+    const activityTypes =
+      activityTypesRaw && activityTypesRaw.trim()
+        ? activityTypesRaw.split(',').map((s) => s.trim()).filter(Boolean)
+        : undefined;
 
     // Exclude blocked users (req.user is guaranteed by JwtAuthGuard)
     const excludeUserIds = await this.usersService.getBlockedUserIds(req.user.id);
@@ -51,6 +58,7 @@ export class CompanionsController {
       ageMax: ageMax ? parseInt(ageMax) : undefined,
       sortBy,
       search,
+      activityTypes,
       limit: parsedLimit,
       offset: parsedOffset,
       excludeUserIds,

--- a/backend/daterabbit-api/src/users/users.service.ts
+++ b/backend/daterabbit-api/src/users/users.service.ts
@@ -98,6 +98,7 @@ export class UsersService {
     ageMax?: number;
     sortBy?: string;
     search?: string;
+    activityTypes?: string[];
     limit?: number;
     offset?: number;
     excludeUserIds?: string[];
@@ -138,6 +139,20 @@ export class UsersService {
       query.andWhere('(user.name ILIKE :search OR user.location ILIKE :search)', {
         search: `%${filters.search}%`,
       });
+    }
+
+    if (filters.activityTypes && filters.activityTypes.length > 0) {
+      // Filter companions who have at least one active package with a matching defaultActivity
+      query.andWhere(
+        `EXISTS (
+          SELECT 1 FROM date_packages dp
+          INNER JOIN date_package_templates dpt ON dpt.id = dp."templateId"
+          WHERE dp."companionId" = user.id
+            AND dp."isActive" = true
+            AND dpt."defaultActivity" IN (:...activityTypes)
+        )`,
+        { activityTypes: filters.activityTypes },
+      );
     }
 
     if (hasLocation && filters.maxDistance) {


### PR DESCRIPTION
## Summary

- Adds `ActivityType` enum to `app/src/types/index.ts` (coffee/dinner/drinks/events/museums/walk/other)
- Extends `FilterOptions` with `activityTypes: ActivityType[]` (default `[]`)
- Adds multi-select Activity Type chip group to `FilterModal` between Availability and Sort By sections
- Serializes `activityTypes` as comma-separated query param in `companionsApi.search()`
- Passes `activityTypes` from `browse.tsx` fetchCompanions call; counts toward `activeFiltersCount` badge
- Backend: `companions.controller.ts` parses comma-separated `activityTypes` param
- Backend: `users.service.ts` adds EXISTS subquery filtering companions by `date_packages` → `date_package_templates.defaultActivity IN (...)` when filter is non-empty

## Test plan

- [ ] Open Browse → tap Filters → scroll to "Activity Type" section — 7 chips visible
- [ ] Select "Coffee" + "Dinner" → Apply — filter badge shows count incremented
- [ ] Verify API request includes `activityTypes=coffee,dinner`
- [ ] Verify only companions with matching active packages are returned
- [ ] Reset filters → activityTypes cleared → all companions shown
- [ ] Empty selection (no chips) → no activityTypes param → no filter on backend