### PR TITLE
fix: AdminGuard isActive+deletedAt checks

### DIFF
--- a/backend/daterabbit-api/src/admin/admin.guard.ts
+++ b/backend/daterabbit-api/src/admin/admin.guard.ts
@@ -36,13 +36,17 @@ export class AdminGuard implements CanActivate {
       throw new UnauthorizedException('Invalid token');
     }
 
-    const user = await this.usersService.findById(payload.id);
+    const user = await this.usersService.findByIdWithDeleted(payload.id);
     if (!user) {
       throw new UnauthorizedException('User not found');
     }
 
     if (!user.isAdmin) {
       throw new ForbiddenException('Admin access required');
+    }
+
+    if (!user.isActive || user.deletedAt) {
+      throw new UnauthorizedException('Account is deactivated');
     }
 
     request.user = user;


### PR DESCRIPTION
Task #2078: Deactivated/deleted admins were retaining /admin/* access. Add isActive+deletedAt checks, switch to findByIdWithDeleted().

## Changes
- Replaced `findById()` with `findByIdWithDeleted()` to catch soft-deleted users
- Added `isActive` and `deletedAt` checks after `isAdmin` check
- Pattern matches JwtStrategy implementation

## Security fix
Deactivated or soft-deleted admin accounts no longer retain access to `/api/admin/*` endpoints.