### PR TITLE
fix: server-side booking gate — reject unverified seekers (verificationStatus)

### DIFF
--- a/backend/daterabbit-api/src/bookings/bookings.service.ts
+++ b/backend/daterabbit-api/src/bookings/bookings.service.ts
@@ -39,6 +39,18 @@ export class BookingsService {
     notes?: string;
     packageId?: string;
   }): Promise<Booking> {
+    // UC-SECURITY-01: Verify seeker has completed identity verification before booking
+    const seeker = await this.usersService.findById(data.seekerId);
+    if (!seeker) {
+      throw new HttpException('Seeker not found', HttpStatus.NOT_FOUND);
+    }
+    if (seeker.verificationStatus !== 'approved') {
+      throw new HttpException(
+        'Identity verification required. Complete verification to book a companion.',
+        HttpStatus.FORBIDDEN,
+      );
+    }
+
     const companion = await this.usersService.findById(data.companionId);
     if (!companion) {
       throw new HttpException('Companion not found', HttpStatus.NOT_FOUND);


### PR DESCRIPTION
## Summary
- Adds server-side verification gate in `bookings.service.ts` `create()` method
- Seeker must have `verificationStatus === 'approved'` to create a booking
- Returns HTTP 403 FORBIDDEN with clear message if not verified
- Closes UC-SECURITY-01: seeker was able to bypass verification and book companions

## Root cause
`bookings.service.ts` `create()` had no check on the seeker's verification status — only frontend gate (`useVerificationGate` hook) existed, which is bypassable via direct API calls.

## Test plan
- [ ] Unverified seeker attempts POST `/bookings` → receives 403 "Identity verification required"
- [ ] Verified seeker (verificationStatus=approved) attempts booking → proceeds normally
- [ ] Frontend gate (`useVerificationGate`) continues to work as before (no changes)

Trinity: #2037