### PR TITLE
fix: date/_layout.tsx wrong import depth — complete #2045

### DIFF
--- a/app/app/date/_layout.tsx
+++ b/app/app/date/_layout.tsx
@@ -1,5 +1,5 @@
 import { Stack } from 'expo-router';
-import { typography } from '../../../src/constants/theme';
+import { typography } from '../../src/constants/theme';
 
 export default function DateLayout() {
   return (


### PR DESCRIPTION
Wrong path `'../../../src/constants/theme'` → `'../../src/constants/theme'`

Fixes TS2307 introduced in previous commit (6ce65ee).

Path verification:
- `_layout.tsx` is at `app/app/date/_layout.tsx`
- `theme.ts` is at `app/src/constants/theme.ts`
- from `app/app/date/` → up to `app/app/` (1), up to `app/` (2), then `src/constants/theme` → `../../src/constants/theme` ✓