### PR TITLE
feat: role-specific onboarding slides based on roleHint (#2033)

### DIFF
--- a/app/app/onboarding.tsx
+++ b/app/app/onboarding.tsx
@@ -6,7 +6,7 @@ import {
   TouchableOpacity,
   Platform,
 } from 'react-native';
-import { router } from 'expo-router';
+import { router, useLocalSearchParams } from 'expo-router';
 import { Heart, Shield, DollarSign, Sparkles, type LucideIcon } from 'lucide-react-native';
 import { useAuthStore } from '../src/store/authStore';
 import { Button } from '../src/components/Button';
@@ -19,39 +19,72 @@ interface SlideItem {
   IconComponent: LucideIcon;
 }
 
-const slides: SlideItem[] = [
+const COMPANION_SLIDES: SlideItem[] = [
   {
     id: '1',
-    title: 'Find Your Perfect Date',
-    description: 'Connect with verified, interesting people for memorable experiences',
+    title: 'Your attention is worth money',
+    description: 'Set your availability and let seekers come to you',
     IconComponent: Heart,
   },
   {
     id: '2',
-    title: 'Safe & Secure',
-    description: 'All users are verified. Your safety is our top priority',
+    title: 'Set your price',
+    description: 'You decide your rates — hourly, by date, or by event',
+    IconComponent: DollarSign,
+  },
+  {
+    id: '3',
+    title: 'Get paid via Stripe',
+    description: 'Secure, automatic payouts after every confirmed date',
+    IconComponent: Sparkles,
+  },
+  {
+    id: '4',
+    title: 'Meet verified seekers',
+    description: 'Only verified, identity-checked men can book you',
+    IconComponent: Shield,
+  },
+];
+
+const SEEKER_SLIDES: SlideItem[] = [
+  {
+    id: '1',
+    title: 'Find a companion',
+    description: 'Browse verified girls available in your city right now',
+    IconComponent: Heart,
+  },
+  {
+    id: '2',
+    title: 'Verified companions',
+    description: 'Every profile is identity-checked — no fakes, no surprises',
     IconComponent: Shield,
   },
   {
     id: '3',
-    title: 'Earn While Dating',
-    description: 'Set your own rates and schedule. You\'re in control',
-    IconComponent: DollarSign,
+    title: 'Book easily',
+    description: 'Pick a girl, choose a time, and confirm in seconds',
+    IconComponent: Sparkles,
   },
   {
     id: '4',
-    title: 'Premium Experiences',
-    description: 'Book amazing dates at top restaurants, events, and more',
-    IconComponent: Sparkles,
+    title: 'Safe & secure',
+    description: 'Stripe handles payments. Your data stays private.',
+    IconComponent: DollarSign,
   },
 ];
 
 export default function OnboardingScreen() {
   const [currentIndex, setCurrentIndex] = useState(0);
   const { setOnboardingSeen } = useAuthStore();
+  const { roleHint } = useLocalSearchParams<{ roleHint?: string }>();
+
+  // Normalize roleHint — useLocalSearchParams can return string | string[]
+  const hint = Array.isArray(roleHint) ? roleHint[0] : roleHint;
+  const activeSlides = hint === 'companion' ? COMPANION_SLIDES : SEEKER_SLIDES;
+  const role = hint === 'companion' ? 'companion' : 'seeker';
 
   const handleNext = () => {
-    if (currentIndex < slides.length - 1) {
+    if (currentIndex < activeSlides.length - 1) {
       setCurrentIndex(prev => prev + 1);
     } else {
       completeOnboarding();
@@ -60,15 +93,14 @@ export default function OnboardingScreen() {
 
   const completeOnboarding = () => {
     setOnboardingSeen();
-    // Navigate to auth welcome (login) page after onboarding
-    router.replace('/(auth)/welcome');
+    router.replace(`/(auth)/login?role=${role}` as any);
   };
 
   const handleSkip = () => {
     completeOnboarding();
   };
 
-  const currentSlide = slides[currentIndex];
+  const currentSlide = activeSlides[currentIndex];
   const SlideIcon = currentSlide.IconComponent;
 
   return (
@@ -92,7 +124,7 @@ export default function OnboardingScreen() {
       </View>
 
       <View style={styles.dotsContainer}>
-        {slides.map((_, index) => (
+        {activeSlides.map((_, index) => (
           <TouchableOpacity
             key={index}
             onPress={() => setCurrentIndex(index)}
@@ -109,7 +141,7 @@ export default function OnboardingScreen() {
 
       <View style={styles.buttonContainer}>
         <Button
-          title={currentIndex === slides.length - 1 ? "Get Started" : "Next"}
+          title={currentIndex === activeSlides.length - 1 ? "Get Started" : "Next"}
           onPress={handleNext}
           fullWidth
           size="lg"


### PR DESCRIPTION
## Summary

- Onboarding now reads `roleHint` URL param via `useLocalSearchParams`
- Shows companion slides (earn money flow) when `roleHint=companion`
- Shows seeker slides (find companion flow) when `roleHint=seeker` or param is absent
- `Get Started` and `Skip` both route to `/(auth)/login?role=companion|seeker`
- Dots pagination updated to use `activeSlides` length (was hardcoded to old `slides` array)
- `roleHint` normalized to handle `string | string[]` from expo-router

## Fixes

Closes #2033 — UC-006 (Companion slides) and UC-007 (Seeker slides) implemented.

## Test plan

- [ ] `/onboarding?roleHint=companion` → 4 companion slides (earn money), Get Started → login?role=companion
- [ ] `/onboarding?roleHint=seeker` → 4 seeker slides (find companion), Get Started → login?role=seeker
- [ ] `/onboarding` (no param) → seeker slides (default)
- [ ] Skip on each flow → same login destination with correct role
- [ ] Dot count matches active slides (4 dots)