### PR TITLE
fix: file upload MIME validation and size limits

### DIFF
--- a/backend/daterabbit-api/src/bookings/bookings.module.ts
+++ b/backend/daterabbit-api/src/bookings/bookings.module.ts
@@ -23,6 +23,14 @@ import { PackagesModule } from '../packages/packages.module';
     MulterModule.register({
       limits: { fileSize: 10 * 1024 * 1024 }, // 10MB max
       storage: multer.memoryStorage(),
+      fileFilter: (_req, file, cb) => {
+        const allowed = ['image/jpeg', 'image/png', 'image/webp'];
+        if (allowed.includes(file.mimetype)) {
+          cb(null, true);
+        } else {
+          cb(new Error('Only JPEG, PNG and WebP images are allowed'), false);
+        }
+      },
     }),
     UsersModule,
     EmailModule,

--- a/backend/daterabbit-api/src/users/users.module.ts
+++ b/backend/daterabbit-api/src/users/users.module.ts
@@ -18,6 +18,14 @@ import { NotificationsModule } from '../notifications/notifications.module';
     MulterModule.register({
       limits: { fileSize: 10 * 1024 * 1024 }, // 10MB max
       storage: multer.memoryStorage(),
+      fileFilter: (_req, file, cb) => {
+        const allowed = ['image/jpeg', 'image/png', 'image/webp'];
+        if (allowed.includes(file.mimetype)) {
+          cb(null, true);
+        } else {
+          cb(new Error('Only JPEG, PNG and WebP images are allowed'), false);
+        }
+      },
     }),
     UploadsModule,
     forwardRef(() => NotificationsModule),

--- a/backend/daterabbit-api/src/verification/verification.controller.ts
+++ b/backend/daterabbit-api/src/verification/verification.controller.ts
@@ -9,6 +9,7 @@ import {
   UploadedFile,
   HttpException,
   HttpStatus,
+  BadRequestException,
 } from '@nestjs/common';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
@@ -44,18 +45,21 @@ export class VerificationController {
   @Post('upload-id')
   @UseInterceptors(FileInterceptor('file'))
   uploadId(@Req() req: any, @UploadedFile() file: Express.Multer.File) {
+    if (!file) throw new BadRequestException('No file provided or invalid file type');
     return this.verificationService.uploadIdPhoto(req.user.id, file);
   }
 
   @Post('selfie')
   @UseInterceptors(FileInterceptor('file'))
   uploadSelfie(@Req() req: any, @UploadedFile() file: Express.Multer.File) {
+    if (!file) throw new BadRequestException('No file provided or invalid file type');
     return this.verificationService.uploadSelfie(req.user.id, file);
   }
 
   @Post('video')
   @UseInterceptors(FileInterceptor('file'))
   uploadVideo(@Req() req: any, @UploadedFile() file: Express.Multer.File) {
+    if (!file) throw new BadRequestException('No file provided or invalid file type');
     return this.verificationService.uploadVideo(req.user.id, file);
   }
 

--- a/backend/daterabbit-api/src/verification/verification.module.ts
+++ b/backend/daterabbit-api/src/verification/verification.module.ts
@@ -12,8 +12,16 @@ import { UploadsModule } from '../uploads/uploads.module';
   imports: [
     TypeOrmModule.forFeature([Verification]),
     MulterModule.register({
-      limits: { fileSize: 20 * 1024 * 1024 }, // 20MB max (video verification)
+      limits: { fileSize: 50 * 1024 * 1024 }, // 50MB max (video verification)
       storage: multer.memoryStorage(),
+      fileFilter: (_req, file, cb) => {
+        const allowed = ['image/jpeg', 'image/png', 'image/webp', 'video/mp4', 'video/quicktime'];
+        if (allowed.includes(file.mimetype)) {
+          cb(null, true);
+        } else {
+          cb(new Error('Invalid file type'), false);
+        }
+      },
     }),
     UsersModule,
     UploadsModule,


### PR DESCRIPTION
## Summary

Task #2077: Add Multer-level file type validation and fix size limits.

- `users.module.ts`: Added `fileFilter` allowing only `image/jpeg`, `image/png`, `image/webp`
- `bookings.module.ts`: Same `fileFilter` for images
- `verification.module.ts`: `fileFilter` for images + `video/mp4`, `video/quicktime`; limit raised 20MB → 50MB
- `verification.controller.ts`: Added `!file` guard on `upload-id`, `selfie`, `video` endpoints — throws `BadRequestException` when Multer rejects the file

## Test plan
- [ ] Upload valid JPEG/PNG/WebP to user avatar → accepted
- [ ] Upload PDF/GIF to user avatar → rejected with error
- [ ] Upload MP4 video to verification/video → accepted
- [ ] Upload file >50MB to verification → rejected by size limit
- [ ] POST to /verification/upload-id with no file → 400 BadRequestException

🤖 Generated with [Claude Code](https://claude.com/claude-code)