### PR TITLE
fix: public companions endpoint for landing + landing copy

### DIFF
--- a/app/app/landing/index.tsx
+++ b/app/app/landing/index.tsx
@@ -315,7 +315,7 @@ function MaleLanding() {
     const fetchCompanions = async () => {
       try {
         const res = await apiRequest<{ companions: CompanionListItem[]; total: number }>(
-          '/companions?limit=10',
+          '/companions/public?limit=10',
           { auth: false }
         );
         setCompanions(res.companions ?? []);
@@ -451,7 +451,7 @@ function MaleLanding() {
             accessibilityLabel="See 200+ girls"
             accessibilityRole="button"
           >
-            <Text style={styles.profileCardCtaText}>200+{'\n'}girls</Text>
+            <Text style={styles.profileCardCtaText}>See all →</Text>
           </TouchableOpacity>
         </ScrollView>
       </View>
@@ -461,7 +461,7 @@ function MaleLanding() {
         <View style={styles.trustRow}>
           <TrustBadge text="Real people, not virtual" />
           <TrustBadge text="ID-Verified" />
-          <TrustBadge text="Full Refund" />
+          <TrustBadge text="Full refund if she cancels" />
           <TrustBadge text="Book in 2 min" />
         </View>
       </View>
@@ -508,6 +508,7 @@ function MaleLanding() {
             onPress={() => router.push('/onboarding?roleHint=seeker')}
           />
         </View>
+        <Text style={styles.refundNote}>Full refund if she cancels · No hidden fees</Text>
       </View>
     </>
   );
@@ -1023,6 +1024,12 @@ const styles = StyleSheet.create({
     textAlign: 'center',
     marginBottom: spacing.lg,
     maxWidth: 460,
+  },
+  refundNote: {
+    fontSize: 12,
+    color: colors.textMuted,
+    textAlign: 'center',
+    marginTop: spacing.sm,
   },
 
   // PROFILE SCROLL (male)

--- a/backend/daterabbit-api/src/companions/companions.controller.ts
+++ b/backend/daterabbit-api/src/companions/companions.controller.ts
@@ -3,7 +3,6 @@ import { UsersService } from '../users/users.service';
 import { ReviewsService } from '../reviews/reviews.service';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 
-@UseGuards(JwtAuthGuard)
 @Controller('companions')
 export class CompanionsController {
   constructor(
@@ -11,6 +10,54 @@ export class CompanionsController {
     private reviewsService: ReviewsService,
   ) {}
 
+  @Get('public')
+  async searchPublicCompanions(
+    @Query('priceMin') priceMin?: string,
+    @Query('priceMax') priceMax?: string,
+    @Query('sortBy') sortBy?: string,
+    @Query('search') search?: string,
+    @Query('limit') limit?: string,
+    @Query('offset') offset?: string,
+    @Query('page') page?: string,
+  ) {
+    const parsedLimit = limit ? parseInt(limit) : 20;
+    const parsedOffset = page
+      ? (parseInt(page) - 1) * parsedLimit
+      : offset
+        ? parseInt(offset)
+        : 0;
+
+    const { companions, total } = await this.usersService.getCompanions({
+      priceMin: priceMin ? parseFloat(priceMin) : undefined,
+      priceMax: priceMax ? parseFloat(priceMax) : undefined,
+      sortBy,
+      search,
+      limit: parsedLimit,
+      offset: parsedOffset,
+    });
+
+    const currentPage = page ? parseInt(page) : Math.floor(parsedOffset / parsedLimit) + 1;
+
+    return {
+      companions: companions.map((c: any) => ({
+        id: c.id,
+        name: c.name,
+        age: c.age,
+        location: c.location,
+        shortBio: c.bio ? c.bio.substring(0, 100) : null,
+        primaryPhoto: c.photos?.[0]?.url || null,
+        hourlyRate: c.hourlyRate != null ? Number(c.hourlyRate) : 0,
+        rating: c.rating ? Number(c.rating) : null,
+        reviewCount: c.reviewCount || 0,
+        isVerified: c.isVerified || false,
+      })),
+      total,
+      page: currentPage,
+      totalPages: Math.ceil(total / parsedLimit),
+    };
+  }
+
+  @UseGuards(JwtAuthGuard)
   @Get()
   async searchCompanions(
     @Request() req,
@@ -87,6 +134,7 @@ export class CompanionsController {
     };
   }
 
+  @UseGuards(JwtAuthGuard)
   @Get(':id')
   async getCompanion(@Param('id', ParseUUIDPipe) id: string) {
     const user = await this.usersService.findById(id);


### PR DESCRIPTION
Tasks #2060 #2061 #2063 #2065: adds GET /api/companions/public (no auth), landing uses it, removes fake '200+ girls', adds refund note