### PR TITLE
feat(notifications): Expo push + email triggers for 5 event types (#2044)

### DIFF
--- a/app/app/_layout.tsx
+++ b/app/app/_layout.tsx
@@ -16,6 +16,8 @@ import { colors } from '../src/constants/theme';
 import { StripeProvider } from '../src/components/StripeProvider';
 import { OfflineBanner } from '../src/components/OfflineBanner';
 import { useNetworkStore } from '../src/store/networkStore';
+// expo-notifications is native-only — all usage is wrapped in Platform.OS !== 'web' guards
+import * as Notifications from 'expo-notifications';
 
 // Listen to browser online/offline events (web only)
 function useWebNetworkStatus() {
@@ -66,6 +68,51 @@ function useHeartbeat() {
       return () => subscription.remove();
     }
   }, [sendHeartbeat]);
+}
+
+// Register for Expo push notifications (native only)
+// Requests permission, retrieves ExponentPushToken, saves to backend
+function usePushNotifications() {
+  const { isAuthenticated } = useAuthStore();
+
+  useEffect(() => {
+    // Push notifications are not supported on web
+    if (Platform.OS === 'web') return;
+    if (!isAuthenticated) return;
+
+    async function register() {
+      try {
+        const { status: existingStatus } = await Notifications.getPermissionsAsync();
+        let finalStatus = existingStatus;
+        if (existingStatus !== 'granted') {
+          const { status } = await Notifications.requestPermissionsAsync();
+          finalStatus = status;
+        }
+        if (finalStatus !== 'granted') return;
+
+        const tokenData = await Notifications.getExpoPushTokenAsync();
+        const token = tokenData.data;
+        if (token?.startsWith('ExponentPushToken[')) {
+          await usersApi.updatePushToken(token);
+        }
+      } catch {
+        // Push registration is best-effort — never crash the app
+      }
+    }
+
+    register();
+
+    // Show notifications when app is in foreground
+    Notifications.setNotificationHandler({
+      handleNotification: async () => ({
+        shouldShowAlert: true,
+        shouldPlaySound: true,
+        shouldSetBadge: false,
+        shouldShowBanner: true,
+        shouldShowList: true,
+      }),
+    });
+  }, [isAuthenticated]);
 }
 
 // Strip __EXPO_ROUTER_key from browser URL bar (Expo Router internal param)
