### PR TITLE
feat: tiered refund policy (100%/50%/0% + cancel-preview + companion-first)

### DIFF
--- a/app/app/(tabs)/male/bookings.tsx
+++ b/app/app/(tabs)/male/bookings.tsx
@@ -10,7 +10,7 @@ import { Icon } from '../../../src/components/Icon';
 import { EmptyState } from '../../../src/components/EmptyState';
 import { useTheme, spacing, typography, borderRadius } from '../../../src/constants/theme';
 import { useBookingsStore } from '../../../src/store/bookingsStore';
-import { Booking } from '../../../src/services/api';
+import { Booking, bookingsApi } from '../../../src/services/api';
 
 type TabType = 'upcoming' | 'pending' | 'past';
 
@@ -38,11 +38,28 @@ export default function BookingsScreen() {
     setRefreshing(false);
   }, [activeTab]);
 
-  const handleCancelBooking = useCallback((booking: Booking) => {
+  const handleCancelBooking = useCallback(async (booking: Booking) => {
     const companionName = booking.companion?.name || 'this companion';
+
+    // Fetch refund preview before showing confirm dialog
+    let refundMessage = '';
+    try {
+      const preview = await bookingsApi.getCancelPreview(booking.id);
+      if (preview.refundPercent === 100) {
+        refundMessage = `\n\nYou will receive a full refund of $${preview.refundAmount.toFixed(2)}.`;
+      } else if (preview.refundPercent === 50) {
+        refundMessage = `\n\nCancelling now gives you a 50% refund of $${preview.refundAmount.toFixed(2)} (48h–24h policy).`;
+      } else {
+        refundMessage = `\n\nNo refund applies — cancellation within 24 hours of the date.`;
+      }
+    } catch {
+      // Preview failed (network or PENDING booking) — show generic message
+      refundMessage = '';
+    }
+
     showConfirm(
       'Cancel Booking',
-      `Are you sure you want to cancel your date with ${companionName}?`,
+      `Are you sure you want to cancel your date with ${companionName}?${refundMessage}`,
       async () => {
         const result = await cancelBooking(booking.id, 'Cancelled by user');
         if (result.success) {

--- a/app/src/services/api.ts
+++ b/app/src/services/api.ts
@@ -341,6 +341,8 @@ export interface Booking {
   location?: string;
   message?: string;
   cancellationReason?: string;
+  cancelledByUserId?: string;
+  refundPercent?: number;
   hourlyRate: number;
   subtotal: number;
   platformFee: number;
@@ -440,6 +442,11 @@ export const bookingsApi = {
 
   getRequests: (status: 'pending' | 'accepted' | 'completed' = 'pending') =>
     apiRequest<{ bookings: Booking[]; total: number }>(`/bookings/requests?status=${status}`),
+
+  getCancelPreview: (id: string) =>
+    apiRequest<{ refundPercent: number; refundAmount: number; totalPrice: number; cancelledByRole: string }>(
+      `/bookings/${id}/cancel-preview`,
+    ),
 
   updateStatus: (id: string, status: 'accepted' | 'declined' | 'cancelled', reason?: string) => {
     if (status === 'accepted') {

--- a/backend/daterabbit-api/src/bookings/bookings.controller.ts
+++ b/backend/daterabbit-api/src/bookings/bookings.controller.ts
@@ -199,6 +199,36 @@ export class BookingsController {
     return this.formatBooking(updated);
   }
 
+  /**
+   * GET /bookings/:id/cancel-preview
+   * Returns the refund amount the seeker would receive if they cancel now.
+   * Used by frontend to display refund info in the cancel confirmation dialog.
+   */
+  @Get(':id/cancel-preview')
+  async getCancelPreview(@Param('id', ParseUUIDPipe) id: string, @Request() req) {
+    const booking = await this.bookingsService.findById(id);
+    if (!booking) {
+      throw new HttpException('Booking not found', HttpStatus.NOT_FOUND);
+    }
+    if (booking.seekerId !== req.user.id && booking.companionId !== req.user.id) {
+      throw new HttpException('Unauthorized', HttpStatus.FORBIDDEN);
+    }
+    if (booking.status === BookingStatus.CANCELLED || booking.status === BookingStatus.COMPLETED) {
+      throw new HttpException('Booking cannot be cancelled', HttpStatus.BAD_REQUEST);
+    }
+
+    const refundPercent = this.paymentsService.calculateRefundPercent(booking, req.user.id);
+    const totalPrice = Number(booking.totalPrice);
+    const refundAmount = Math.round(totalPrice * refundPercent) / 100;
+
+    return {
+      refundPercent,
+      refundAmount,
+      totalPrice,
+      cancelledByRole: req.user.id === booking.companionId ? 'companion' : 'seeker',
+    };
+  }
+
   @Put(':id/cancel')
   async cancelBooking(@Param('id', ParseUUIDPipe) id: string, @Request() req, @Body() body: { reason?: string }) {
     const booking = await this.bookingsService.findById(id);
@@ -214,10 +244,16 @@ export class BookingsController {
     if (booking.status === BookingStatus.COMPLETED) {
       throw new HttpException('Cannot cancel a completed booking', HttpStatus.BAD_REQUEST);
     }
-    const updated = await this.bookingsService.updateStatus(id, BookingStatus.CANCELLED, body.reason);
-    // Release Stripe hold or refund (fire-and-forget, don't fail the cancel if Stripe fails)
-    this.paymentsService.cancelPaymentHold(id).catch(err =>
-      console.error('Stripe cancel error for booking', id, err),
+
+    // Calculate refund percent before marking cancelled
+    const refundPercent = this.paymentsService.calculateRefundPercent(booking, req.user.id);
+
+    // Save cancellation metadata alongside status update
+    const updated = await this.bookingsService.cancelWithRefund(id, req.user.id, refundPercent, body.reason);
+
+    // Apply tiered refund on Stripe (fire-and-forget, don't fail the cancel if Stripe fails)
+    this.paymentsService.tieredRefund(id, refundPercent).catch(err =>
+      console.error('Stripe tiered refund error for booking', id, err),
     );
 
     // UC-051: Notify the other party about cancellation
@@ -446,6 +482,8 @@ export class BookingsController {
       totalPrice: booking.totalPrice,
       status: booking.status,
       cancellationReason: booking.cancellationReason || undefined,
+      cancelledByUserId: booking.cancelledByUserId || undefined,
+      refundPercent: booking.refundPercent !== null && booking.refundPercent !== undefined ? booking.refundPercent : undefined,
       seekerCheckinAt: booking.seekerCheckinAt || undefined,
       companionCheckinAt: booking.companionCheckinAt || undefined,
       activeDateStartedAt: booking.activeDateStartedAt || undefined,

--- a/backend/daterabbit-api/src/bookings/bookings.service.ts
+++ b/backend/daterabbit-api/src/bookings/bookings.service.ts
@@ -234,6 +234,28 @@ export class BookingsService {
     return this.findById(id);
   }
 
+  /**
+   * Cancel a booking and record who cancelled + the refund percent that was applied.
+   * Used by the tiered refund policy flow.
+   */
+  async cancelWithRefund(
+    id: string,
+    cancelledByUserId: string,
+    refundPercent: number,
+    reason?: string,
+  ): Promise<Booking | null> {
+    const update: Partial<Booking> = {
+      status: BookingStatus.CANCELLED,
+      cancelledByUserId,
+      refundPercent,
+    };
+    if (reason) {
+      update.cancellationReason = sanitizeText(reason);
+    }
+    await this.bookingsRepository.update(id, update);
+    return this.findById(id);
+  }
+
   async confirm(id: string): Promise<Booking | null> {
     const booking = await this.updateStatus(id, BookingStatus.CONFIRMED);
     if (!booking) return null;

--- a/backend/daterabbit-api/src/bookings/entities/booking.entity.ts
+++ b/backend/daterabbit-api/src/bookings/entities/booking.entity.ts
@@ -131,6 +131,14 @@ export class Booking {
   @Column({ type: 'boolean', default: false })
   selfieVerified: boolean;
 
+  // Who initiated the cancellation (seekerId or companionId) — used for tiered refund policy
+  @Column({ nullable: true })
+  cancelledByUserId: string;
+
+  // Refund percentage applied at cancellation time (0, 50, or 100)
+  @Column({ type: 'int', nullable: true })
+  refundPercent: number;
+
   @CreateDateColumn()
   createdAt: Date;
 

--- a/backend/daterabbit-api/src/payments/payments.service.ts
+++ b/backend/daterabbit-api/src/payments/payments.service.ts
@@ -170,6 +170,88 @@ export class PaymentsService {
     }
   }
 
+  // --- Tiered refund policy ---
+
+  /**
+   * Calculate refund percentage based on who cancelled and how far in advance.
+   * Rules:
+   *   - Companion-initiated cancel → always 100% refund to seeker
+   *   - 48+ hours before date → 100% refund
+   *   - 24–48 hours before date → 50% refund
+   *   - < 24 hours before date → 0% refund
+   */
+  calculateRefundPercent(booking: Booking, cancelledByUserId: string): number {
+    // Companion-first rule: companion cancels → seeker always gets full refund
+    if (cancelledByUserId === booking.companionId) {
+      return 100;
+    }
+
+    const now = new Date();
+    const dateTime = new Date(booking.dateTime);
+    const hoursUntilDate = (dateTime.getTime() - now.getTime()) / (1000 * 60 * 60);
+
+    if (hoursUntilDate >= 48) return 100;
+    if (hoursUntilDate >= 24) return 50;
+    return 0;
+  }
+
+  /**
+   * Execute tiered refund on Stripe based on refundPercent.
+   * - 100%: cancel hold (if requires_capture) or full refund (if succeeded)
+   * - 50%: capture first then partial refund (half amount)
+   * - 0%: capture full amount (companion gets paid in full)
+   * - No paymentIntentId (PENDING bookings): skip Stripe, no-op
+   */
+  async tieredRefund(bookingId: string, refundPercent: number): Promise<void> {
+    const booking = await this.bookingsRepo.findOne({ where: { id: bookingId } });
+    if (!booking?.paymentIntentId) return; // PENDING booking — no payment yet, nothing to do
+
+    if (!this.stripe) return; // Stripe not configured
+
+    try {
+      const pi = await this.stripe.paymentIntents.retrieve(booking.paymentIntentId);
+      const totalAmountCents = Math.round(Number(booking.totalPrice) * 100);
+
+      if (refundPercent === 100) {
+        if (pi.status === 'requires_capture') {
+          // Cancel the hold — no charge at all
+          await this.stripe.paymentIntents.cancel(booking.paymentIntentId);
+        } else if (pi.status === 'succeeded') {
+          // Already captured — full refund
+          await this.stripe.refunds.create({ payment_intent: booking.paymentIntentId });
+        }
+      } else if (refundPercent === 50) {
+        // 50% refund: seeker gets half back, companion keeps half
+        const refundAmountCents = Math.round(totalAmountCents * 0.5);
+        if (pi.status === 'requires_capture') {
+          // Must capture first, then refund 50%
+          await this.stripe.paymentIntents.capture(booking.paymentIntentId);
+          if (refundAmountCents >= 50) {
+            await this.stripe.refunds.create({
+              payment_intent: booking.paymentIntentId,
+              amount: refundAmountCents,
+            });
+          }
+        } else if (pi.status === 'succeeded') {
+          if (refundAmountCents >= 50) {
+            await this.stripe.refunds.create({
+              payment_intent: booking.paymentIntentId,
+              amount: refundAmountCents,
+            });
+          }
+        }
+      } else {
+        // 0% refund: companion gets full payment — capture the hold
+        if (pi.status === 'requires_capture') {
+          await this.stripe.paymentIntents.capture(booking.paymentIntentId);
+        }
+        // If already succeeded, nothing to do
+      }
+    } catch (err: any) {
+      console.error(`[TIERED_REFUND] Stripe error for booking ${bookingId}:`, err.message);
+    }
+  }
+
   // --- Partial refund for end-early ---
 
   async partialRefundForEndEarly(bookingId: string, actualHours: number): Promise<void> {


### PR DESCRIPTION
## Summary
- Companion-initiated cancel always gives seeker 100% refund (companion-first rule)
- Seeker-initiated cancel: 48h+ before date = 100%, 24-48h = 50%, <24h = 0%
- New `GET /bookings/:id/cancel-preview` endpoint returns refund info before confirming
- Frontend cancel dialog fetches and shows refund amount to user before they confirm
- 50% Stripe tier: captures payment first, then issues partial refund (handles `requires_capture`)
- PENDING bookings (no paymentIntentId): refund % calculated for display, Stripe call skipped

## Files changed
- `booking.entity.ts` — added `cancelledByUserId`, `refundPercent` columns
- `payments.service.ts` — `calculateRefundPercent()`, `tieredRefund()`
- `bookings.service.ts` — `cancelWithRefund()`
- `bookings.controller.ts` — cancel-preview endpoint, updated cancel handler
- `app/src/services/api.ts` — `getCancelPreview()`, updated Booking interface
- `app/app/(tabs)/male/bookings.tsx` — cancel dialog shows refund info

## Test plan
- [ ] Create and confirm a booking 49h in future → cancel → verify 100% refund
- [ ] Create and confirm a booking 36h in future → cancel → verify 50% refund
- [ ] Create and confirm a booking 12h in future → cancel → verify 0% refund
- [ ] Companion cancels → verify always 100% refund regardless of timing
- [ ] PENDING booking cancel (no paymentIntentId) → no Stripe error
- [ ] Cancel preview dialog shows correct amount before confirmation