### PR TITLE
feat: cities table + public /cities API + admin endpoints

### DIFF
--- a/backend/daterabbit-api/src/admin/admin.controller.ts
+++ b/backend/daterabbit-api/src/admin/admin.controller.ts
@@ -16,6 +16,8 @@ import {
 } from '@nestjs/common';
 import { AdminGuard } from './admin.guard';
 import { AdminService } from './admin.service';
+import { CreateCityDto } from '../cities/dto/create-city.dto';
+import { UpdateCityDto } from '../cities/dto/update-city.dto';
 
 @Controller('admin')
 @UseGuards(AdminGuard)
@@ -168,5 +170,24 @@ export class AdminController {
     },
   ) {
     return this.adminService.updateSettings(body);
+  }
+
+  // #2039 - cities management
+  @Get('cities')
+  getCities() {
+    return this.adminService.getCities();
+  }
+
+  @Post('cities')
+  createCity(@Body() dto: CreateCityDto) {
+    return this.adminService.createCity(dto);
+  }
+
+  @Patch('cities/:id')
+  updateCity(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() dto: UpdateCityDto,
+  ) {
+    return this.adminService.updateCity(id, dto);
   }
 }

--- a/backend/daterabbit-api/src/admin/admin.module.ts
+++ b/backend/daterabbit-api/src/admin/admin.module.ts
@@ -11,6 +11,7 @@ import { Verification } from '../verification/entities/verification.entity';
 import { Review } from '../reviews/entities/review.entity';
 import { PlatformSettings } from './entities/platform-settings.entity';
 import { UsersModule } from '../users/users.module';
+import { CitiesModule } from '../cities/cities.module';
 
 @Module({
   imports: [
@@ -24,6 +25,7 @@ import { UsersModule } from '../users/users.module';
       }),
     }),
     UsersModule,
+    CitiesModule,
   ],
   controllers: [AdminController],
   providers: [AdminService, AdminGuard],

--- a/backend/daterabbit-api/src/admin/admin.service.ts
+++ b/backend/daterabbit-api/src/admin/admin.service.ts
@@ -6,6 +6,9 @@ import { Booking, BookingStatus } from '../bookings/entities/booking.entity';
 import { Verification, VerificationStatus } from '../verification/entities/verification.entity';
 import { Review } from '../reviews/entities/review.entity';
 import { PlatformSettings } from './entities/platform-settings.entity';
