### PR TITLE
feat(bookings): UC-048 post-date time confirmation flow

### DIFF
--- a/app/app/(tabs)/female/requests.tsx
+++ b/app/app/(tabs)/female/requests.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import { View, Text, StyleSheet, ScrollView, TouchableOpacity, RefreshControl, Platform } from 'react-native';
+import { View, Text, StyleSheet, ScrollView, TouchableOpacity, RefreshControl, Platform, Modal, TextInput } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { router } from 'expo-router';
 import { showAlert, showConfirm } from '../../../src/utils/alert';
@@ -21,7 +21,12 @@ export default function RequestsScreen() {
   const [activeTab, setActiveTab] = useState<TabType>('pending');
   const [refreshing, setRefreshing] = useState(false);
 
-  const { requests = [], isLoading, fetchRequests, acceptRequest, declineRequest } = useBookingsStore();
+  // UC-048: completion modal state
+  const [completionModalBooking, setCompletionModalBooking] = useState<Booking | null>(null);
+  const [actualHoursInput, setActualHoursInput] = useState('');
+  const [isSubmittingCompletion, setIsSubmittingCompletion] = useState(false);
+
+  const { requests = [], isLoading, fetchRequests, acceptRequest, declineRequest, completeBooking } = useBookingsStore();
 
   useEffect(() => {
     fetchRequests(activeTab);
@@ -67,6 +72,32 @@ export default function RequestsScreen() {
     );
   }, [activeTab]);
 
+  // UC-048: Companion marks date as completed
+  const handleDateCompleted = useCallback((booking: Booking) => {
+    setActualHoursInput(String(booking.duration || ''));
+    setCompletionModalBooking(booking);
+  }, []);
+
+  const handleSubmitCompletion = useCallback(async () => {
+    if (!completionModalBooking) return;
+    const hours = parseFloat(actualHoursInput);
+    if (isNaN(hours) || hours <= 0 || hours > 24) {
+      showAlert('Invalid Hours', 'Please enter a valid number of hours (0–24).');
+      return;
+    }
+    setIsSubmittingCompletion(true);
+    const result = await completeBooking(completionModalBooking.id, hours);
+    setIsSubmittingCompletion(false);
+    if (result.success) {
+      setCompletionModalBooking(null);
+      setActualHoursInput('');
+      showAlert('Done', 'Date marked as completed. Seeker has 24 hours to confirm.');
+      fetchRequests(activeTab);
+    } else {
+      showAlert('Error', result.error || 'Failed to submit completion');
+    }
+  }, [completionModalBooking, actualHoursInput, activeTab]);
+
   const formatDate = (dateStr: string) => {
     const date = new Date(dateStr);
     return date.toLocaleDateString(undefined, {
@@ -83,6 +114,56 @@ export default function RequestsScreen() {
       <View style={[styles.header, { paddingTop: insets.top + spacing.md }]}>
         <Text style={[styles.title, { color: colors.text }]}>Date Requests</Text>
       </View>
+
+      {/* UC-048: Date completion modal */}
+      <Modal
+        visible={completionModalBooking !== null}
+        transparent
+        animationType="fade"
+        onRequestClose={() => setCompletionModalBooking(null)}
+      >
+        <View style={styles.modalOverlay}>
+          <View style={[styles.modalCard, { backgroundColor: colors.surface }]}>
+            <Text style={[styles.modalTitle, { color: colors.text }]}>Date Completed</Text>
+            <Text style={[styles.modalSubtitle, { color: colors.textSecondary }]}>
+              How many hours did the date actually last?
+            </Text>
+            <TextInput
+              style={[styles.hoursInput, { color: colors.text, borderColor: colors.border, backgroundColor: colors.background }]}
+              value={actualHoursInput}
+              onChangeText={setActualHoursInput}
+              keyboardType="decimal-pad"
+              placeholder={`Booked: ${completionModalBooking?.duration}h`}
+              placeholderTextColor={colors.textSecondary}
+              maxLength={4}
+              accessibilityLabel="Actual hours"
+            />
+            <Text style={[styles.modalHint, { color: colors.textSecondary }]}>
+              The seeker will receive a notification and has 24 hours to confirm.
+            </Text>
+            <View style={styles.modalActions}>
+              <Button
+                title="Cancel"
+                variant="outline"
+                size="sm"
+                style={{ flex: 1 }}
+                onPress={() => {
+                  setCompletionModalBooking(null);
+                  setActualHoursInput('');
+                }}
+                disabled={isSubmittingCompletion}
+              />
+              <Button
+                title={isSubmittingCompletion ? 'Submitting...' : 'Confirm'}
+                size="sm"
+                style={{ flex: 1 }}
+                onPress={handleSubmitCompletion}
+                disabled={isSubmittingCompletion}
+              />
+            </View>
+          </View>
+        </View>
+      </Modal>
 
       <View style={styles.tabs}>
         {(['pending', 'accepted', 'completed'] as TabType[]).map((tab) => (
@@ -139,6 +220,7 @@ export default function RequestsScreen() {
               colors={colors}
               onAccept={() => handleAccept(request)}
               onDecline={() => handleDecline(request)}
+              onComplete={() => handleDateCompleted(request)}
               formatDate={formatDate}
             />
           ))
@@ -154,10 +236,11 @@ interface RequestCardProps {
   colors: any;
   onAccept: () => void;
   onDecline: () => void;
+  onComplete: () => void;
   formatDate: (date: string) => string;
 }
 
-function RequestCard({ request, type, colors, onAccept, onDecline, formatDate }: RequestCardProps) {
+function RequestCard({ request, type, colors, onAccept, onDecline, onComplete, formatDate }: RequestCardProps) {
   const seeker = request.seeker || { name: 'Unknown', photo: null };
 
   const getStatusStyle = (status: string) => {
@@ -165,6 +248,7 @@ function RequestCard({ request, type, colors, onAccept, onDecline, formatDate }:
       case 'completed': return { bg: colors.primary + '20', text: colors.primary };
       case 'cancelled': return { bg: colors.error + '20', text: colors.error };
       case 'no_show': return { bg: colors.error + '20', text: colors.error };
+      case 'pending_completion': return { bg: colors.warning + '20', text: colors.warning };
       default: return { bg: colors.textSecondary + '20', text: colors.textSecondary };
     }
   };
@@ -232,7 +316,16 @@ function RequestCard({ request, type, colors, onAccept, onDecline, formatDate }:
         </View>
       )}
 
-      {type === 'accepted' && (
+      {type === 'accepted' && request.status === 'pending_completion' && (
+        <View style={[styles.pendingCompletionBanner, { backgroundColor: colors.warning + '15' }]}>
+          <Icon name="clock" size={14} color={colors.warning} />
+          <Text style={[styles.pendingCompletionText, { color: colors.warning }]}>
+            Waiting for seeker to confirm ({request.completionActualHours}h reported)
+          </Text>
+        </View>
+      )}
+
+      {type === 'accepted' && request.status !== 'pending_completion' && (
         <View style={styles.actions}>
           <Button
             title="Message"
@@ -259,7 +352,20 @@ function RequestCard({ request, type, colors, onAccept, onDecline, formatDate }:
         </View>
       )}
 
-      {request.status === 'active' && (
+      {type === 'accepted' && (request.status === 'active' || request.status === 'paid' || request.status === 'confirmed') && (
+        <View style={[styles.actions, { marginTop: spacing.sm }]}>
+          <Button
+            title="Date Completed"
+            onPress={onComplete}
+            size="sm"
+            style={{ flex: 1, backgroundColor: colors.success }}
+            testID={`complete-date-${request.id}`}
+            accessibilityLabel="Mark date as completed"
+          />
+        </View>
+      )}
+
+      {request.status === 'active' && type !== 'accepted' && (
         <View style={styles.actions}>
           <Button
             title="Resume Date"
@@ -425,5 +531,59 @@ const styles = StyleSheet.create({
   ratingText: {
     fontFamily: typography.fonts.body,
     fontSize: typography.sizes.sm,
+  },
+  pendingCompletionBanner: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.xs,
+    marginTop: spacing.md,
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+    borderRadius: borderRadius.md,
+  },
+  pendingCompletionText: {
+    fontFamily: typography.fonts.bodyMedium,
+    fontSize: typography.sizes.sm,
+    flex: 1,
+  },
+  // Modal styles
+  modalOverlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.5)',
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: spacing.lg,
+  },
+  modalCard: {
+    width: '100%',
+    maxWidth: 400,
+    borderRadius: borderRadius.lg,
+    padding: spacing.lg,
+    gap: spacing.md,
+  },
+  modalTitle: {
+    fontFamily: typography.fonts.heading,
+    fontSize: typography.sizes.lg,
+  },
+  modalSubtitle: {
+    fontFamily: typography.fonts.body,
+    fontSize: typography.sizes.sm,
+  },
+  hoursInput: {
+    borderWidth: 1,
+    borderRadius: borderRadius.md,
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+    fontFamily: typography.fonts.body,
+    fontSize: typography.sizes.md,
+    minHeight: 48,
+  },
+  modalHint: {
+    fontFamily: typography.fonts.body,
+    fontSize: typography.sizes.xs,
+  },
+  modalActions: {
+    flexDirection: 'row',
+    gap: spacing.md,
   },
 });

--- a/app/app/(tabs)/male/bookings.tsx
+++ b/app/app/(tabs)/male/bookings.tsx
@@ -26,7 +26,7 @@ export default function BookingsScreen() {
   const [activeTab, setActiveTab] = useState<TabType>('upcoming');
   const [refreshing, setRefreshing] = useState(false);
 
-  const { bookings = [], isLoading, fetchMyBookings, cancelBooking } = useBookingsStore();
+  const { bookings = [], isLoading, fetchMyBookings, cancelBooking, confirmCompletion } = useBookingsStore();
 
   useEffect(() => {
     fetchMyBookings(filterMap[activeTab]);
@@ -71,6 +71,27 @@ export default function BookingsScreen() {
       },
       'Yes, Cancel',
       'No'
+    );
+  }, [activeTab]);
+
+  // UC-048: Seeker confirms completion after companion marks date done
+  const handleConfirmCompletion = useCallback(async (booking: Booking) => {
+    const companionName = booking.companion?.name || 'your companion';
+    const hours = booking.completionActualHours;
+    showConfirm(
+      'Confirm Date Completed',
+      `${companionName} reported the date lasted ${hours}h. Do you confirm?`,
+      async () => {
+        const result = await confirmCompletion(booking.id);
+        if (result.success) {
+          showAlert('Confirmed', 'Date confirmed. Payment will be released to the companion.');
+          fetchMyBookings(filterMap[activeTab]);
+        } else {
+          showAlert('Error', result.error || 'Failed to confirm');
+        }
+      },
+      'Yes, Confirm',
+      'Not Now',
     );
   }, [activeTab]);
 
@@ -159,6 +180,7 @@ export default function BookingsScreen() {
               type={activeTab}
               colors={colors}
               onCancel={() => handleCancelBooking(booking)}
+              onConfirmCompletion={() => handleConfirmCompletion(booking)}
               formatDate={formatDate}
             />
           ))
@@ -173,10 +195,11 @@ interface BookingCardProps {
   type: TabType;
   colors: any;
   onCancel: () => void;
+  onConfirmCompletion: () => void;
   formatDate: (date: string) => string;
 }
 
-function BookingCard({ booking, type, colors, onCancel, formatDate }: BookingCardProps) {
+function BookingCard({ booking, type, colors, onCancel, onConfirmCompletion, formatDate }: BookingCardProps) {
   // Guard against undefined companion OR empty object {} produced by normalization
   const rawCompanion = booking.companion;
   const companion = (rawCompanion && rawCompanion.name)
@@ -193,6 +216,7 @@ function BookingCard({ booking, type, colors, onCancel, formatDate }: BookingCar
       case 'no_show': return { bg: colors.error + '20', text: colors.error };
       case 'paid': return { bg: colors.success + '20', text: colors.success };
       case 'active': return { bg: colors.accent + '20', text: colors.accent };
+      case 'pending_completion': return { bg: colors.warning + '20', text: colors.warning };
       default: return { bg: colors.warning + '20', text: colors.warning };
     }
   };
@@ -291,7 +315,24 @@ function BookingCard({ booking, type, colors, onCancel, formatDate }: BookingCar
         </View>
       )}
 
-      {type === 'past' && (
+      {type === 'past' && booking.status === 'pending_completion' && (
+        <View style={[styles.confirmSection, { borderTopColor: colors.border, backgroundColor: colors.warning + '10' }]}>
+          <Icon name="clock" size={16} color={colors.warning} />
+          <Text style={[styles.confirmText, { color: colors.text }]}>
+            {companion.name} marked this date as completed ({booking.completionActualHours}h).
+          </Text>
+          <Button
+            title="Confirm Date Completed"
+            onPress={onConfirmCompletion}
+            size="sm"
+            style={{ alignSelf: 'stretch', backgroundColor: colors.success, marginTop: spacing.sm }}
+            testID={`confirm-completion-${booking.id}`}
+            accessibilityLabel="Confirm date completed"
+          />
+        </View>
+      )}
+
+      {type === 'past' && booking.status !== 'pending_completion' && (
         <View style={[styles.ratingSection, { borderTopColor: colors.border }]}>
           <Text style={[styles.ratingLabel, { color: colors.textSecondary }]}>Rating</Text>
           <View style={{ flexDirection: 'row', gap: 4 }}>
@@ -464,5 +505,20 @@ const styles = StyleSheet.create({
   paidText: {
     fontFamily: typography.fonts.bodySemiBold,
     fontSize: typography.sizes.sm,
+  },
+  confirmSection: {
+    marginTop: spacing.md,
+    alignItems: 'center',
+    paddingTop: spacing.md,
+    paddingHorizontal: spacing.md,
+    paddingBottom: spacing.md,
+    borderTopWidth: 1,
+    borderRadius: borderRadius.md,
+    gap: spacing.xs,
+  },
+  confirmText: {
+    fontFamily: typography.fonts.body,
+    fontSize: typography.sizes.sm,
+    textAlign: 'center',
   },
 });

--- a/app/src/services/api.ts
+++ b/app/src/services/api.ts
@@ -330,7 +330,8 @@ export type BookingStatus =
   | 'checkin_ready'
   | 'active'
   | 'cancelled'
-  | 'completed';
+  | 'completed'
+  | 'pending_completion';
 
 export interface Booking {
   id: string;
@@ -363,6 +364,10 @@ export interface Booking {
   seekerRating?: { average: number; count: number } | null;
   noShowReason?: string;
   createdAt: string;
+  // UC-048: post-date completion confirmation
+  completionRequestedAt?: string;
+  completionActualHours?: number;
+  completionConfirmedAt?: string;
 }
 
 export interface CreateBookingData {
@@ -457,8 +462,14 @@ export const bookingsApi = {
     }
   },
 
-  complete: (id: string) =>
+  complete: (id: string, actualDurationHours: number) =>
     apiRequest<Booking>(`/bookings/${id}/complete`, {
+      method: 'PUT',
+      body: { actualDurationHours },
+    }),
+
+  confirmCompletion: (id: string) =>
+    apiRequest<Booking>(`/bookings/${id}/confirm-completion`, {
       method: 'PUT',
     }),
 

--- a/app/src/store/bookingsStore.ts
+++ b/app/src/store/bookingsStore.ts
@@ -21,7 +21,8 @@ interface BookingsState {
 
   // Shared actions
   cancelBooking: (id: string, reason?: string) => Promise<{ success: boolean; error?: string }>;
-  completeBooking: (id: string) => Promise<{ success: boolean; error?: string }>;
+  completeBooking: (id: string, actualDurationHours: number) => Promise<{ success: boolean; error?: string }>;
+  confirmCompletion: (id: string) => Promise<{ success: boolean; error?: string }>;
   createReview: (bookingId: string, rating: number, comment?: string) => Promise<{ success: boolean; error?: string }>;
 
   // Fetch actions
@@ -118,11 +119,11 @@ export const useBookingsStore = create<BookingsState>((set, get) => ({
     }
   },
 
-  completeBooking: async (id) => {
+  completeBooking: async (id, actualDurationHours) => {
     set({ isLoading: true, error: null });
 
     try {
-      const updated = await bookingsApi.complete(id);
+      const updated = await bookingsApi.complete(id, actualDurationHours);
       set((state) => ({
         bookings: state.bookings.map((b) => (b.id === id ? updated : b)),
         requests: state.requests.map((r) => (r.id === id ? updated : r)),
@@ -131,6 +132,24 @@ export const useBookingsStore = create<BookingsState>((set, get) => ({
       return { success: true };
     } catch (err) {
       const message = err instanceof ApiError ? err.message : 'Failed to complete booking';
+      set({ error: message, isLoading: false });
+      return { success: false, error: message };
+    }
+  },
+
+  confirmCompletion: async (id) => {
+    set({ isLoading: true, error: null });
+
+    try {
+      const updated = await bookingsApi.confirmCompletion(id);
+      set((state) => ({
+        bookings: state.bookings.map((b) => (b.id === id ? updated : b)),
+        requests: state.requests.map((r) => (r.id === id ? updated : r)),
+        isLoading: false,
+      }));
+      return { success: true };
+    } catch (err) {
+      const message = err instanceof ApiError ? err.message : 'Failed to confirm completion';
       set({ error: message, isLoading: false });
       return { success: false, error: message };
     }

--- a/backend/daterabbit-api/src/app.module.ts
+++ b/backend/daterabbit-api/src/app.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { AddPendingCompletionStatus1743763200000 } from './migrations/1743763200000-add-pending-completion-status';
 import { ThrottlerModule, ThrottlerGuard } from '@nestjs/throttler';
 import { ScheduleModule } from '@nestjs/schedule';
 import { APP_GUARD } from '@nestjs/core';
@@ -50,6 +51,8 @@ import { CitiesModule } from './cities/cities.module';
         database: configService.get('DB_NAME'),
         autoLoadEntities: true,
         synchronize: configService.get('NODE_ENV') !== 'production',
+        migrations: [AddPendingCompletionStatus1743763200000],
+        migrationsRun: configService.get('NODE_ENV') === 'production',
         logging: configService.get('NODE_ENV') === 'development',
       }),
     }),

--- a/backend/daterabbit-api/src/bookings/bookings.controller.ts
+++ b/backend/daterabbit-api/src/bookings/bookings.controller.ts
@@ -111,9 +111,14 @@ export class BookingsController {
   }
 
   @Get('requests')
-  async getPendingRequests(@Request() req) {
+  async getPendingRequests(
+    @Request() req,
+    @Query('status') status: 'pending' | 'accepted' | 'completed' = 'pending',
+  ) {
     const companionId = req.user.id;
-    const requests = await this.bookingsService.getPendingRequests(companionId);
+    const validStatuses = ['pending', 'accepted', 'completed'];
+    const safeStatus = validStatuses.includes(status) ? status : 'pending';
+    const requests = await this.bookingsService.getRequestsByStatus(companionId, safeStatus);
 
     // Batch-query seeker ratings to avoid N+1
     const seekerIds = [...new Set(requests.map((b) => b.seekerId).filter(Boolean))];
@@ -291,10 +296,32 @@ export class BookingsController {
     return this.formatBooking(updated);
   }
 
+  /**
+   * UC-048: Companion marks date as completed with actual duration.
+   * Moves booking to PENDING_COMPLETION; seeker gets 24h to confirm.
+   * Stripe capture does NOT happen here — it fires after seeker confirms.
+   */
   @Put(':id/complete')
-  async completeBooking(@Param('id', ParseUUIDPipe) id: string, @Request() req) {
-    const updated = await this.bookingsService.complete(id, req.user.id);
-    // Capture the Stripe hold (fire-and-forget)
+  async completeBooking(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Request() req,
+    @Body() body: { actualDurationHours: number },
+  ) {
+    if (typeof body.actualDurationHours !== 'number' || body.actualDurationHours <= 0) {
+      throw new HttpException('actualDurationHours is required and must be a positive number', HttpStatus.BAD_REQUEST);
+    }
+    const updated = await this.bookingsService.complete(id, req.user.id, body.actualDurationHours);
+    return this.formatBooking(updated);
+  }
+
+  /**
+   * UC-048: Seeker confirms the date completion.
+   * Moves booking to COMPLETED and triggers Stripe payment capture.
+   */
+  @Put(':id/confirm-completion')
+  async confirmCompletion(@Param('id', ParseUUIDPipe) id: string, @Request() req) {
+    const updated = await this.bookingsService.confirmCompletion(id, req.user.id);
+    // Capture the Stripe hold now that seeker confirmed (fire-and-forget)
     this.paymentsService.capturePayment(id).catch(err =>
       console.error('Stripe capture error for booking', id, err),
     );
@@ -501,6 +528,9 @@ export class BookingsController {
       reportIssueText: booking.reportIssueText || undefined,
       packageId: booking.packageId || undefined,
       selfieVerified: booking.selfieVerified || false,
+      completionRequestedAt: booking.completionRequestedAt || undefined,
+      completionActualHours: booking.completionActualHours !== null && booking.completionActualHours !== undefined ? booking.completionActualHours : undefined,
+      completionConfirmedAt: booking.completionConfirmedAt || undefined,
       seeker: booking.seeker ? {
         id: booking.seeker.id,
         name: booking.seeker.name,

--- a/backend/daterabbit-api/src/bookings/bookings.cron.ts
+++ b/backend/daterabbit-api/src/bookings/bookings.cron.ts
@@ -84,6 +84,24 @@ export class BookingsCron {
     }
   }
 
+  /**
+   * UC-048: Auto-complete PENDING_COMPLETION bookings that have been waiting >24h.
+   * Runs hourly. Also triggers Stripe payment capture for each auto-completed booking.
+   */
+  @Cron(CronExpression.EVERY_HOUR)
+  async autoCompleteExpiredCompletions() {
+    const completedIds = await this.bookingsService.autoCompleteExpiredCompletions();
+
+    for (const bookingId of completedIds) {
+      this.logger.log(`Auto-completing booking ${bookingId} after 24h timeout`);
+
+      // Capture Stripe payment (fire-and-forget)
+      this.paymentsService.capturePayment(bookingId).catch(err => {
+        this.logger.error(`Stripe capture error on auto-complete for booking ${bookingId}: ${err.message}`);
+      });
+    }
+  }
+
   private async sendNoShowNotifications(
     booking: Booking,
     reason: 'seeker' | 'companion' | 'both',

--- a/backend/daterabbit-api/src/bookings/bookings.service.ts
+++ b/backend/daterabbit-api/src/bookings/bookings.service.ts
@@ -189,14 +189,17 @@ export class BookingsService {
 
       case 'past':
         // Completed/cancelled bookings with past dates OR confirmed/paid bookings with past dates
+        // PENDING_COMPLETION: seeker sees it in "past" tab so they can confirm
         seekerWhere = [
           { seekerId: userId, status: BookingStatus.COMPLETED },
+          { seekerId: userId, status: BookingStatus.PENDING_COMPLETION },
           { seekerId: userId, status: BookingStatus.CANCELLED, dateTime: LessThan(now) },
           { seekerId: userId, dateTime: LessThan(now), status: BookingStatus.CONFIRMED },
           { seekerId: userId, dateTime: LessThan(now), status: BookingStatus.PAID },
         ];
         companionWhere = [
           { companionId: userId, status: BookingStatus.COMPLETED },
+          { companionId: userId, status: BookingStatus.PENDING_COMPLETION },
           { companionId: userId, status: BookingStatus.CANCELLED, dateTime: LessThan(now) },
           { companionId: userId, dateTime: LessThan(now), status: BookingStatus.CONFIRMED },
           { companionId: userId, dateTime: LessThan(now), status: BookingStatus.PAID },
@@ -320,21 +323,61 @@ export class BookingsService {
     });
   }
 
-  async complete(id: string, userId: string): Promise<Booking> {
+  /**
+   * Get companion requests filtered by tab status.
+   * - pending: PENDING
+   * - accepted: CONFIRMED, PAID, ACTIVE, PENDING_COMPLETION
+   * - completed: COMPLETED
+   */
+  async getRequestsByStatus(companionId: string, status: 'pending' | 'accepted' | 'completed'): Promise<Booking[]> {
+    let statuses: BookingStatus[];
+
+    switch (status) {
+      case 'pending':
+        statuses = [BookingStatus.PENDING];
+        break;
+      case 'accepted':
+        statuses = [
+          BookingStatus.CONFIRMED,
+          BookingStatus.PAID,
+          BookingStatus.ACTIVE,
+          BookingStatus.PENDING_COMPLETION,
+        ];
+        break;
+      case 'completed':
+        statuses = [BookingStatus.COMPLETED, BookingStatus.CANCELLED];
+        break;
+      default:
+        statuses = [BookingStatus.PENDING];
+    }
+
+    const whereConditions = statuses.map(s => ({ companionId, status: s }));
+
+    return this.bookingsRepository.find({
+      where: whereConditions,
+      relations: ['seeker'],
+      order: { createdAt: 'DESC' },
+    });
+  }
+
+  /**
+   * UC-048: Companion marks the date as completed, providing actual duration.
+   * Transitions booking to PENDING_COMPLETION and notifies the seeker.
+   * Seeker has 24h to confirm; payment capture only happens after real COMPLETED.
+   */
+  async complete(id: string, companionId: string, actualDurationHours: number): Promise<Booking> {
     const booking = await this.findById(id);
 
     if (!booking) {
       throw new HttpException('Booking not found', HttpStatus.NOT_FOUND);
     }
 
-    if (booking.seekerId !== userId && booking.companionId !== userId) {
-      throw new HttpException('Unauthorized', HttpStatus.FORBIDDEN);
+    if (booking.companionId !== companionId) {
+      throw new HttpException('Only the companion can mark a date as completed', HttpStatus.FORBIDDEN);
     }
 
-    if (
-      booking.status !== BookingStatus.CONFIRMED &&
-      booking.status !== BookingStatus.PAID
-    ) {
+    const validStatuses = [BookingStatus.ACTIVE, BookingStatus.CONFIRMED, BookingStatus.PAID];
+    if (!validStatuses.includes(booking.status)) {
       throw new HttpException(
         `Cannot complete a ${booking.status} booking`,
         HttpStatus.BAD_REQUEST,
@@ -351,23 +394,138 @@ export class BookingsService {
       );
     }
 
-    const updated = await this.updateStatus(id, BookingStatus.COMPLETED);
+    if (typeof actualDurationHours !== 'number' || actualDurationHours <= 0 || actualDurationHours > 24) {
+      throw new HttpException('actualDurationHours must be a positive number up to 24', HttpStatus.BAD_REQUEST);
+    }
+
+    await this.bookingsRepository.update(id, {
+      status: BookingStatus.PENDING_COMPLETION,
+      completionRequestedAt: now,
+      completionActualHours: actualDurationHours,
+      activeDateEndedAt: now,
+    });
+
+    const updated = await this.findById(id);
     if (!updated) {
       throw new HttpException('Failed to update booking', HttpStatus.INTERNAL_SERVER_ERROR);
     }
 
-    // Credit referral bonus if seeker was referred and has no credited referral yet
-    try {
-      const seeker = await this.usersService.findById(updated.seekerId);
-      if (seeker?.referredBy) {
-        await this.referralService.creditBonus(updated.seekerId);
-      }
-    } catch (err) {
-      // Referral credit failure must not break booking completion
-      console.error('[REFERRAL] Failed to credit bonus:', err);
-    }
+    // Notify seeker: they have 24h to confirm or it auto-completes
+    const companionName = booking.companion?.name || 'Your companion';
+    await this.notificationsService.create({
+      userId: booking.seekerId,
+      type: NotificationType.DATE_COMPLETION_REQUEST,
+      title: 'Date completed — confirm?',
+      body: `${companionName} marked your date as completed (${actualDurationHours}h). Confirm within 24 hours or it will be auto-confirmed.`,
+      data: {
+        bookingId: id,
+        actualDurationHours,
+        companionId,
+        companionName,
+      },
+    }).catch(err => console.error('[COMPLETION] Failed to notify seeker:', err));
 
     return updated;
+  }
+
+  /**
+   * UC-048: Seeker confirms the date was completed as reported.
+   * Transitions booking to COMPLETED. Caller must trigger payment capture.
+   */
+  async confirmCompletion(id: string, seekerId: string): Promise<Booking> {
+    const booking = await this.findById(id);
+
+    if (!booking) {
+      throw new HttpException('Booking not found', HttpStatus.NOT_FOUND);
+    }
+
+    if (booking.seekerId !== seekerId) {
+      throw new HttpException('Only the seeker can confirm completion', HttpStatus.FORBIDDEN);
+    }
+
+    if (booking.status !== BookingStatus.PENDING_COMPLETION) {
+      throw new HttpException(
+        `Cannot confirm a ${booking.status} booking`,
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+
+    const now = new Date();
+    await this.bookingsRepository.update(id, {
+      status: BookingStatus.COMPLETED,
+      completionConfirmedAt: now,
+      actualDurationHours: booking.completionActualHours,
+    });
+
+    const updated = await this.findById(id);
+    if (!updated) {
+      throw new HttpException('Failed to update booking', HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    // Credit referral bonus if seeker was referred
+    try {
+      const seeker = await this.usersService.findById(seekerId);
+      if (seeker?.referredBy) {
+        await this.referralService.creditBonus(seekerId);
+      }
+    } catch (err) {
+      console.error('[REFERRAL] Failed to credit bonus on confirm:', err);
+    }
+
+    // Notify companion that payment will be released
+    const seekerName = booking.seeker?.name || 'The seeker';
+    await this.notificationsService.create({
+      userId: booking.companionId,
+      type: NotificationType.DATE_COMPLETION_CONFIRMED,
+      title: 'Date confirmed',
+      body: `${seekerName} confirmed the date. Payment will be released to you shortly.`,
+      data: { bookingId: id, seekerId },
+    }).catch(err => console.error('[COMPLETION] Failed to notify companion:', err));
+
+    return updated;
+  }
+
+  /**
+   * UC-048: Auto-complete PENDING_COMPLETION bookings after 24h if seeker has not responded.
+   * Returns list of booking IDs that were auto-completed (so caller can trigger Stripe captures).
+   */
+  async autoCompleteExpiredCompletions(): Promise<string[]> {
+    const cutoff = new Date(Date.now() - 24 * 60 * 60 * 1000);
+
+    const expired = await this.bookingsRepository.find({
+      where: {
+        status: BookingStatus.PENDING_COMPLETION,
+        completionRequestedAt: LessThan(cutoff),
+      },
+      relations: ['seeker', 'companion'],
+    });
+
+    const completedIds: string[] = [];
+
+    for (const booking of expired) {
+      try {
+        await this.bookingsRepository.update(booking.id, {
+          status: BookingStatus.COMPLETED,
+          completionConfirmedAt: new Date(),
+          actualDurationHours: booking.completionActualHours,
+        });
+        completedIds.push(booking.id);
+
+        // Credit referral bonus
+        try {
+          const seeker = await this.usersService.findById(booking.seekerId);
+          if (seeker?.referredBy) {
+            await this.referralService.creditBonus(booking.seekerId);
+          }
+        } catch (err) {
+          console.error('[REFERRAL] Failed to credit bonus on auto-complete:', err);
+        }
+      } catch (err) {
+        console.error(`[COMPLETION] Auto-complete failed for ${booking.id}:`, err);
+      }
+    }
+
+    return completedIds;
   }
 
   async seekerCheckin(bookingId: string, seekerId: string, lat?: number, lon?: number): Promise<Booking> {

--- a/backend/daterabbit-api/src/bookings/entities/booking.entity.ts
+++ b/backend/daterabbit-api/src/bookings/entities/booking.entity.ts
@@ -16,6 +16,7 @@ export enum BookingStatus {
   ACTIVE = 'active',
   CANCELLED = 'cancelled',
   COMPLETED = 'completed',
+  PENDING_COMPLETION = 'pending_completion',
 }
 
 export enum ActivityType {
@@ -138,6 +139,19 @@ export class Booking {
   // Refund percentage applied at cancellation time (0, 50, or 100)
   @Column({ type: 'int', nullable: true })
   refundPercent: number;
+
+  // UC-048: Post-date completion confirmation flow
+  // Set by companion when they mark the date as completed; moves booking to PENDING_COMPLETION
+  @Column({ type: 'timestamp', nullable: true })
+  completionRequestedAt: Date;
+
+  // Actual hours reported by companion at completion time
+  @Column({ type: 'decimal', precision: 10, scale: 2, nullable: true })
+  completionActualHours: number;
+
+  // Set when seeker confirms (or auto-set after 24h timeout)
+  @Column({ type: 'timestamp', nullable: true })
+  completionConfirmedAt: Date;
 
   @CreateDateColumn()
   createdAt: Date;

--- a/backend/daterabbit-api/src/migrations/1743763200000-add-pending-completion-status.ts
+++ b/backend/daterabbit-api/src/migrations/1743763200000-add-pending-completion-status.ts
@@ -1,0 +1,40 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * UC-048: Post-date time confirmation flow
+ * - Adds 'pending_completion' to the booking_status enum
+ * - Adds 3 new columns to the bookings table:
+ *   completion_requested_at, completion_actual_hours, completion_confirmed_at
+ */
+export class AddPendingCompletionStatus1743763200000 implements MigrationInterface {
+  name = 'AddPendingCompletionStatus1743763200000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Add new enum value — PostgreSQL requires this to be done before ALTER TABLE
+    await queryRunner.query(`
+      ALTER TYPE "bookings_status_enum" ADD VALUE IF NOT EXISTS 'pending_completion'
+    `);
+
+    // Add new columns
+    await queryRunner.query(`
+      ALTER TABLE "bookings"
+        ADD COLUMN IF NOT EXISTS "completion_requested_at" TIMESTAMP,
+        ADD COLUMN IF NOT EXISTS "completion_actual_hours" DECIMAL(10,2),
+        ADD COLUMN IF NOT EXISTS "completion_confirmed_at" TIMESTAMP
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // Drop columns (reversible)
+    await queryRunner.query(`
+      ALTER TABLE "bookings"
+        DROP COLUMN IF EXISTS "completion_requested_at",
+        DROP COLUMN IF EXISTS "completion_actual_hours",
+        DROP COLUMN IF EXISTS "completion_confirmed_at"
+    `);
+
+    // Note: PostgreSQL does not support DROP VALUE from enum.
+    // To fully revert the enum, a full enum recreation would be needed.
+    // For safety, we leave the enum value in place on rollback.
+  }
+}

--- a/backend/daterabbit-api/src/notifications/entities/notification.entity.ts
+++ b/backend/daterabbit-api/src/notifications/entities/notification.entity.ts
@@ -19,6 +19,8 @@ export enum NotificationType {
   SAFETY_ALERT = 'safety_alert',
   REPORT_ISSUE = 'report_issue',
   COMPANION_ONLINE = 'companion_online',
+  DATE_COMPLETION_REQUEST = 'date_completion_request',
+  DATE_COMPLETION_CONFIRMED = 'date_completion_confirmed',
 }
 
 @Entity('notifications')


### PR DESCRIPTION
## Summary

- **PENDING_COMPLETION** status added to `BookingStatus` enum (entity + frontend type)
- Companion taps **Date Completed** → enters actual hours → booking moves to `pending_completion`, seeker notified
- Seeker sees booking in past tab with **Confirm Date Completed** button → triggers `COMPLETED` + Stripe capture
- If seeker doesn't respond within 24h → hourly cron auto-completes and captures payment
- TypeORM migration included for staging/production (`booking_status_enum` + 3 new columns)

## Backend changes

- `booking.entity.ts`: new enum value + `completionRequestedAt`, `completionActualHours`, `completionConfirmedAt` columns
- `bookings.service.ts`: `complete()` rewritten (companion-only, requires `actualDurationHours`), `confirmCompletion()` added, `autoCompleteExpiredCompletions()` added, `getRequestsByStatus()` added
- `bookings.controller.ts`: `PUT /:id/complete` now requires body, `PUT /:id/confirm-completion` added, Stripe capture moved to post-confirm
- `bookings.cron.ts`: hourly job for auto-complete + Stripe capture
- `notification.entity.ts`: 2 new notification types
- `app.module.ts`: migration registered with `migrationsRun: true` in production
- `migrations/1743763200000-add-pending-completion-status.ts`: schema migration

## Frontend changes

- `api.ts`: `pending_completion` in `BookingStatus` union, `completionActualHours/RequestedAt/ConfirmedAt` on `Booking`, updated `complete()` signature, new `confirmCompletion()` call
- `bookingsStore.ts`: `completeBooking()` updated, `confirmCompletion()` action added
- `female/requests.tsx`: Date Completed button + hours input modal + "Waiting for seeker" banner for `pending_completion`
- `male/bookings.tsx`: Confirm Date Completed card in past tab for `pending_completion` bookings

## Test plan

- [ ] Log in as companion → Requests → Accepted tab → tap "Date Completed" → enter hours → confirm → status becomes `pending_completion`
- [ ] Log in as seeker → Bookings → Past tab → booking shows "confirm" prompt → tap Confirm → status becomes `completed`
- [ ] Verify Stripe capture fires after seeker confirmation (backend log), NOT at companion mark
- [ ] `endEarly` flow unchanged: still goes straight to `COMPLETED` with immediate capture
- [ ] Cron auto-complete: manually set `completion_requested_at` to 25h ago → cron fires → booking completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)