### PR TITLE
fix: getEarningsHistory fee 0.85→0.80 — complete #2035

### DIFF
--- a/backend/daterabbit-api/src/payments/payments.service.ts
+++ b/backend/daterabbit-api/src/payments/payments.service.ts
@@ -270,7 +270,7 @@ export class PaymentsService {
     const transactions = bookings.map((b) => ({
       id: b.id,
       type: 'earning' as const,
-      amount: Math.round(Number(b.totalPrice) * 0.85 * 100) / 100,
+      amount: Math.round(Number(b.totalPrice) * 0.80 * 100) / 100,
       status: 'completed' as const,
       description: `Booking with ${b.seeker?.name || 'Unknown'}`,
       seekerName: b.seeker?.name,


### PR DESCRIPTION
Missed occurrence in getEarningsHistory() (line ~273). All 0.85 fee references now updated to 0.80.

Fixes remaining issue from #2035