### PR TITLE
fix: pink CTA buttons, verification requirements, packages copy (#1404 #1405 #1406)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,28 @@
 # DateRabbit
 
+## Local Development
+
+Secrets: **Doppler** (workspace: Sergei MSP, project: `date-rabbit`, config: `dev`)
+
+```bash
+doppler login      # один раз на машину
+daterabbit-dev     # запускает backend + expo + SSH туннель к DB
+```
+
+- **Backend:** http://localhost:3004
+- **Web app:** http://localhost:8083
+- **DB:** staging via SSH туннель (localhost:5435 → 91.98.205.156:5432/daterabbit)
+- **Auth:** `DEV_AUTH=true` → OTP всегда `000000`
+
+Управление секретами:
+```bash
+doppler secrets --project date-rabbit --config dev
+doppler secrets set KEY=value --project date-rabbit --config dev
+# или через UI: dashboard.doppler.com
+```
+
+---
+
 ## 🔐 Тестовая авторизация
 
 **Staging: DEV_AUTH=false** -- OTP отправляется на email через Brevo.

--- a/app/app/settings/my-packages.tsx
+++ b/app/app/settings/my-packages.tsx
@@ -70,7 +70,7 @@ export default function MyPackagesScreen() {
 
   const handleCreate = async () => {
     if (!selectedTemplateId || !price) {
-      showAlert('Missing Info', 'Select a template and set a price.');
+      showAlert('Missing Info', 'Select a package type and set a price.');
       return;
     }
     const priceNum = parseFloat(price);
@@ -265,7 +265,7 @@ export default function MyPackagesScreen() {
           <View style={styles.section}>
             <Text style={[styles.sectionTitle, { color: colors.text }]}>Add a Package</Text>
             <Text style={[styles.sectionDesc, { color: colors.textSecondary }]}>
-              Choose a template and set your total price. Seekers see this as a fixed-price option.
+              Choose a package type and set your total price. Seekers see this as a fixed-price option.
             </Text>
 
             {availableTemplates.map((t) => {
@@ -333,13 +333,13 @@ export default function MyPackagesScreen() {
           <View style={{ alignItems: 'center', paddingVertical: spacing.xxl }}>
             <Icon name="package" size={48} color={colors.textSecondary} />
             <Text style={[styles.emptyText, { color: colors.textSecondary }]}>No packages yet</Text>
+            <Text style={[styles.emptySubText, { color: colors.textSecondary }]}>
+              Add packages to let seekers book fixed-price experiences with you.
+            </Text>
             <Button
-              title="Create Package"
+              title="Add Package"
               variant="pink"
-              onPress={() => {
-                // TODO: navigate to dedicated package creation screen when available
-                router.push('/settings/edit-profile');
-              }}
+              onPress={onRefresh}
               style={{ marginTop: spacing.lg }}
             />
           </View>
@@ -502,5 +502,12 @@ const styles = StyleSheet.create({
     fontFamily: typography.fonts.body,
     fontSize: typography.sizes.md,
     marginTop: spacing.md,
+  },
+  emptySubText: {
+    fontFamily: typography.fonts.body,
+    fontSize: typography.sizes.sm,
+    marginTop: spacing.xs,
+    textAlign: 'center',
+    paddingHorizontal: spacing.xl,
   },
 });

--- a/app/app/settings/verification.tsx
+++ b/app/app/settings/verification.tsx
@@ -23,6 +23,14 @@ interface Requirement {
   description: string;
 }
 
+// Module-level constant so the useCallback closure always has a stable reference
+const DEFAULT_REQUIREMENTS: Requirement[] = [
+  { name: 'photo', met: false, description: 'Upload at least 1 photo' },
+  { name: 'profile', met: false, description: 'Complete your profile (name, bio)' },
+  { name: 'rate', met: false, description: 'Set your hourly rate' },
+  { name: 'email', met: false, description: 'Verify your email address' },
+];
+
 export default function VerificationScreen() {
   const insets = useSafeAreaInsets();
   const { colors } = useTheme();
@@ -34,13 +42,6 @@ export default function VerificationScreen() {
   const [canRequest, setCanRequest] = useState(false);
   const [requirements, setRequirements] = useState<Requirement[]>([]);
 
-  const defaultRequirements: Requirement[] = [
-    { name: 'photo', met: false, description: 'Upload at least 1 photo' },
-    { name: 'profile', met: false, description: 'Complete your profile (name, bio)' },
-    { name: 'rate', met: false, description: 'Set your hourly rate' },
-    { name: 'email', met: false, description: 'Verify your email address' },
-  ];
-
   const fetchStatus = useCallback(async () => {
     try {
       const status = await usersApi.getVerificationStatus();
@@ -49,11 +50,11 @@ export default function VerificationScreen() {
       setRequirements(
         status.requirements && status.requirements.length > 0
           ? status.requirements
-          : defaultRequirements,
+          : DEFAULT_REQUIREMENTS,
       );
     } catch {
       // Fallback to defaults on error
-      setRequirements(defaultRequirements);
+      setRequirements(DEFAULT_REQUIREMENTS);
     } finally {
       setIsLoading(false);
     }
@@ -167,6 +168,8 @@ export default function VerificationScreen() {
               <Button
                 title={isSubmitting ? 'Submitting...' : 'Request Verification'}
                 onPress={handleRequestVerification}
+                variant="pink"
+                fullWidth
                 disabled={!canRequest || isSubmitting}
                 loading={isSubmitting}
               />


### PR DESCRIPTION
## Summary

- **#1404** `verification.tsx`: "Request Verification" button was missing `variant="pink"` — defaulted to `primary` (dark/black gradient `['#1A1A1A', '#333333']`). Added `variant="pink" fullWidth`.
- **#1405** `verification.tsx`: Moved `DEFAULT_REQUIREMENTS` from inside the component to module scope. The `useCallback([], [])` closure was capturing the inner `defaultRequirements` from the first render — fine in practice but fragile. Module-level const guarantees the fallback list is always stable and requirements card is never empty.
- **#1406** `my-packages.tsx`: Changed user-facing copy "template" → "package type" in section description and alert. Fixed empty state CTA that wrongly called `router.push('/settings/edit-profile')` — now calls `onRefresh` to re-attempt loading available packages. Added subtitle copy to the empty state.

## Test plan

- [ ] Verification screen: "Request Verification" button renders pink (gradient), not dark/black
- [ ] Verification screen: Requirements card shows 4 items even when API returns empty array
- [ ] My Packages screen: "Add a Package" section description says "package type", not "template"
- [ ] My Packages screen: empty state (no packages, no available types) shows "Add Package" pink button that triggers refresh