### PR TITLE
feat: conditional CTAs on companion profile by seeker status

### DIFF
--- a/app/app/profile/[id].tsx
+++ b/app/app/profile/[id].tsx
@@ -634,19 +634,44 @@ export default function ProfileViewScreen() {
 
       {/* Bottom Action Bar */}
       <View style={[styles.bottomBar, { backgroundColor: colors.white, borderTopColor: colors.border, paddingBottom: insets.bottom || spacing.xl }]}>
-        <Button
-          title="Message"
-          onPress={handleMessage}
-          variant="outline"
-          style={styles.messageButton}
-          testID="profile-view-message-btn"
-        />
-        <Button
-          title={`Book Date • $${profile.hourlyRate ?? 0}/hr`}
-          onPress={handleBookDate}
-          style={styles.bookButton}
-          testID="profile-view-book-btn"
-        />
+        {isSelf ? (
+          <Button
+            title="Edit Profile"
+            onPress={() => router.push('/settings/edit-profile')}
+            style={{ flex: 1 }}
+            testID="profile-view-edit-btn"
+          />
+        ) : !isAuthenticated ? (
+          <Button
+            title="Sign Up to Book"
+            onPress={() => router.push('/onboarding?roleHint=seeker')}
+            style={{ flex: 1 }}
+            testID="profile-view-signup-btn"
+          />
+        ) : currentUser?.verificationStatus !== 'approved' ? (
+          <Button
+            title="Verify to Book"
+            onPress={() => router.push('/(seeker-verify)/intro')}
+            style={{ flex: 1 }}
+            testID="profile-view-verify-btn"
+          />
+        ) : (
+          <>
+            <Button
+              title="Message"
+              onPress={handleMessage}
+              variant="outline"
+              style={styles.messageButton}
+              testID="profile-view-message-btn"
+            />
+            <Button
+              title={`Book Date • $${profile.hourlyRate ?? 0}/hr`}
+              onPress={handleBookDate}
+              style={styles.bookButton}
+              testID="profile-view-book-btn"
+            />
+          </>
+        )}
       </View>
 
       {/* Menu Modal */}


### PR DESCRIPTION
## Summary
- Replace static Message+BookDate bottom bar with state-dependent CTAs based on viewer status
- Guest (not authenticated): "Sign Up to Book" → /onboarding?roleHint=seeker
- Authenticated but unverified: "Verify to Book" → /(seeker-verify)/intro
- Verified seeker: existing "Message" + "Book Date" layout
- Self-view (own profile): "Edit Profile" → /settings/edit-profile

Closes #2050

## Test plan
- [ ] Open companion profile as guest → see "Sign Up to Book"
- [ ] Open companion profile as unverified user → see "Verify to Book"
- [ ] Open companion profile as verified seeker → see "Message" + "Book Date"
- [ ] Open own profile → see "Edit Profile"

Generated with [Claude Code](https://claude.com/claude-code)