### PR TITLE
feat: Stripe Identity for Seeker #2038

### DIFF
--- a/app/app/(seeker-verify)/_layout.tsx
+++ b/app/app/(seeker-verify)/_layout.tsx
@@ -12,10 +12,6 @@ export default function SeekerVerifyLayout() {
       }}
     >
       <Stack.Screen name="intro" />
-      <Stack.Screen name="ssn" />
-      <Stack.Screen name="photo-id" />
-      <Stack.Screen name="selfie" />
-      <Stack.Screen name="consent" />
       <Stack.Screen name="pending" />
       <Stack.Screen name="approved" />
     </Stack>

--- a/app/app/(seeker-verify)/consent.tsx
+++ b/app/app/(seeker-verify)/consent.tsx
@@ -14,7 +14,7 @@ import { ConsentForm } from '../../src/components/verification/ConsentForm';
 import { useVerificationStore } from '../../src/store/verificationStore';
 import { colors, spacing, typography, PAGE_PADDING } from '../../src/constants/theme';
 
-const STEPS = ['Intro', 'SSN', 'Photo ID', 'Selfie', 'Consent'];
+const STEPS = ['Intro', 'Pending', 'Done'];
 
 export default function SeekerConsentScreen() {
   const insets = useSafeAreaInsets();
@@ -46,7 +46,7 @@ export default function SeekerConsentScreen() {
         ]}
         showsVerticalScrollIndicator={false}
       >
-        <ProgressBar currentStep={4} totalSteps={5} labels={STEPS} />
+        <ProgressBar currentStep={2} totalSteps={3} labels={STEPS} />
 
         <View style={styles.header}>
           <Text style={styles.title}>Background Check Consent</Text>

--- a/app/app/(seeker-verify)/intro.tsx
+++ b/app/app/(seeker-verify)/intro.tsx
@@ -7,49 +7,74 @@ import {
   Platform,
 } from 'react-native';
 import { router } from 'expo-router';
+import * as WebBrowser from 'expo-web-browser';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { showAlert } from '../../src/utils/alert';
 import { Button } from '../../src/components/Button';
 import { Icon } from '../../src/components/Icon';
-import { ProgressBar } from '../../src/components/verification/ProgressBar';
 import { useVerificationStore } from '../../src/store/verificationStore';
 import { colors, spacing, typography, borderRadius, PAGE_PADDING } from '../../src/constants/theme';
 
