### PR TITLE
feat: isPublicProfile toggle for companion — settings UI + browse filter

### DIFF
--- a/app/app/settings/index.tsx
+++ b/app/app/settings/index.tsx
@@ -1,10 +1,11 @@
-import React from 'react';
+import React, { useState } from 'react';
 import {
   View,
   Text,
   StyleSheet,
   ScrollView,
   TouchableOpacity,
+  Switch,
 } from 'react-native';
 import { router } from 'expo-router';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -13,6 +14,7 @@ import { Card } from '../../src/components/Card';
 import { Button } from '../../src/components/Button';
 import { useAuthStore } from '../../src/store/authStore';
 import { useTheme, spacing, typography, borderRadius } from '../../src/constants/theme';
+import { showAlert } from '../../src/utils/alert';
 
 function SettingsMenuItem({
   icon,
@@ -52,11 +54,23 @@ function SettingsMenuItem({
 export default function SettingsScreen() {
   const insets = useSafeAreaInsets();
   const { colors } = useTheme();
-  const { user, logout } = useAuthStore();
+  const { user, logout, updateProfile } = useAuthStore();
+
+  const [isPublicProfile, setIsPublicProfile] = useState(user?.isPublicProfile ?? true);
 
   const handleLogout = () => {
     logout();
     router.replace('/(auth)/welcome');
+  };
+
+  const togglePublicProfile = async (value: boolean) => {
+    const prev = isPublicProfile;
+    setIsPublicProfile(value);
+    const result = await updateProfile({ isPublicProfile: value });
+    if (!result.success) {
+      setIsPublicProfile(prev);
+      showAlert('Error', result.error || 'Failed to update profile visibility.');
+    }
   };
 
   return (
@@ -129,6 +143,24 @@ export default function SettingsScreen() {
                   onPress={() => router.push('/settings/my-packages')}
                   colors={colors}
                 />
+                <View style={[styles.divider, { backgroundColor: colors.divider }]} />
+                <View style={styles.toggleRow}>
+                  <View style={[styles.menuIconContainer, { backgroundColor: colors.primary + '15' }]}>
+                    <Icon name="eye" size={18} color={colors.primary} />
+                  </View>
+                  <View style={styles.menuTextContainer}>
+                    <Text style={[styles.menuLabel, { color: colors.text }]}>Public Profile</Text>
+                    <Text style={[styles.menuDescription, { color: colors.textSecondary }]}>
+                      {isPublicProfile ? 'Visible in browse & discover' : 'Hidden from browse & discover'}
+                    </Text>
+                  </View>
+                  <Switch
+                    value={isPublicProfile}
+                    onValueChange={togglePublicProfile}
+                    trackColor={{ false: colors.border, true: colors.primary + '60' }}
+                    thumbColor={isPublicProfile ? colors.primary : colors.textSecondary}
+                  />
+                </View>
               </>
             )}
           </Card>
@@ -245,5 +277,11 @@ const styles = StyleSheet.create({
   },
   divider: {
     height: 1,
+  },
+  toggleRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: spacing.sm,
+    minHeight: 56,
   },
 });

--- a/app/src/store/authStore.ts
+++ b/app/src/store/authStore.ts
@@ -33,6 +33,7 @@ interface ProfileUpdateData {
     reminders: boolean;
     payments: boolean;
   };
+  isPublicProfile?: boolean;
 }
 
 interface AuthState {

--- a/app/src/types/index.ts
+++ b/app/src/types/index.ts
@@ -61,6 +61,7 @@ export interface User {
     reminders: boolean;
     payments: boolean;
   };
+  isPublicProfile?: boolean;
   latitude?: number;
   longitude?: number;
   createdAt: string;

--- a/backend/daterabbit-api/src/users/dto/update-user.dto.ts
+++ b/backend/daterabbit-api/src/users/dto/update-user.dto.ts
@@ -78,6 +78,10 @@ export class UpdateUserDto {
   notificationsEnabled?: boolean;
 
   @IsOptional()
+  @IsBoolean()
+  isPublicProfile?: boolean;
+
+  @IsOptional()
   @IsString()
   @MaxLength(200)
   expoPushToken?: string;

--- a/backend/daterabbit-api/src/users/entities/user.entity.ts
+++ b/backend/daterabbit-api/src/users/entities/user.entity.ts
@@ -80,6 +80,9 @@ export class User {
   @Column({ default: false })
   isAdmin: boolean;
 
+  @Column({ default: true })
+  isPublicProfile: boolean;
+
   @Column({ nullable: true })
   stripeAccountId: string;
 

--- a/backend/daterabbit-api/src/users/users.controller.ts
+++ b/backend/daterabbit-api/src/users/users.controller.ts
@@ -34,7 +34,7 @@ export class UsersController {
   @UseGuards(JwtAuthGuard)
   @Put('me')
   async updateProfile(@Request() req, @Body() body: UpdateUserDto) {
-    const { name, age, location, bio, photos, hourlyRate, notificationsEnabled, expoPushToken, notificationPreferences } = body;
+    const { name, age, location, bio, photos, hourlyRate, notificationsEnabled, expoPushToken, notificationPreferences, isPublicProfile } = body;
 
     // Validate hourlyRate if provided
     if (hourlyRate !== undefined && hourlyRate !== null) {
@@ -59,6 +59,7 @@ export class UsersController {
       notificationsEnabled,
       expoPushToken,
       notificationPreferences,
+      isPublicProfile,
     });
     if (!updated) {
       return { error: 'User not found' };

--- a/backend/daterabbit-api/src/users/users.service.ts
+++ b/backend/daterabbit-api/src/users/users.service.ts
@@ -154,7 +154,8 @@ export class UsersService {
     const query = this.usersRepository
       .createQueryBuilder('user')
       .where('user.role = :role', { role: UserRole.COMPANION })
-      .andWhere('user.isActive = true');
+      .andWhere('user.isActive = true')
+      .andWhere('user.isPublicProfile = true');
 
     if (hasLocation) {
       query.addSelect(distanceExpr, 'distance');


### PR DESCRIPTION
## Summary

- Add `isPublicProfile` boolean column to User entity (default: `true` — existing companions remain visible)
- Browse/discover endpoint now filters to `isPublicProfile = true` only
- Companion settings screen has a new "Public Profile" toggle with optimistic UI + rollback
- Direct profile links (`GET /companions/:id`, `GET /users/:id`) remain unaffected — always show profile

## Changes

- `user.entity.ts` — new `@Column({ default: true }) isPublicProfile` field
- `update-user.dto.ts` — add `@IsOptional() @IsBoolean() isPublicProfile`
- `users.controller.ts` — destructure and pass `isPublicProfile` in `PUT /users/me`
- `users.service.ts` — `getCompanions()` now filters `.andWhere('user.isPublicProfile = true')`
- `app/src/types/index.ts` — `isPublicProfile?: boolean` on User interface
- `app/src/store/authStore.ts` — `isPublicProfile?: boolean` in ProfileUpdateData
- `app/app/settings/index.tsx` — companion-only "Public Profile" Switch toggle

## Test plan

- [ ] Toggle off as companion → disappears from browse, reappears on direct profile link
- [ ] Toggle on again → reappears in browse
- [ ] Seeker does not see the toggle
- [ ] TypeScript clean on both projects (verified — no new errors in changed files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)