@@ -213,6 +260,8 @@ export default function RootLayout() {
   useWebNetworkStatus();
   // Send heartbeat to update online status
   useHeartbeat();
+  // Register for push notifications (native only)
+  usePushNotifications();
 
   // Load Neo-Brutalism font
   const [fontsLoaded] = useFonts({

--- a/app/src/services/api.ts
+++ b/app/src/services/api.ts
@@ -150,6 +150,12 @@ export const usersApi = {
   getMe: () =>
     apiRequest<User>('/users/me'),
 
+  updatePushToken: (expoPushToken: string) =>
+    apiRequest<{ success: boolean }>('/users/me/push-token', {
+      method: 'PATCH',
+      body: { expoPushToken },
+    }),
+
   updateProfile: (data: Partial<User>) =>
     apiRequest<User>('/users/me', {
       method: 'PUT',

--- a/backend/daterabbit-api/src/bookings/bookings.controller.ts
+++ b/backend/daterabbit-api/src/bookings/bookings.controller.ts
@@ -3,6 +3,7 @@ import { FileInterceptor } from '@nestjs/platform-express';
 import { BookingsService } from './bookings.service';
 import { PaymentsService } from '../payments/payments.service';
 import { UploadsService } from '../uploads/uploads.service';
+import { EmailService } from '../email/email.service';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { BookingStatus, ActivityType } from './entities/booking.entity';
 import { NotificationsService } from '../notifications/notifications.service';
@@ -16,6 +17,7 @@ export class BookingsController {
     private bookingsService: BookingsService,
     private paymentsService: PaymentsService,
     private notificationsService: NotificationsService,
+    private emailService: EmailService,
     private uploadsService: UploadsService,
     @Inject(forwardRef(() => ReviewsService))
     private reviewsService: ReviewsService,
@@ -76,6 +78,29 @@ export class BookingsController {
       notes: body.notes,
       packageId: body.packageId,
     });
+
+    // UC-120: Notify companion of new booking request (push + email, fire-and-forget)
+    if (booking.companion) {
+      this.notificationsService.create({
+        userId: body.companionId,
+        type: NotificationType.BOOKING_REQUEST,
+        title: 'New Booking Request',
+        body: `${booking.seeker?.name || 'Someone'} wants to book a date with you.`,
+        data: { bookingId: booking.id, seekerId: req.user.id },
+      }).catch(() => {/* swallow */});
+
+      if (booking.companion.email) {
+        this.emailService.sendNewBookingRequest({
+          companionEmail: booking.companion.email,
+          companionName: booking.companion.name || 'there',
+          seekerName: booking.seeker?.name || 'A guest',
+          dateTime,
+          duration: body.duration,
+          activity: body.activity,
+          location: body.location,
+        }).catch(() => {/* swallow */});
+      }
+    }
 
     return booking;
   }
@@ -256,10 +281,10 @@ export class BookingsController {
       console.error('Stripe tiered refund error for booking', id, err),
     );
 
-    // UC-051: Notify the other party about cancellation
+    // UC-051: Notify the other party about cancellation (push + email)
     const isCompanionCancelling = booking.companionId === req.user.id;
     if (isCompanionCancelling) {
-      // Companion declined -> notify seeker
+      // Companion declined -> notify seeker via push
       await this.notificationsService.create({
         userId: booking.seekerId,
         type: NotificationType.BOOKING_DECLINED,
@@ -272,8 +297,19 @@ export class BookingsController {
           reason: body.reason,
         },
       });
+      // Email to seeker (fire-and-forget)
+      if (booking.seeker?.email) {
+        this.emailService.sendBookingDeclinedToSeeker({
+          seekerEmail: booking.seeker.email,
+          seekerName: booking.seeker.name || 'there',
+          companionName: booking.companion?.name || 'The companion',
+          dateTime: booking.dateTime,
+          activity: booking.activity,
+          reason: body.reason,
+        }).catch(() => {/* swallow */});
+      }
     } else {
-      // Seeker cancelled -> notify companion
+      // Seeker cancelled -> notify companion via push
       await this.notificationsService.create({
         userId: booking.companionId,
         type: NotificationType.BOOKING_CANCELLED,
@@ -286,6 +322,17 @@ export class BookingsController {
           reason: body.reason,
         },
       });
+      // Email to companion (fire-and-forget)
+      if (booking.companion?.email) {
+        this.emailService.sendBookingCancelledToCompanion({
+          companionEmail: booking.companion.email,
+          companionName: booking.companion.name || 'there',
+          seekerName: booking.seeker?.name || 'The seeker',
+          dateTime: booking.dateTime,
+          activity: booking.activity,
+          reason: body.reason,
+        }).catch(() => {/* swallow */});
+      }
     }
 
     return this.formatBooking(updated);

--- a/backend/daterabbit-api/src/bookings/bookings.service.ts
+++ b/backend/daterabbit-api/src/bookings/bookings.service.ts
@@ -260,7 +260,6 @@ export class BookingsService {
     const booking = await this.updateStatus(id, BookingStatus.CONFIRMED);
     if (!booking) return null;
 
-    // Send confirmation emails to both parties (fire-and-forget)
     const emailData = {
       dateTime: booking.dateTime,
       duration: booking.duration,
@@ -269,6 +268,27 @@ export class BookingsService {
       totalPrice: booking.totalPrice,
     };
 
+    // UC-121: In-app push notifications for booking confirmed (fire-and-forget)
+    if (booking.seekerId) {
+      this.notificationsService.create({
+        userId: booking.seekerId,
+        type: NotificationType.BOOKING_CONFIRMED,
+        title: 'Booking Confirmed!',
+        body: `${booking.companion?.name || 'Your companion'} confirmed your date request.`,
+        data: { bookingId: booking.id },
+      }).catch(() => {/* swallow */});
+    }
+    if (booking.companionId) {
+      this.notificationsService.create({
+        userId: booking.companionId,
+        type: NotificationType.BOOKING_CONFIRMED,
+        title: 'Booking Confirmed',
+        body: `You confirmed the booking with ${booking.seeker?.name || 'your guest'}.`,
+        data: { bookingId: booking.id },
+      }).catch(() => {/* swallow */});
+    }
+
+    // Send confirmation emails to both parties (fire-and-forget)
     if (booking.seeker?.email) {
       this.emailService
         .sendBookingConfirmedToSeeker({

--- a/backend/daterabbit-api/src/email/email.service.ts
+++ b/backend/daterabbit-api/src/email/email.service.ts
@@ -138,6 +138,112 @@ export class EmailService {
     });
   }
 
+  // ─── Transactional email methods ────────────────────────────────────────────
+
+  async sendNewBookingRequest(data: {
+    companionEmail: string;
+    companionName: string;
+    seekerName: string;
+    dateTime: Date;
+    duration: number;
+    activity: string;
+    location?: string;
+  }): Promise<boolean> {
+    const dateStr = data.dateTime.toLocaleDateString('en-US', {
+      weekday: 'long', year: 'numeric', month: 'long', day: 'numeric',
+    });
+    const timeStr = data.dateTime.toLocaleTimeString('en-US', {
+      hour: '2-digit', minute: '2-digit',
+    });
+    const activityFormatted = data.activity.charAt(0).toUpperCase() + data.activity.slice(1).toLowerCase();
+    const locationRow = data.location
+      ? `<tr><td style="padding:6px 0;font-size:14px;color:#555;">Location</td><td style="padding:6px 0;font-size:14px;color:#000;font-weight:600;">${data.location}</td></tr>`
+      : '';
+    return this.sendEmail({
+      to: data.companionEmail,
+      subject: `New Booking Request from ${data.seekerName}`,
+      htmlContent: `<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8"/><meta name="viewport" content="width=device-width,initial-scale=1.0"/><title>New Booking Request</title></head><body style="margin:0;padding:0;background:#F4F0EA;font-family:Arial,sans-serif;"><table width="100%" cellpadding="0" cellspacing="0" style="background:#F4F0EA;padding:40px 20px;"><tr><td align="center"><table width="480" cellpadding="0" cellspacing="0" style="background:#F4F0EA;border:3px solid #000;border-radius:12px;padding:32px;"><tr><td><p style="margin:0 0 4px 0;font-size:11px;font-weight:700;letter-spacing:3px;text-transform:uppercase;color:#FF2A5F;">DateRabbit</p><h1 style="margin:0 0 8px 0;font-size:24px;font-weight:700;color:#000;">New Booking Request!</h1><p style="margin:0 0 24px 0;font-size:15px;color:#333;">Hi ${data.companionName}, <strong>${data.seekerName}</strong> wants to book a date with you.</p><div style="background:#fff;border:3px solid #000;border-radius:8px;padding:20px;margin:0 0 24px 0;"><table width="100%" cellpadding="0" cellspacing="0"><tr><td colspan="2" style="padding:0 0 12px 0;font-size:12px;font-weight:700;letter-spacing:2px;text-transform:uppercase;color:#FF2A5F;border-bottom:2px solid #000;">Request Details</td></tr><tr><td style="padding:6px 0;font-size:14px;color:#555;">Guest</td><td style="padding:6px 0;font-size:14px;color:#000;font-weight:600;">${data.seekerName}</td></tr><tr><td style="padding:6px 0;font-size:14px;color:#555;">Date</td><td style="padding:6px 0;font-size:14px;color:#000;font-weight:600;">${dateStr}</td></tr><tr><td style="padding:6px 0;font-size:14px;color:#555;">Time</td><td style="padding:6px 0;font-size:14px;color:#000;font-weight:600;">${timeStr}</td></tr><tr><td style="padding:6px 0;font-size:14px;color:#555;">Duration</td><td style="padding:6px 0;font-size:14px;color:#000;font-weight:600;">${data.duration} hour${data.duration !== 1 ? 's' : ''}</td></tr><tr><td style="padding:6px 0;font-size:14px;color:#555;">Activity</td><td style="padding:6px 0;font-size:14px;color:#000;font-weight:600;">${activityFormatted}</td></tr>${locationRow}</table></div><p style="margin:0;font-size:13px;color:#666;">Open the DateRabbit app to accept or decline this request.</p></td></tr></table></td></tr></table></body></html>`,
+    });
+  }
+
+  async sendBookingCancelledToCompanion(data: {
+    companionEmail: string;
+    companionName: string;
+    seekerName: string;
+    dateTime: Date;
+    activity: string;
+    reason?: string;
+  }): Promise<boolean> {
+    const dateStr = data.dateTime.toLocaleDateString('en-US', {
+      weekday: 'long', year: 'numeric', month: 'long', day: 'numeric',
+    });
+    const reasonRow = data.reason
+      ? `<tr><td style="padding:6px 0;font-size:14px;color:#555;">Reason</td><td style="padding:6px 0;font-size:14px;color:#000;font-weight:600;">${data.reason}</td></tr>`
+      : '';
+    return this.sendEmail({
+      to: data.companionEmail,
+      subject: `Booking Cancelled by ${data.seekerName}`,
+      htmlContent: `<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8"/><title>Booking Cancelled</title></head><body style="margin:0;padding:0;background:#F4F0EA;font-family:Arial,sans-serif;"><table width="100%" cellpadding="0" cellspacing="0" style="background:#F4F0EA;padding:40px 20px;"><tr><td align="center"><table width="480" cellpadding="0" cellspacing="0" style="background:#F4F0EA;border:3px solid #000;border-radius:12px;padding:32px;"><tr><td><p style="margin:0 0 4px 0;font-size:11px;font-weight:700;letter-spacing:3px;text-transform:uppercase;color:#FF2A5F;">DateRabbit</p><h1 style="margin:0 0 8px 0;font-size:24px;font-weight:700;color:#000;">Booking Cancelled</h1><p style="margin:0 0 24px 0;font-size:15px;color:#333;">Hi ${data.companionName}, <strong>${data.seekerName}</strong> has cancelled your booking on ${dateStr}.</p><div style="background:#fff;border:3px solid #000;border-radius:8px;padding:20px;margin:0 0 24px 0;"><table width="100%" cellpadding="0" cellspacing="0"><tr><td style="padding:6px 0;font-size:14px;color:#555;">Guest</td><td style="padding:6px 0;font-size:14px;color:#000;font-weight:600;">${data.seekerName}</td></tr><tr><td style="padding:6px 0;font-size:14px;color:#555;">Date</td><td style="padding:6px 0;font-size:14px;color:#000;font-weight:600;">${dateStr}</td></tr>${reasonRow}</table></div><p style="margin:0;font-size:13px;color:#666;">Your time slot is now available again.</p></td></tr></table></td></tr></table></body></html>`,
+    });
+  }
+
+  async sendBookingDeclinedToSeeker(data: {
+    seekerEmail: string;
+    seekerName: string;
+    companionName: string;
+    dateTime: Date;
+    activity: string;
+    reason?: string;
+  }): Promise<boolean> {
+    const dateStr = data.dateTime.toLocaleDateString('en-US', {
+      weekday: 'long', year: 'numeric', month: 'long', day: 'numeric',
+    });
+    const reasonRow = data.reason
+      ? `<tr><td style="padding:6px 0;font-size:14px;color:#555;">Reason</td><td style="padding:6px 0;font-size:14px;color:#000;font-weight:600;">${data.reason}</td></tr>`
+      : '';
+    return this.sendEmail({
+      to: data.seekerEmail,
+      subject: `Booking Declined by ${data.companionName}`,
+      htmlContent: `<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8"/><title>Booking Declined</title></head><body style="margin:0;padding:0;background:#F4F0EA;font-family:Arial,sans-serif;"><table width="100%" cellpadding="0" cellspacing="0" style="background:#F4F0EA;padding:40px 20px;"><tr><td align="center"><table width="480" cellpadding="0" cellspacing="0" style="background:#F4F0EA;border:3px solid #000;border-radius:12px;padding:32px;"><tr><td><p style="margin:0 0 4px 0;font-size:11px;font-weight:700;letter-spacing:3px;text-transform:uppercase;color:#FF2A5F;">DateRabbit</p><h1 style="margin:0 0 8px 0;font-size:24px;font-weight:700;color:#000;">Booking Declined</h1><p style="margin:0 0 24px 0;font-size:15px;color:#333;">Hi ${data.seekerName}, unfortunately <strong>${data.companionName}</strong> has declined your booking request for ${dateStr}.</p><div style="background:#fff;border:3px solid #000;border-radius:8px;padding:20px;margin:0 0 24px 0;"><table width="100%" cellpadding="0" cellspacing="0"><tr><td style="padding:6px 0;font-size:14px;color:#555;">Companion</td><td style="padding:6px 0;font-size:14px;color:#000;font-weight:600;">${data.companionName}</td></tr><tr><td style="padding:6px 0;font-size:14px;color:#555;">Date</td><td style="padding:6px 0;font-size:14px;color:#000;font-weight:600;">${dateStr}</td></tr>${reasonRow}</table></div><p style="margin:0;font-size:13px;color:#666;">Browse other companions on DateRabbit and find your perfect match.</p></td></tr></table></td></tr></table></body></html>`,
+    });
+  }
+
+  async sendPaymentReceived(data: {
+    companionEmail: string;
+    companionName: string;
+    seekerName: string;
+    amount: number;
+    activity: string;
+    dateTime: Date;
+  }): Promise<boolean> {
+    const dateStr = data.dateTime.toLocaleDateString('en-US', {
+      weekday: 'long', year: 'numeric', month: 'long', day: 'numeric',
+    });
+    return this.sendEmail({
+      to: data.companionEmail,
+      subject: `Payment received — $${Number(data.amount).toFixed(2)} from ${data.seekerName}`,
+      htmlContent: `<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8"/><title>Payment Received</title></head><body style="margin:0;padding:0;background:#F4F0EA;font-family:Arial,sans-serif;"><table width="100%" cellpadding="0" cellspacing="0" style="background:#F4F0EA;padding:40px 20px;"><tr><td align="center"><table width="480" cellpadding="0" cellspacing="0" style="background:#F4F0EA;border:3px solid #000;border-radius:12px;padding:32px;"><tr><td><p style="margin:0 0 4px 0;font-size:11px;font-weight:700;letter-spacing:3px;text-transform:uppercase;color:#FF2A5F;">DateRabbit</p><h1 style="margin:0 0 8px 0;font-size:24px;font-weight:700;color:#000;">Payment Received!</h1><p style="margin:0 0 24px 0;font-size:15px;color:#333;">Hi ${data.companionName}, you received a payment from <strong>${data.seekerName}</strong>.</p><div style="background:#fff;border:3px solid #000;border-radius:8px;padding:20px;margin:0 0 24px 0;"><table width="100%" cellpadding="0" cellspacing="0"><tr><td style="padding:6px 0;font-size:14px;color:#555;">From</td><td style="padding:6px 0;font-size:14px;color:#000;font-weight:600;">${data.seekerName}</td></tr><tr><td style="padding:6px 0;font-size:14px;color:#555;">Date</td><td style="padding:6px 0;font-size:14px;color:#000;font-weight:600;">${dateStr}</td></tr><tr><td style="padding:12px 0 6px 0;font-size:14px;color:#555;border-top:2px solid #eee;">Amount</td><td style="padding:12px 0 6px 0;font-size:18px;color:#000;font-weight:700;border-top:2px solid #eee;">$${Number(data.amount).toFixed(2)}</td></tr></table></div><p style="margin:0;font-size:13px;color:#666;">Your earnings will be available for payout via your Stripe account.</p></td></tr></table></td></tr></table></body></html>`,
+    });
+  }
+
+  async sendNewReview(data: {
+    revieweeEmail: string;
+    revieweeName: string;
+    reviewerName: string;
+    rating: number;
+    comment?: string;
+  }): Promise<boolean> {
+    const stars = '★'.repeat(Math.round(data.rating)) + '☆'.repeat(5 - Math.round(data.rating));
+    const commentRow = data.comment
+      ? `<tr><td colspan="2" style="padding:12px 0 6px 0;font-size:14px;color:#333;border-top:2px solid #eee;font-style:italic;">"${data.comment}"</td></tr>`
+      : '';
+    return this.sendEmail({
+      to: data.revieweeEmail,
+      subject: `${data.reviewerName} left you a ${data.rating}-star review`,
+      htmlContent: `<!DOCTYPE html><html lang="en"><head><meta charset="UTF-8"/><title>New Review</title></head><body style="margin:0;padding:0;background:#F4F0EA;font-family:Arial,sans-serif;"><table width="100%" cellpadding="0" cellspacing="0" style="background:#F4F0EA;padding:40px 20px;"><tr><td align="center"><table width="480" cellpadding="0" cellspacing="0" style="background:#F4F0EA;border:3px solid #000;border-radius:12px;padding:32px;"><tr><td><p style="margin:0 0 4px 0;font-size:11px;font-weight:700;letter-spacing:3px;text-transform:uppercase;color:#FF2A5F;">DateRabbit</p><h1 style="margin:0 0 8px 0;font-size:24px;font-weight:700;color:#000;">New Review!</h1><p style="margin:0 0 24px 0;font-size:15px;color:#333;">Hi ${data.revieweeName}, <strong>${data.reviewerName}</strong> just reviewed you.</p><div style="background:#fff;border:3px solid #000;border-radius:8px;padding:20px;margin:0 0 24px 0;"><table width="100%" cellpadding="0" cellspacing="0"><tr><td style="padding:6px 0;font-size:14px;color:#555;">From</td><td style="padding:6px 0;font-size:14px;color:#000;font-weight:600;">${data.reviewerName}</td></tr><tr><td style="padding:6px 0;font-size:14px;color:#555;">Rating</td><td style="padding:6px 0;font-size:22px;color:#FF2A5F;">${stars}</td></tr>${commentRow}</table></div><p style="margin:0;font-size:13px;color:#666;">Open the DateRabbit app to view your full reviews and respond.</p></td></tr></table></td></tr></table></body></html>`,
+    });
+  }
+
   // ─── HTML Templates ─────────────────────────────────────────────────────────
 
   private buildOtpTemplate(otp: string): string {

--- a/backend/daterabbit-api/src/main.ts
+++ b/backend/daterabbit-api/src/main.ts
@@ -1,11 +1,29 @@
 import { NestFactory } from '@nestjs/core';
 import { ValidationPipe } from '@nestjs/common';
 import { AppModule } from './app.module';
+import { DataSource } from 'typeorm';
+
+// Run raw SQL that TypeORM synchronize cannot handle automatically.
+// Enum value additions require ALTER TYPE and are idempotent via IF NOT EXISTS.
+async function runEnumMigrations(dataSource: DataSource): Promise<void> {
+  const newValues = ['booking_request', 'payment_received', 'new_review'];
+  for (const value of newValues) {
+    await dataSource
+      .query(`ALTER TYPE notification_type_enum ADD VALUE IF NOT EXISTS '${value}'`)
+      .catch(() => {
+        // Ignore if type does not exist yet — synchronize will create it on first run
+      });
+  }
+}
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule, {
     rawBody: true,
   });
+
+  // Apply enum migrations before app starts serving requests
+  const dataSource = app.get(DataSource);
+  await runEnumMigrations(dataSource);
 
   // Enable CORS
   const corsOrigins = ['https://daterabbit.smartlaunchhub.com'];

--- a/backend/daterabbit-api/src/notifications/entities/notification.entity.ts
+++ b/backend/daterabbit-api/src/notifications/entities/notification.entity.ts
@@ -13,12 +13,15 @@ export enum NotificationType {
   BOOKING_DECLINED = 'booking_declined',
   BOOKING_CANCELLED = 'booking_cancelled',
   BOOKING_COMPLETED = 'booking_completed',
+  BOOKING_REQUEST = 'booking_request',
   NEW_MESSAGE = 'new_message',
   NO_SHOW = 'no_show',
   SOS_ALERT = 'sos_alert',
   SAFETY_ALERT = 'safety_alert',
   REPORT_ISSUE = 'report_issue',
   COMPANION_ONLINE = 'companion_online',
+  PAYMENT_RECEIVED = 'payment_received',
+  NEW_REVIEW = 'new_review',
 }
 
 @Entity('notifications')

--- a/backend/daterabbit-api/src/notifications/notifications.module.ts
+++ b/backend/daterabbit-api/src/notifications/notifications.module.ts
@@ -1,11 +1,15 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Notification } from './entities/notification.entity';
 import { NotificationsService } from './notifications.service';
 import { NotificationsController } from './notifications.controller';
+import { UsersModule } from '../users/users.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Notification])],
+  imports: [
+    TypeOrmModule.forFeature([Notification]),
+    forwardRef(() => UsersModule),
+  ],
   providers: [NotificationsService],
   controllers: [NotificationsController],
   exports: [NotificationsService],

--- a/backend/daterabbit-api/src/notifications/notifications.service.ts
+++ b/backend/daterabbit-api/src/notifications/notifications.service.ts
@@ -1,13 +1,20 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Inject, forwardRef, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Notification, NotificationType } from './entities/notification.entity';
+import { UsersService } from '../users/users.service';
+
+const EXPO_PUSH_API = 'https://exp.host/--/api/v2/push/send';
 
 @Injectable()
 export class NotificationsService {
+  private readonly logger = new Logger(NotificationsService.name);
+
   constructor(
     @InjectRepository(Notification)
     private notificationsRepository: Repository<Notification>,
+    @Inject(forwardRef(() => UsersService))
+    private usersService: UsersService,
   ) {}
 
   async create(data: {
@@ -18,7 +25,14 @@ export class NotificationsService {
     data?: Record<string, any>;
   }): Promise<Notification> {
     const notification = this.notificationsRepository.create(data);
-    return this.notificationsRepository.save(notification);
+    const saved = await this.notificationsRepository.save(notification);
+
+    // Fire push delivery after DB save — failure must never break the caller
+    this.sendExpoPush(data.userId, data.title, data.body, data.data).catch(
+      (err) => this.logger.error(`Push delivery failed for user ${data.userId}: ${err}`),
+    );
+
+    return saved;
   }
 
   async getByUser(userId: string, limit = 20, offset = 0): Promise<Notification[]> {
@@ -48,5 +62,64 @@ export class NotificationsService {
       { userId, isRead: false },
       { isRead: true },
     );
+  }
+
+  // ─── Expo Push ──────────────────────────────────────────────────────────────
+
+  private async sendExpoPush(
+    userId: string,
+    title: string,
+    body: string,
+    data?: Record<string, any>,
+  ): Promise<void> {
+    const user = await this.usersService.findById(userId);
+    if (!user) return;
+
+    // Respect user-level notification toggle
+    if (!user.notificationsEnabled) return;
+
+    const token = user.expoPushToken;
+    // Expo push tokens always start with 'ExponentPushToken['
+    if (!token || !token.startsWith('ExponentPushToken[')) return;
+
+    const payload = {
+      to: token,
+      title,
+      body,
+      sound: 'default',
+      data: data ?? {},
+    };
+
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 10_000);
+
+    try {
+      const res = await fetch(EXPO_PUSH_API, {
+        method: 'POST',
+        headers: {
+          Accept: 'application/json',
+          'Accept-Encoding': 'gzip, deflate',
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(payload),
+        signal: controller.signal,
+      });
+
+      clearTimeout(timeout);
+
+      if (!res.ok) {
+        const text = await res.text();
+        this.logger.warn(`Expo push non-OK (${res.status}) for user ${userId}: ${text}`);
+      } else {
+        this.logger.log(`Expo push sent to user ${userId}`);
+      }
+    } catch (err: any) {
+      clearTimeout(timeout);
+      if (err?.name === 'AbortError') {
+        this.logger.warn(`Expo push timeout for user ${userId}`);
+      } else {
+        throw err;
+      }
+    }
   }
 }

--- a/backend/daterabbit-api/src/payments/payments.module.ts
+++ b/backend/daterabbit-api/src/payments/payments.module.ts
@@ -4,9 +4,15 @@ import { User } from '../users/entities/user.entity';
 import { Booking } from '../bookings/entities/booking.entity';
 import { PaymentsService } from './payments.service';
 import { PaymentsController, WebhooksController } from './payments.controller';
+import { NotificationsModule } from '../notifications/notifications.module';
+import { EmailModule } from '../email/email.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([User, Booking])],
+  imports: [
+    TypeOrmModule.forFeature([User, Booking]),
+    NotificationsModule,
+    EmailModule,
+  ],
   providers: [PaymentsService],
   controllers: [PaymentsController, WebhooksController],
   exports: [PaymentsService],

--- a/backend/daterabbit-api/src/payments/payments.service.ts
+++ b/backend/daterabbit-api/src/payments/payments.service.ts
@@ -1,14 +1,18 @@
-import { Injectable, HttpException, HttpStatus } from '@nestjs/common';
+import { Injectable, HttpException, HttpStatus, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import Stripe from 'stripe';
 import { User } from '../users/entities/user.entity';
 import { Booking, BookingStatus } from '../bookings/entities/booking.entity';
+import { NotificationsService } from '../notifications/notifications.service';
+import { NotificationType } from '../notifications/entities/notification.entity';
+import { EmailService } from '../email/email.service';
 
 @Injectable()
 export class PaymentsService {
   private stripe: Stripe;
+  private readonly logger = new Logger(PaymentsService.name);
 
   constructor(
     private configService: ConfigService,
@@ -16,6 +20,8 @@ export class PaymentsService {
     private usersRepo: Repository<User>,
     @InjectRepository(Booking)
     private bookingsRepo: Repository<Booking>,
+    private notificationsService: NotificationsService,
+    private emailService: EmailService,
   ) {
     const secretKey = this.configService.get('STRIPE_SECRET_KEY');
     if (secretKey) {
@@ -588,6 +594,33 @@ export class PaymentsService {
           await this.bookingsRepo.update(bookingId, {
             status: BookingStatus.PAID,
           });
+
+          // UC-123: Notify companion of payment received (fire-and-forget)
+          const booking = await this.bookingsRepo.findOne({
+            where: { id: bookingId },
+            relations: ['seeker', 'companion'],
+          });
+          if (booking?.companionId) {
+            const amount = Number(pi.amount_received ?? pi.amount) / 100;
+            this.notificationsService.create({
+              userId: booking.companionId,
+              type: NotificationType.PAYMENT_RECEIVED,
+              title: 'Payment Received',
+              body: `$${amount.toFixed(2)} received from ${booking.seeker?.name || 'your guest'}.`,
+              data: { bookingId, amount },
+            }).catch((err) => this.logger.error('payment_received notification error', err));
+
+            if (booking.companion?.email) {
+              this.emailService.sendPaymentReceived({
+                companionEmail: booking.companion.email,
+                companionName: booking.companion.name || 'there',
+                seekerName: booking.seeker?.name || 'your guest',
+                amount,
+                activity: booking.activity,
+                dateTime: booking.dateTime,
+              }).catch((err) => this.logger.error('payment_received email error', err));
+            }
+          }
         }
         break;
       }

--- a/backend/daterabbit-api/src/reviews/reviews.module.ts
+++ b/backend/daterabbit-api/src/reviews/reviews.module.ts
@@ -5,9 +5,15 @@ import { Booking } from '../bookings/entities/booking.entity';
 import { User } from '../users/entities/user.entity';
 import { ReviewsService } from './reviews.service';
 import { ReviewsController } from './reviews.controller';
+import { NotificationsModule } from '../notifications/notifications.module';
+import { EmailModule } from '../email/email.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Review, Booking, User])],
+  imports: [
+    TypeOrmModule.forFeature([Review, Booking, User]),
+    NotificationsModule,
+    EmailModule,
+  ],
   providers: [ReviewsService],
   controllers: [ReviewsController],
   exports: [ReviewsService],

--- a/backend/daterabbit-api/src/reviews/reviews.service.ts
+++ b/backend/daterabbit-api/src/reviews/reviews.service.ts
@@ -5,6 +5,9 @@ import { Review } from './entities/review.entity';
 import { Booking, BookingStatus } from '../bookings/entities/booking.entity';
 import { User } from '../users/entities/user.entity';
 import { sanitizeText } from '../common/sanitize';
+import { NotificationsService } from '../notifications/notifications.service';
+import { NotificationType } from '../notifications/entities/notification.entity';
+import { EmailService } from '../email/email.service';
 
 @Injectable()
 export class ReviewsService {
@@ -15,6 +18,8 @@ export class ReviewsService {
     private bookingsRepo: Repository<Booking>,
     @InjectRepository(User)
     private usersRepo: Repository<User>,
+    private notificationsService: NotificationsService,
+    private emailService: EmailService,
   ) {}
 
   async createReview(
@@ -66,6 +71,31 @@ export class ReviewsService {
 
     // Update reviewee's average rating
     await this.updateUserRating(revieweeId);
+
+    // UC-124: Notify reviewee about new review (push + email, fire-and-forget)
+    const reviewerName =
+      booking.seekerId === reviewerId
+        ? booking.seeker?.name || 'Someone'
+        : booking.companion?.name || 'Someone';
+
+    this.notificationsService.create({
+      userId: revieweeId,
+      type: NotificationType.NEW_REVIEW,
+      title: 'New Review',
+      body: `${reviewerName} gave you a ${rating}-star review.`,
+      data: { bookingId, reviewId: saved.id, rating },
+    }).catch(() => {/* swallow */});
+
+    const reviewee = await this.usersRepo.findOne({ where: { id: revieweeId } });
+    if (reviewee?.email) {
+      this.emailService.sendNewReview({
+        revieweeEmail: reviewee.email,
+        revieweeName: reviewee.name || 'there',
+        reviewerName,
+        rating,
+        comment,
+      }).catch(() => {/* swallow */});
+    }
 
     return saved;
   }

--- a/backend/daterabbit-api/src/users/users.controller.ts
+++ b/backend/daterabbit-api/src/users/users.controller.ts
@@ -20,6 +20,17 @@ export class UsersController {
   }
 
   @UseGuards(JwtAuthGuard)
+  @Patch('me/push-token')
+  async updatePushToken(@Request() req, @Body() body: { expoPushToken: string }) {
+    const token = body?.expoPushToken;
+    if (!token || typeof token !== 'string') {
+      throw new BadRequestException('expoPushToken is required');
+    }
+    await this.usersService.updatePushToken(req.user.id, token);
+    return { success: true };
+  }
+
+  @UseGuards(JwtAuthGuard)
   @Get('me')
   async getProfile(@Request() req) {
     const user = await this.usersService.findById(req.user.id);

--- a/backend/daterabbit-api/src/users/users.service.ts
+++ b/backend/daterabbit-api/src/users/users.service.ts
@@ -71,6 +71,10 @@ export class UsersService {
     return this.findById(id);
   }
 
+  async updatePushToken(userId: string, token: string): Promise<void> {
+    await this.usersRepository.update(userId, { expoPushToken: token });
+  }
+
   async updateLastSeen(userId: string): Promise<void> {
     // Check if user was offline before updating — needed to know whether to notify watchers
     const user = await this.usersRepository.findOne({ where: { id: userId }, select: ['id', 'name', 'lastSeen'] });


### PR DESCRIPTION
## Summary

- Expo push notifications wired into NotificationsService — every `create()` call now fires push delivery after DB save
- 5 email triggers via Brevo for: new booking request, cancellation (both directions), payment received, new review
- `PATCH /users/me/push-token` endpoint for native token registration
- Frontend push registration hook in `_layout.tsx` (native only, web-safe)
- DB enum migration runs at startup via raw SQL with `IF NOT EXISTS` (idempotent)

## Events covered

| Event | Push | Email |
|-------|------|-------|
| New booking request → companion | ✅ UC-120 | ✅ |
| Booking confirmed → seeker | ✅ UC-121 | existing |
| Booking confirmed → companion | ✅ UC-121 | existing |
| Booking cancelled/declined → other party | ✅ UC-122 | ✅ |
| Payment received → companion | ✅ UC-123 | ✅ |
| New review → reviewee | ✅ UC-124 | ✅ |

## Test plan

- [ ] Register device on native app → DB shows ExponentPushToken in user record
- [ ] Create booking → companion receives push notification
- [ ] Accept booking → seeker receives push + email
- [ ] Cancel booking → other party receives push + email (check Brevo sent events)
- [ ] Complete booking + submit review → reviewee receives push + email
- [ ] Make Stripe payment → companion receives push + email (verify via webhook)
- [ ] Web app: no crashes (Platform.OS !== 'web' guards in place)
- [ ] `tsc --noEmit` passes with zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)