### PR TITLE
fix: KeyboardAvoidingView missing in 3 screens with TextInput (#2046)

### DIFF
--- a/app/app/(tabs)/female/earnings/withdraw.tsx
+++ b/app/app/(tabs)/female/earnings/withdraw.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { View, Text, StyleSheet, ScrollView, TouchableOpacity, TextInput, ActivityIndicator } from 'react-native';
+import { View, Text, StyleSheet, ScrollView, TouchableOpacity, TextInput, ActivityIndicator, KeyboardAvoidingView, Platform } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useRouter } from 'expo-router';
 import { showAlert, showConfirm } from '../../../../src/utils/alert';
@@ -108,8 +108,11 @@ export default function WithdrawScreen() {
   }
 
   return (
-    <ScrollView
+    <KeyboardAvoidingView
       style={[styles.container, { backgroundColor: colors.background }]}
+      behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+    >
+    <ScrollView
       contentContainerStyle={[styles.content, { paddingTop: insets.top + spacing.md }]}
     >
       <View style={styles.header}>
@@ -241,6 +244,7 @@ export default function WithdrawScreen() {
         </Text>
       </View>
     </ScrollView>
+    </KeyboardAvoidingView>
   );
 }
 

--- a/app/app/date/report/[bookingId].tsx
+++ b/app/app/date/report/[bookingId].tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
-import { View, Text, StyleSheet, TouchableOpacity, TextInput, ScrollView, Alert } from 'react-native';
+import { View, Text, StyleSheet, TouchableOpacity, TextInput, ScrollView, Alert, KeyboardAvoidingView, Platform } from 'react-native';
 import { useLocalSearchParams, router } from 'expo-router';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { activeDateApi } from '../../../src/services/activeDateApi';
 import { colors } from '../../../src/constants/theme';
 
@@ -13,6 +14,7 @@ const ISSUE_TYPES: { label: string; value: string }[] = [
 ];
 
 export default function ReportIssueScreen() {
+  const insets = useSafeAreaInsets();
   const { bookingId } = useLocalSearchParams<{ bookingId: string }>();
   const [type, setType] = useState('');
   const [description, setDescription] = useState('');
@@ -44,7 +46,11 @@ export default function ReportIssueScreen() {
   );
 
   return (
-    <ScrollView style={styles.container} contentContainerStyle={styles.content}>
+    <KeyboardAvoidingView
+      style={styles.container}
+      behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+    >
+    <ScrollView contentContainerStyle={[styles.content, { paddingTop: insets.top + 24 }]}>
       <Text style={styles.title}>Report an Issue</Text>
 
       <Text style={styles.sectionLabel}>Issue Type</Text>
@@ -83,12 +89,13 @@ export default function ReportIssueScreen() {
         <Text style={styles.submitBtnText}>{submitting ? 'Submitting...' : 'Submit Report'}</Text>
       </TouchableOpacity>
     </ScrollView>
+    </KeyboardAvoidingView>
   );
 }
 
 const styles = StyleSheet.create({
   container: { flex: 1, backgroundColor: '#F4F0EA' },
-  content: { padding: 24, paddingTop: 40 },
+  content: { padding: 24 },
   center: { flex: 1, backgroundColor: '#F4F0EA', justifyContent: 'center', alignItems: 'center', padding: 24 },
   title: { fontSize: 32, fontFamily: 'SpaceGrotesk-Bold', fontWeight: '700', color: '#000', marginBottom: 32 },
   sectionLabel: { fontSize: 14, fontFamily: 'SpaceGrotesk-Bold', fontWeight: '700', color: '#000', marginBottom: 12, textTransform: 'uppercase', letterSpacing: 1 },

--- a/app/app/reviews/write/[bookingId].tsx
+++ b/app/app/reviews/write/[bookingId].tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { View, Text, StyleSheet, TouchableOpacity, TextInput, ScrollView, Alert, ActivityIndicator } from 'react-native';
+import { View, Text, StyleSheet, TouchableOpacity, TextInput, ScrollView, Alert, ActivityIndicator, KeyboardAvoidingView, Platform } from 'react-native';
 import { useLocalSearchParams, router } from 'expo-router';
 import { apiRequest } from '../../../src/services/api';
 import { colors, typography, shadows } from '../../../src/constants/theme';
@@ -27,7 +27,11 @@ export default function WriteReviewScreen() {
   };
 
   return (
-    <ScrollView style={styles.container} contentContainerStyle={styles.content}>
+    <KeyboardAvoidingView
+      style={styles.container}
+      behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+    >
+    <ScrollView contentContainerStyle={styles.content}>
       <Text style={styles.title}>How was{'\n'}your date?</Text>
 
       <View style={styles.starsRow}>
@@ -66,6 +70,7 @@ export default function WriteReviewScreen() {
         }
       </TouchableOpacity>
     </ScrollView>
+    </KeyboardAvoidingView>
   );
 }
 


### PR DESCRIPTION
## Summary

Fixes keyboard covering TextInput fields in 3 screens:

- `reviews/write/[bookingId].tsx` — multiline review textarea
- `date/report/[bookingId].tsx` — report description textarea (also replaced hardcoded `paddingTop: 40` with `useSafeAreaInsets().top`)
- `(tabs)/female/earnings/withdraw.tsx` — custom amount input

Pattern follows `settings/edit-profile.tsx`: `KeyboardAvoidingView` wraps the screen with `behavior={Platform.OS === 'ios' ? 'padding' : 'height'}`.

## Fixes
Fixes: #2046