### PR TITLE
fix: service fee 15% -> 20% in booking screen (#2035)

### DIFF
--- a/app/app/booking/[id].tsx
+++ b/app/app/booking/[id].tsx
@@ -149,7 +149,7 @@ export default function BookingScreen() {
     return () => subscription.remove();
   }, [hasUnsavedData]);
 
-  const serviceFee = 0.15; // 15% platform fee
+  const serviceFee = 0.20; // 20% platform fee
   const hourlyRate = companion?.hourlyRate ?? 0;
   const isPackageBooking = !!selectedPackage;
   const subtotal = isPackageBooking ? Number(selectedPackage!.price) : hourlyRate * selectedDuration;
@@ -512,7 +512,7 @@ export default function BookingScreen() {
             <Text style={[styles.summaryValue, { color: colors.text }]}>${subtotal}</Text>
           </View>
           <View style={styles.summaryRow}>
-            <Text style={[styles.summaryLabel, { color: colors.textSecondary }]}>Service fee (15%)</Text>
+            <Text style={[styles.summaryLabel, { color: colors.textSecondary }]}>Service fee (20%)</Text>
             <Text style={[styles.summaryValue, { color: colors.text }]}>${fee}</Text>
           </View>
           <View style={[styles.summaryRow, styles.summaryTotal, { borderTopColor: colors.border }]}>

--- a/backend/daterabbit-api/src/payments/payments.service.ts
+++ b/backend/daterabbit-api/src/payments/payments.service.ts
@@ -113,7 +113,7 @@ export class PaymentsService {
     }
 
     const amount = Math.round(Number(booking.totalPrice) * 100); // cents
-    const platformFee = Math.round(amount * 0.15); // 15% platform fee
+    const platformFee = Math.round(amount * 0.20); // 20% platform fee
 
     const paymentIntent = await this.stripe.paymentIntents.create({
       amount,
@@ -220,7 +220,7 @@ export class PaymentsService {
       .getMany();
 
     const totalEarnings = completedBookings.reduce(
-      (sum, b) => sum + Number(b.totalPrice) * 0.85, // minus 15% platform fee
+      (sum, b) => sum + Number(b.totalPrice) * 0.80, // minus 20% platform fee
       0,
     );
 


### PR DESCRIPTION
## Summary
- `booking/[id].tsx`: `serviceFee` constant 0.15 -> 0.20, UI label "Service fee (15%)" -> "Service fee (20%)"
- `payments.service.ts`: `platformFee` calc 0.15 -> 0.20, companion earnings payout factor 0.85 -> 0.80

Fixes service fee inconsistency per UC-041 business decision. Backend and frontend were both hardcoded to 15% instead of 20%.

Fixes: #2035