### PR TITLE
feat: date history — status badges, no_show, earnings label, tappable cards

### DIFF
--- a/app/app/(tabs)/female/requests.tsx
+++ b/app/app/(tabs)/female/requests.tsx
@@ -159,8 +159,20 @@ interface RequestCardProps {
 
 function RequestCard({ request, type, colors, onAccept, onDecline, formatDate }: RequestCardProps) {
   const seeker = request.seeker || { name: 'Unknown', photo: null };
-  
-  return (
+
+  const getStatusStyle = (status: string) => {
+    switch (status) {
+      case 'completed': return { bg: colors.primary + '20', text: colors.primary };
+      case 'cancelled': return { bg: colors.error + '20', text: colors.error };
+      case 'no_show': return { bg: colors.error + '20', text: colors.error };
+      default: return { bg: colors.textSecondary + '20', text: colors.textSecondary };
+    }
+  };
+
+  const displayStatus = request.noShowReason ? 'no_show' : request.status;
+  const statusStyle = getStatusStyle(displayStatus);
+
+  const cardContent = (
     <Card style={styles.card}>
       <View style={styles.cardHeader}>
         <UserImage name={seeker.name} uri={seeker.photo} size={56} />
@@ -182,7 +194,16 @@ function RequestCard({ request, type, colors, onAccept, onDecline, formatDate }:
         </View>
         <View style={styles.cardAmount}>
           <Text style={[styles.amountValue, { color: colors.success }]}>${request.total}</Text>
-          <Text style={[styles.amountLabel, { color: colors.textSecondary }]}>Total</Text>
+          <Text style={[styles.amountLabel, { color: colors.textSecondary }]}>
+            {type === 'completed' ? 'Earned' : 'Total'}
+          </Text>
+          {type === 'completed' && (
+            <View style={[styles.statusBadge, { backgroundColor: statusStyle.bg }]}>
+              <Text style={[styles.statusText, { color: statusStyle.text }]}>
+                {displayStatus === 'no_show' ? 'no show' : displayStatus}
+              </Text>
+            </View>
+          )}
         </View>
       </View>
 
@@ -265,6 +286,21 @@ function RequestCard({ request, type, colors, onAccept, onDecline, formatDate }:
       )}
     </Card>
   );
+
+  if (type === 'completed') {
+    return (
+      <TouchableOpacity
+        onPress={() => router.push(`/date/summary/${request.id}`)}
+        activeOpacity={0.85}
+        accessibilityRole="button"
+        accessibilityLabel={`View summary of date with ${seeker.name}`}
+      >
+        {cardContent}
+      </TouchableOpacity>
+    );
+  }
+
+  return cardContent;
 }
 
 const styles = StyleSheet.create({
@@ -353,6 +389,17 @@ const styles = StyleSheet.create({
   amountLabel: {
     fontFamily: typography.fonts.body,
     fontSize: typography.sizes.xs,
+  },
+  statusBadge: {
+    paddingHorizontal: spacing.sm,
+    paddingVertical: 2,
+    borderRadius: borderRadius.sm,
+    marginTop: spacing.xs,
+  },
+  statusText: {
+    fontFamily: typography.fonts.bodyMedium,
+    fontSize: typography.sizes.xs,
+    textTransform: 'capitalize',
   },
   messageBox: {
     marginTop: spacing.md,

--- a/app/app/(tabs)/male/bookings.tsx
+++ b/app/app/(tabs)/male/bookings.tsx
@@ -173,16 +173,17 @@ function BookingCard({ booking, type, colors, onCancel, formatDate }: BookingCar
       case 'accepted': return { bg: colors.success + '20', text: colors.success };
       case 'cancelled': return { bg: colors.error + '20', text: colors.error };
       case 'completed': return { bg: colors.primary + '20', text: colors.primary };
+      case 'no_show': return { bg: colors.error + '20', text: colors.error };
       case 'paid': return { bg: colors.success + '20', text: colors.success };
       case 'active': return { bg: colors.accent + '20', text: colors.accent };
       default: return { bg: colors.warning + '20', text: colors.warning };
     }
   };
 
-  const statusStyle = getStatusStyle(booking.status);
+  const statusStyle = getStatusStyle(booking.noShowReason ? 'no_show' : booking.status);
   const canCancel = ['pending', 'accepted', 'confirmed'].includes(booking.status);
 
-  return (
+  const cardContent = (
     <Card style={styles.card}>
       <View style={styles.cardHeader}>
         <UserImage name={companion.name} uri={companion.photo} size={56} showVerified />
@@ -193,13 +194,11 @@ function BookingCard({ booking, type, colors, onCancel, formatDate }: BookingCar
         </View>
         <View style={styles.cardAmount}>
           <Text style={[styles.amountValue, { color: colors.primary }]}>${booking.total}</Text>
-          {type !== 'past' && (
-            <View style={[styles.statusBadge, { backgroundColor: statusStyle.bg }]}>
-              <Text style={[styles.statusText, { color: statusStyle.text }]}>
-                {booking.status}
-              </Text>
-            </View>
-          )}
+          <View style={[styles.statusBadge, { backgroundColor: statusStyle.bg }]}>
+            <Text style={[styles.statusText, { color: statusStyle.text }]}>
+              {booking.noShowReason ? 'no show' : booking.status}
+            </Text>
+          </View>
         </View>
       </View>
 
@@ -312,6 +311,21 @@ function BookingCard({ booking, type, colors, onCancel, formatDate }: BookingCar
       )}
     </Card>
   );
+
+  if (type === 'past') {
+    return (
+      <TouchableOpacity
+        onPress={() => router.push(`/date/summary/${booking.id}`)}
+        activeOpacity={0.85}
+        accessibilityRole="button"
+        accessibilityLabel={`View summary of date with ${companion.name}`}
+      >
+        {cardContent}
+      </TouchableOpacity>
+    );
+  }
+
+  return cardContent;
 }
 
 const styles = StyleSheet.create({

--- a/app/src/services/api.ts
+++ b/app/src/services/api.ts
@@ -359,6 +359,7 @@ export interface Booking {
     rating: number;
   };
   seekerRating?: { average: number; count: number } | null;
+  noShowReason?: string;
   createdAt: string;
 }
 


### PR DESCRIPTION
## Summary
- Add status badge to past seeker bookings (completed/cancelled/no_show)
- Detect no_show via noShowReason field, display 'no show' label
- Add noShowReason to frontend Booking interface in api.ts (was missing)
- Add status badge to companion completed requests
- Change amount label from 'Total' to 'Earned' on completed tab
- Wrap past seeker cards and completed companion cards in TouchableOpacity navigating to /date/summary/:id

## Test plan
- [ ] Seeker Bookings → Past tab: each card shows status badge (completed/cancelled/no show)
- [ ] Seeker past card: tap anywhere on card → navigates to /date/summary/:id
- [ ] Companion Requests → Completed tab: shows status badge and "Earned" label
- [ ] Companion completed card: tap anywhere → navigates to /date/summary/:id
- [ ] No TypeScript errors introduced (only pre-existing companion_id error remains)

🤖 Generated with [Claude Code](https://claude.com/claude-code)