### PR TITLE
fix: companion registration routes to step2, not dead step1 (#2032)

### DIFF
--- a/app/app/(auth)/register.tsx
+++ b/app/app/(auth)/register.tsx
@@ -201,7 +201,7 @@ export default function RegisterScreen() {
 
     // Route to verification flow
     if (isFemale) {
-      router.replace('/(comp-onboard)/step1');
+      router.replace('/(comp-onboard)/step2');
     } else {
       router.replace('/(seeker-verify)/intro');
     }


### PR DESCRIPTION
After companion registration, route to `(comp-onboard)/step2` instead of `step1` (UC-021 was removed, step1 is a dead screen).

## Change
- `app/app/(auth)/register.tsx:204` — `/(comp-onboard)/step1` → `/(comp-onboard)/step2`

## Verify
Register as companion → should land on step2 (photo upload), NOT step1.

Fixes: #2032