-const STEPS = ['Intro', 'SSN', 'Photo ID', 'Selfie', 'Consent'];
-
-const REQUIREMENTS = [
-  {
-    icon: 'shield' as const,
-    title: 'Last 4 of SSN',
-    description: 'Used only for identity verification',
-  },
-  {
-    icon: 'credit-card' as const,
-    title: 'Government-Issued ID',
-    description: 'Driver\'s license, passport, or state ID',
-  },
-  {
-    icon: 'camera' as const,
-    title: 'Selfie Photo',
-    description: 'We\'ll match it with your ID photo',
-  },
-  {
-    icon: 'check-circle' as const,
-    title: 'Consent',
-    description: 'Authorize the background check',
-  },
-];
+type ScreenState = 'intro' | 'loading' | 'pending' | 'success' | 'failed';
 
 export default function SeekerVerifyIntroScreen() {
   const insets = useSafeAreaInsets();
-  const { startVerification, isLoading } = useVerificationStore();
-  const [starting, setStarting] = useState(false);
+  const { startIdentitySession, checkIdentityStatus, isLoading } = useVerificationStore();
+  const [screenState, setScreenState] = useState<ScreenState>('intro');
+  const [submitting, setSubmitting] = useState(false);
 
-  const handleGetStarted = async () => {
-    setStarting(true);
-    await startVerification();
-    setStarting(false);
-    // Navigate even if API fails — screens handle errors individually
-    router.push('/(seeker-verify)/ssn');
+  const handleStartVerification = async () => {
+    setSubmitting(true);
+    setScreenState('loading');
+
+    const session = await startIdentitySession();
+    if (!session) {
+      setSubmitting(false);
+      setScreenState('intro');
+      showAlert('Error', 'Could not start identity verification. Please try again.');
+      return;
+    }
+
+    // Open Stripe Identity hosted page via WebBrowser (same pattern as companion verify.tsx)
+    if (Platform.OS === 'web') {
+      // On web: open in same tab since deep links are not available
+      window.location.href = session.url;
+      return;
+    }
+
+    await WebBrowser.openAuthSessionAsync(session.url, 'daterabbit://');
+
+    // After returning from the browser, check the status
+    setSubmitting(false);
+    await handleCheckStatus();
+  };
+
+  const handleCheckStatus = async () => {
+    setSubmitting(true);
+    const result = await checkIdentityStatus();
+    setSubmitting(false);
+
+    if (!result) {
+      showAlert('Error', 'Could not check verification status. Please try again.');
+      return;
+    }
+
+    if (result.status === 'verified') {
+      setScreenState('success');
+    } else if (result.status === 'processing' || result.verificationStatus === 'pending_review') {
+      setScreenState('pending');
+    } else {
+      // requires_input or canceled — let user retry
+      setScreenState('failed');
+    }
+  };
+
+  const handleContinuePending = () => {
+    router.push('/(seeker-verify)/pending');
+  };
+
+  const handleContinueApproved = () => {
+    router.push('/(seeker-verify)/approved');
   };
 
   return (
@@ -62,51 +87,132 @@ export default function SeekerVerifyIntroScreen() {
         ]}
         showsVerticalScrollIndicator={false}
       >
-        <ProgressBar currentStep={0} totalSteps={5} labels={STEPS} />
-
-        <View style={styles.heroContainer}>
-          <View style={styles.heroIconContainer}>
-            <Icon name="shield" size={48} color={colors.primary} />
-          </View>
-        </View>
-
-        <View style={styles.header}>
-          <Text style={styles.title}>Verify Your Identity</Text>
-          <Text style={styles.subtitle}>Help keep our community safe</Text>
-        </View>
-
-        <View style={styles.requirementsList}>
-          {REQUIREMENTS.map((item, index) => (
-            <View key={index} style={styles.requirementItem}>
-              <View style={styles.requirementIcon}>
-                <Icon name={item.icon} size={22} color={colors.primary} />
-              </View>
-              <View style={styles.requirementText}>
-                <Text style={styles.requirementTitle}>{item.title}</Text>
-                <Text style={styles.requirementDescription}>{item.description}</Text>
+        {/* Intro / Loading state */}
+        {(screenState === 'intro' || screenState === 'loading') && (
+          <>
+            <View style={styles.heroContainer}>
+              <View style={styles.heroIconContainer}>
+                <Icon name="shield" size={48} color={colors.primary} />
               </View>
             </View>
-          ))}
-        </View>
 
-        <View style={styles.timeBadge}>
-          <Icon name="clock" size={16} color={colors.accent} />
-          <Text style={styles.timeBadgeText}>Takes about 2 minutes</Text>
-        </View>
+            <View style={styles.header}>
+              <Text style={styles.title}>Identity Verification</Text>
+              <Text style={styles.subtitle}>
+                We need to verify your identity to keep the platform safe
+              </Text>
+            </View>
 
-        <Text style={styles.privacyNote}>
-          All data is encrypted and used only for verification purposes.
-        </Text>
+            <View style={styles.infoCard}>
+              <Text style={styles.infoTitle}>How it works</Text>
+              {[
+                'Take a photo of your government-issued ID',
+                'Take a quick selfie to match your ID',
+                'Stripe securely verifies your identity',
+              ].map((step, i) => (
+                <View key={i} style={styles.stepRow}>
+                  <View style={styles.stepBadge}>
+                    <Text style={styles.stepBadgeText}>{i + 1}</Text>
+                  </View>
+                  <Text style={styles.stepText}>{step}</Text>
+                </View>
+              ))}
+            </View>
 
-        <Button
-          title="Get Started"
-          onPress={handleGetStarted}
-          loading={starting || isLoading}
-          variant="pink"
-          fullWidth
-          size="lg"
-          testID="seeker-verify-get-started-btn"
-        />
+            <View style={styles.timeBadge}>
+              <Icon name="clock" size={16} color={colors.accent} />
+              <Text style={styles.timeBadgeText}>Takes about 2 minutes</Text>
+            </View>
+
+            <Text style={styles.privacyNote}>
+              Your information is securely handled by Stripe, a PCI-certified verification provider. DateRabbit does not store your ID photos.
+            </Text>
+
+            <Button
+              title={submitting ? 'Opening verification...' : 'Start Identity Verification'}
+              onPress={handleStartVerification}
+              loading={submitting || isLoading}
+              disabled={submitting || isLoading}
+              variant="pink"
+              fullWidth
+              size="lg"
+              testID="seeker-verify-start-btn"
+            />
+          </>
+        )}
+
+        {/* Pending state */}
+        {screenState === 'pending' && (
+          <>
+            <View style={styles.statusCard}>
+              <Text style={styles.statusIcon}>...</Text>
+              <Text style={styles.statusTitle}>Verification in Review</Text>
+              <Text style={styles.statusBody}>
+                Your identity is being reviewed by Stripe. This usually takes a few minutes.
+              </Text>
+            </View>
+            <Button
+              title="Check Status"
+              onPress={handleContinuePending}
+              variant="pink"
+              fullWidth
+              size="lg"
+              testID="seeker-verify-check-status-btn"
+            />
+            <Button
+              title="Check Again"
+              onPress={handleCheckStatus}
+              loading={submitting}
+              variant="outline"
+              fullWidth
+              size="lg"
+              style={styles.secondaryBtn}
+            />
+          </>
+        )}
+
+        {/* Success state */}
+        {screenState === 'success' && (
+          <>
+            <View style={styles.statusCard}>
+              <Text style={styles.statusIcon}>OK</Text>
+              <Text style={styles.statusTitle}>Identity Verified</Text>
+              <Text style={styles.statusBody}>
+                Your identity has been successfully verified.
+              </Text>
+            </View>
+            <Button
+              title="Continue"
+              onPress={handleContinueApproved}
+              variant="pink"
+              fullWidth
+              size="lg"
+              testID="seeker-verify-continue-btn"
+            />
+          </>
+        )}
+
+        {/* Failed / retry state */}
+        {screenState === 'failed' && (
+          <>
+            <View style={[styles.statusCard, styles.statusCardError]}>
+              <Text style={styles.statusIcon}>!</Text>
+              <Text style={styles.statusTitle}>Verification Incomplete</Text>
+              <Text style={styles.statusBody}>
+                The verification session did not complete. Please try again or contact support if the issue persists.
+              </Text>
+            </View>
+            <Button
+              title="Try Again"
+              onPress={handleStartVerification}
+              loading={submitting}
+              variant="pink"
+              fullWidth
+              size="lg"
+              testID="seeker-verify-retry-btn"
+            />
+          </>
+        )}
       </ScrollView>
     </View>
   );
@@ -157,43 +263,42 @@ const styles = StyleSheet.create({
     textAlign: 'center',
     lineHeight: 24,
   },
-  requirementsList: {
-    marginBottom: spacing.xl,
+  infoCard: {
+    backgroundColor: colors.surface,
+    borderRadius: borderRadius.xl,
+    padding: spacing.lg,
+    marginBottom: spacing.md,
     gap: spacing.md,
   },
-  requirementItem: {
+  infoTitle: {
+    fontFamily: typography.fonts.bodySemiBold,
+    fontSize: typography.sizes.lg,
+    color: colors.text,
+    marginBottom: spacing.xs,
+  },
+  stepRow: {
     flexDirection: 'row',
     alignItems: 'center',
-    gap: spacing.md,
-    backgroundColor: colors.surface,
-    borderRadius: borderRadius.lg,
-    padding: spacing.md,
+    gap: spacing.sm,
   },
-  requirementIcon: {
-    width: 44,
-    height: 44,
-    borderRadius: borderRadius.md,
-    backgroundColor: colors.secondary,
-    borderWidth: 2,
-    borderColor: colors.black,
+  stepBadge: {
+    width: 28,
+    height: 28,
+    borderRadius: borderRadius.full,
+    backgroundColor: colors.primary,
     alignItems: 'center',
     justifyContent: 'center',
-    flexShrink: 0,
   },
-  requirementText: {
-    flex: 1,
+  stepBadgeText: {
+    fontFamily: typography.fonts.bodySemiBold,
+    fontSize: typography.sizes.sm,
+    color: colors.white,
   },
-  requirementTitle: {
-    fontFamily: typography.fonts.bodyMedium,
+  stepText: {
+    fontFamily: typography.fonts.body,
     fontSize: typography.sizes.md,
     color: colors.text,
-    marginBottom: 2,
-  },
-  requirementDescription: {
-    fontFamily: typography.fonts.body,
-    fontSize: typography.sizes.sm,
-    color: colors.textMuted,
-    lineHeight: 20,
+    flex: 1,
   },
   timeBadge: {
     flexDirection: 'row',
@@ -222,5 +327,39 @@ const styles = StyleSheet.create({
     lineHeight: 18,
     marginBottom: spacing.xl,
     paddingHorizontal: spacing.md,
+  },
+  statusCard: {
+    backgroundColor: colors.surface,
+    borderRadius: borderRadius.xl,
+    padding: spacing.xl,
+    marginBottom: spacing.xl,
+    alignItems: 'center',
+    gap: spacing.sm,
+  },
+  statusCardError: {
+    borderWidth: 2,
+    borderColor: colors.error,
+  },
+  statusIcon: {
+    fontFamily: typography.fonts.heading,
+    fontSize: 40,
+    color: colors.primary,
+    marginBottom: spacing.sm,
+  },
+  statusTitle: {
+    fontFamily: typography.fonts.heading,
+    fontSize: typography.sizes.xl,
+    color: colors.text,
+    textAlign: 'center',
+  },
+  statusBody: {
+    fontFamily: typography.fonts.body,
+    fontSize: typography.sizes.md,
+    color: colors.textMuted,
+    textAlign: 'center',
+    lineHeight: 24,
+  },
+  secondaryBtn: {
+    marginTop: spacing.sm,
   },
 });


### PR DESCRIPTION
## Summary

- Replaces old SSN/photo-id/selfie manual flow with Stripe Identity hosted verification
- Same pattern as companion verify.tsx (implemented in #2034)
- `intro.tsx`: full rewrite — launches Stripe Identity via `WebBrowser.openAuthSessionAsync`, handles `intro/loading/pending/success/failed` states inline
- `_layout.tsx`: removed `ssn`, `photo-id`, `selfie`, `consent` Stack.Screen entries (kept `intro`, `pending`, `approved`)
- `consent.tsx`: updated STEPS array to 3-step flow (Intro/Pending/Done), fixed ProgressBar step counts

## Backend

No backend changes needed. `POST /api/verification/session` and `GET /api/verification/status` are already role-agnostic (added in #2034).

## Test plan

- [ ] Open app in browser → navigate to `(seeker-verify)/intro` → should show "Start Identity Verification" button (not SSN form)
- [ ] Tap button → opens Stripe Identity hosted page via WebBrowser
- [ ] After returning → status checked automatically via `checkIdentityStatus()`
- [ ] Verified → navigates to `approved` screen
- [ ] Processing/pending → navigates to `pending` screen
- [ ] Failed/canceled → shows retry UI inline

🤖 Generated with [Claude Code](https://claude.com/claude-code)