### PR TITLE
fix(ts): correct VerificationStatus comparison and color token

### DIFF
--- a/app/src/components/VerificationBanner.tsx
+++ b/app/src/components/VerificationBanner.tsx
@@ -19,7 +19,7 @@ export function VerificationBanner({ compact = false }: VerificationBannerProps)
   const router = useRouter();
 
   const isVerified = user?.verificationStatus === 'approved';
-  const isPending = user?.verificationStatus === 'pending';
+  const isPending = user?.verificationStatus === 'pending_review';
 
   if (isVerified) return null;
 
@@ -96,7 +96,7 @@ const styles = StyleSheet.create({
   text: {
     fontFamily: typography.fonts.bodyMedium,
     fontSize: typography.sizes.sm,
-    color: colors.textPrimary,
+    color: colors.text,
     flex: 1,
   },
   compactText: {

--- a/app/src/hooks/useVerificationGate.ts
+++ b/app/src/hooks/useVerificationGate.ts
@@ -18,7 +18,7 @@ export function useVerificationGate() {
   const router = useRouter();
 
   const isVerified = user?.verificationStatus === 'approved';
-  const isPending = user?.verificationStatus === 'pending';
+  const isPending = user?.verificationStatus === 'pending_review';
 
   /**
    * Call before a gated action. Returns true if action should be blocked.


### PR DESCRIPTION
## Summary
- `VerificationBanner.tsx` line 22: `'pending'` → `'pending_review'` to match `VerificationStatus` enum (TS2367)
- `VerificationBanner.tsx` line 99: `colors.textPrimary` → `colors.text` — token did not exist in theme (TS2339)
- `useVerificationGate.ts` line 21: `'pending'` → `'pending_review'` same enum fix (TS2367)

## Test plan
- [ ] `cd app && npx tsc --noEmit 2>&1 | grep -E "VerificationBanner|useVerificationGate"` returns empty
- [ ] No other files changed

Closes Trinity task #2054