### PR TITLE
fix: Stripe idempotency key for double-payment prevention

### DIFF
--- a/backend/daterabbit-api/src/payments/payments.service.ts
+++ b/backend/daterabbit-api/src/payments/payments.service.ts
@@ -142,7 +142,7 @@ export class PaymentsService {
         seekerId: userId,
         companionId: booking.companionId,
       },
-    });
+    }, { idempotencyKey: bookingId });
 
     await this.bookingsRepo.update(bookingId, {
       paymentIntentId: paymentIntent.id,


### PR DESCRIPTION
Task #2068: Pass booking.id as Stripe idempotency key to prevent race condition on concurrent payment requests