### PR TITLE
feat: booking expiration 24h cron job

### DIFF
--- a/backend/daterabbit-api/src/bookings/bookings.cron.ts
+++ b/backend/daterabbit-api/src/bookings/bookings.cron.ts
@@ -20,6 +20,25 @@ export class BookingsCron {
     private notificationsService: NotificationsService,
   ) {}
 
+  @Cron(CronExpression.EVERY_HOUR)
+  async expirePendingBookings(): Promise<void> {
+    const cutoff = new Date(Date.now() - 24 * 60 * 60 * 1000);
+    const result = await this.bookingsRepository.update(
+      {
+        status: BookingStatus.PENDING,
+        createdAt: LessThan(cutoff),
+      },
+      {
+        status: BookingStatus.CANCELLED,
+        cancellationReason: 'expired: companion did not respond within 24 hours',
+      },
+    );
+    const count = result.affected ?? 0;
+    if (count > 0) {
+      this.logger.log(`[BookingsCron] Expired ${count} pending bookings`);
+    }
+  }
+
   @Cron(CronExpression.EVERY_5_MINUTES)
   async checkNoShows() {
     const fifteenMinutesAgo = new Date(Date.now() - 15 * 60 * 1000);


### PR DESCRIPTION
## Summary
- Task #2072: Auto-cancel pending bookings after 24 hours using existing `BookingsCron`
- Adds `expirePendingBookings()` method with `@Cron(EVERY_HOUR)` decorator
- Bulk UPDATE via TypeORM (no N+1 loop) — sets `status=CANCELLED` and `cancellationReason='expired: companion did not respond within 24 hours'`
- Uses existing `BookingStatus.CANCELLED`, `LessThan` (already imported), `createdAt` field

## Test plan
- [ ] Deploy to staging and verify no PENDING bookings older than 24h remain after next hourly tick
- [ ] Confirm logs show `[BookingsCron] Expired N pending bookings` when records expire