+import { CitiesService } from '../cities/cities.service';
+import { CreateCityDto } from '../cities/dto/create-city.dto';
+import { UpdateCityDto } from '../cities/dto/update-city.dto';
 
 @Injectable()
 export class AdminService {
@@ -20,6 +23,7 @@ export class AdminService {
     private reviewsRepo: Repository<Review>,
     @InjectRepository(PlatformSettings)
     private settingsRepo: Repository<PlatformSettings>,
+    private readonly citiesService: CitiesService,
   ) {}
 
   async getStats() {
@@ -393,5 +397,18 @@ export class AdminService {
 
     await this.settingsRepo.save(settings);
     return this.getSettings();
+  }
+
+  // #2039 - cities management
+  async getCities() {
+    return this.citiesService.findAll(false);
+  }
+
+  async createCity(dto: CreateCityDto) {
+    return this.citiesService.create(dto);
+  }
+
+  async updateCity(id: string, dto: UpdateCityDto) {
+    return this.citiesService.update(id, dto);
   }
 }

--- a/backend/daterabbit-api/src/app.module.ts
+++ b/backend/daterabbit-api/src/app.module.ts
@@ -17,6 +17,7 @@ import { NotificationsModule } from './notifications/notifications.module';
 import { CalendarModule } from './calendar/calendar.module';
 import { ReferralModule } from './referral/referral.module';
 import { PackagesModule } from './packages/packages.module';
+import { CitiesModule } from './cities/cities.module';
 
 @Module({
   imports: [
@@ -66,6 +67,7 @@ import { PackagesModule } from './packages/packages.module';
     CalendarModule,
     ReferralModule,
     PackagesModule,
+    CitiesModule,
   ],
   providers: [
     {

--- a/backend/daterabbit-api/src/cities/cities.controller.ts
+++ b/backend/daterabbit-api/src/cities/cities.controller.ts
@@ -1,0 +1,14 @@
+import { Controller, Get, Query, DefaultValuePipe, ParseBoolPipe } from '@nestjs/common';
+import { CitiesService } from './cities.service';
+
+@Controller('cities')
+export class CitiesController {
+  constructor(private readonly citiesService: CitiesService) {}
+
+  @Get()
+  findAll(
+    @Query('active', new DefaultValuePipe(true), ParseBoolPipe) active: boolean,
+  ) {
+    return this.citiesService.findAll(active);
+  }
+}

--- a/backend/daterabbit-api/src/cities/cities.module.ts
+++ b/backend/daterabbit-api/src/cities/cities.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { City } from './entities/city.entity';
+import { CitiesService } from './cities.service';
+import { CitiesController } from './cities.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([City])],
+  controllers: [CitiesController],
+  providers: [CitiesService],
+  exports: [CitiesService],
+})
+export class CitiesModule {}

--- a/backend/daterabbit-api/src/cities/cities.service.ts
+++ b/backend/daterabbit-api/src/cities/cities.service.ts
@@ -1,0 +1,36 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { City } from './entities/city.entity';
+import { CreateCityDto } from './dto/create-city.dto';
+import { UpdateCityDto } from './dto/update-city.dto';
+
+@Injectable()
+export class CitiesService {
+  constructor(
+    @InjectRepository(City)
+    private readonly citiesRepo: Repository<City>,
+  ) {}
+
+  async findAll(activeOnly = true): Promise<City[]> {
+    const where = activeOnly ? { isActive: true } : {};
+    return this.citiesRepo.find({
+      where,
+      order: { state: 'ASC', name: 'ASC' },
+    });
+  }
+
+  async create(dto: CreateCityDto): Promise<City> {
+    const city = this.citiesRepo.create(dto);
+    return this.citiesRepo.save(city);
+  }
+
+  async update(id: string, dto: UpdateCityDto): Promise<City> {
+    const city = await this.citiesRepo.findOne({ where: { id } });
+    if (!city) {
+      throw new NotFoundException('City not found');
+    }
+    Object.assign(city, dto);
+    return this.citiesRepo.save(city);
+  }
+}

--- a/backend/daterabbit-api/src/cities/dto/create-city.dto.ts
+++ b/backend/daterabbit-api/src/cities/dto/create-city.dto.ts
@@ -1,0 +1,14 @@
+import { IsString, IsBoolean, IsOptional, Length } from 'class-validator';
+
+export class CreateCityDto {
+  @IsString()
+  name: string;
+
+  @IsString()
+  @Length(2, 2)
+  state: string;
+
+  @IsBoolean()
+  @IsOptional()
+  isActive?: boolean;
+}

--- a/backend/daterabbit-api/src/cities/dto/update-city.dto.ts
+++ b/backend/daterabbit-api/src/cities/dto/update-city.dto.ts
@@ -1,0 +1,16 @@
+import { IsString, IsBoolean, IsOptional, Length } from 'class-validator';
+
+export class UpdateCityDto {
+  @IsString()
+  @IsOptional()
+  name?: string;
+
+  @IsString()
+  @Length(2, 2)
+  @IsOptional()
+  state?: string;
+
+  @IsBoolean()
+  @IsOptional()
+  isActive?: boolean;
+}

--- a/backend/daterabbit-api/src/cities/entities/city.entity.ts
+++ b/backend/daterabbit-api/src/cities/entities/city.entity.ts
@@ -1,0 +1,19 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn } from 'typeorm';
+
+@Entity('cities')
+export class City {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  name: string;
+
+  @Column({ length: 2 })
+  state: string;
+
+  @Column({ default: true })
+  isActive: boolean;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}

--- a/backend/daterabbit-api/src/seed/seed.ts
+++ b/backend/daterabbit-api/src/seed/seed.ts
@@ -6,6 +6,7 @@ import { User, UserRole, UserVerificationStatus } from '../users/entities/user.e
 import { Booking, BookingStatus, ActivityType } from '../bookings/entities/booking.entity';
 import { Message, Conversation } from '../messages/entities/message.entity';
 import { Verification } from '../verification/entities/verification.entity';
+import { City } from '../cities/entities/city.entity';
 
 // Load .env — try backend root first, then project root
 dotenv.config({ path: path.resolve(__dirname, '../../.env') });
@@ -18,7 +19,7 @@ const AppDataSource = new DataSource({
   username: process.env.DB_USERNAME || 'postgres',
   password: process.env.DB_PASSWORD || 'postgres',
   database: process.env.DB_NAME || 'daterabbit',
-  entities: [User, Booking, Message, Conversation, Verification],
+  entities: [User, Booking, Message, Conversation, Verification, City],
   synchronize: false,
   logging: false,
 });
@@ -966,6 +967,133 @@ async function seed() {
     console.log(`  Created ${conversationScripts.length} conversations with ${totalMessages} messages.\n`);
 
     // -----------------------------------------------------------------------
+    // 6. Seed 100 US cities (idempotent — upsert by name+state)
+    // -----------------------------------------------------------------------
+    console.log('Seeding 100 US cities...');
+
+    const usCities: { name: string; state: string }[] = [
+      { name: 'New York', state: 'NY' },
+      { name: 'Los Angeles', state: 'CA' },
+      { name: 'Chicago', state: 'IL' },
+      { name: 'Houston', state: 'TX' },
+      { name: 'Phoenix', state: 'AZ' },
+      { name: 'Philadelphia', state: 'PA' },
+      { name: 'San Antonio', state: 'TX' },
+      { name: 'San Diego', state: 'CA' },
+      { name: 'Dallas', state: 'TX' },
+      { name: 'San Jose', state: 'CA' },
+      { name: 'Austin', state: 'TX' },
+      { name: 'Jacksonville', state: 'FL' },
+      { name: 'Fort Worth', state: 'TX' },
+      { name: 'Columbus', state: 'OH' },
+      { name: 'Charlotte', state: 'NC' },
+      { name: 'Indianapolis', state: 'IN' },
+      { name: 'San Francisco', state: 'CA' },
+      { name: 'Seattle', state: 'WA' },
+      { name: 'Denver', state: 'CO' },
+      { name: 'Nashville', state: 'TN' },
+      { name: 'Oklahoma City', state: 'OK' },
+      { name: 'El Paso', state: 'TX' },
+      { name: 'Washington', state: 'DC' },
+      { name: 'Boston', state: 'MA' },
+      { name: 'Las Vegas', state: 'NV' },
+      { name: 'Memphis', state: 'TN' },
+      { name: 'Louisville', state: 'KY' },
+      { name: 'Portland', state: 'OR' },
+      { name: 'Baltimore', state: 'MD' },
+      { name: 'Milwaukee', state: 'WI' },
+      { name: 'Albuquerque', state: 'NM' },
+      { name: 'Tucson', state: 'AZ' },
+      { name: 'Fresno', state: 'CA' },
+      { name: 'Sacramento', state: 'CA' },
+      { name: 'Mesa', state: 'AZ' },
+      { name: 'Kansas City', state: 'MO' },
+      { name: 'Atlanta', state: 'GA' },
+      { name: 'Omaha', state: 'NE' },
+      { name: 'Colorado Springs', state: 'CO' },
+      { name: 'Raleigh', state: 'NC' },
+      { name: 'Long Beach', state: 'CA' },
+      { name: 'Virginia Beach', state: 'VA' },
+      { name: 'Minneapolis', state: 'MN' },
+      { name: 'Tampa', state: 'FL' },
+      { name: 'New Orleans', state: 'LA' },
+      { name: 'Arlington', state: 'TX' },
+      { name: 'Bakersfield', state: 'CA' },
+      { name: 'Honolulu', state: 'HI' },
+      { name: 'Anaheim', state: 'CA' },
+      { name: 'Aurora', state: 'CO' },
+      { name: 'Santa Ana', state: 'CA' },
+      { name: 'Corpus Christi', state: 'TX' },
+      { name: 'Riverside', state: 'CA' },
+      { name: 'St. Louis', state: 'MO' },
+      { name: 'Lexington', state: 'KY' },
+      { name: 'Pittsburgh', state: 'PA' },
+      { name: 'Stockton', state: 'CA' },
+      { name: 'Anchorage', state: 'AK' },
+      { name: 'Cincinnati', state: 'OH' },
+      { name: 'St. Paul', state: 'MN' },
+      { name: 'Greensboro', state: 'NC' },
+      { name: 'Toledo', state: 'OH' },
+      { name: 'Newark', state: 'NJ' },
+      { name: 'Plano', state: 'TX' },
+      { name: 'Henderson', state: 'NV' },
+      { name: 'Lincoln', state: 'NE' },
+      { name: 'Buffalo', state: 'NY' },
+      { name: 'Fort Wayne', state: 'IN' },
+      { name: 'Jersey City', state: 'NJ' },
+      { name: 'Chula Vista', state: 'CA' },
+      { name: 'Orlando', state: 'FL' },
+      { name: 'St. Petersburg', state: 'FL' },
+      { name: 'Norfolk', state: 'VA' },
+      { name: 'Chandler', state: 'AZ' },
+      { name: 'Laredo', state: 'TX' },
+      { name: 'Madison', state: 'WI' },
+      { name: 'Durham', state: 'NC' },
+      { name: 'Lubbock', state: 'TX' },
+      { name: 'Winston-Salem', state: 'NC' },
+      { name: 'Garland', state: 'TX' },
+      { name: 'Glendale', state: 'AZ' },
+      { name: 'Hialeah', state: 'FL' },
+      { name: 'Reno', state: 'NV' },
+      { name: 'Baton Rouge', state: 'LA' },
+      { name: 'Irvine', state: 'CA' },
+      { name: 'Chesapeake', state: 'VA' },
+      { name: 'Irving', state: 'TX' },
+      { name: 'Scottsdale', state: 'AZ' },
+      { name: 'North Las Vegas', state: 'NV' },
+      { name: 'Fremont', state: 'CA' },
+      { name: 'Gilbert', state: 'AZ' },
+      { name: 'San Bernardino', state: 'CA' },
+      { name: 'Boise', state: 'ID' },
+      { name: 'Birmingham', state: 'AL' },
+      { name: 'Rochester', state: 'NY' },
+      { name: 'Richmond', state: 'VA' },
+      { name: 'Spokane', state: 'WA' },
+      { name: 'Des Moines', state: 'IA' },
+      { name: 'Montgomery', state: 'AL' },
+      { name: 'Modesto', state: 'CA' },
+      { name: 'Tacoma', state: 'WA' },
+    ];
+
+    const cityRepo = AppDataSource.getRepository(City);
+    let citiesCreated = 0;
+    let citiesSkipped = 0;
+
+    for (const c of usCities) {
+      const existing = await cityRepo.findOne({
+        where: { name: c.name, state: c.state },
+      });
+      if (existing) {
+        citiesSkipped++;
+        continue;
+      }
+      await cityRepo.save(cityRepo.create({ name: c.name, state: c.state, isActive: true }));
+      citiesCreated++;
+    }
+
+    console.log(`  Cities: ${citiesCreated} created, ${citiesSkipped} already existed.\n`);
+
+    // -----------------------------------------------------------------------
     // Summary
     // -----------------------------------------------------------------------
     const pendingCount = bookings.filter((b) => b.status === BookingStatus.PENDING).length;
@@ -985,6 +1113,7 @@ async function seed() {
     console.log(`    Cancelled:   ${cancelledCount}`);
     console.log(`  Conversations: ${conversationScripts.length}`);
     console.log(`  Messages:      ${totalMessages}`);
+    console.log(`  Cities:        ${citiesCreated} new (${citiesSkipped} existed)`);
     console.log('='.repeat(50));
     console.log('\nSample test accounts (OTP: 000000 in DEV mode):');
     console.log('  Seeker:    james.mitchell@seed.daterabbit.com');


### PR DESCRIPTION
## Summary
- Adds City entity (TypeORM) with uuid, name, state (2-char), isActive, createdAt
- CitiesModule with public GET /cities?active=true (no auth guard)
- Admin CRUD endpoints: GET/POST/PATCH /admin/cities (behind AdminGuard)
- Seeds 100 US cities idempotently in seed.ts

## Test plan
- [ ] `curl http://localhost:3004/api/cities` returns 100 cities (after seed)
- [ ] `curl http://localhost:3004/api/cities?active=true` filters by isActive
- [ ] Admin endpoints require auth token
- [ ] TypeScript compiles clean (`npx tsc --noEmit`)

Task #2039