### PR TITLE
feat: dispute resolution flow

### DIFF
--- a/backend/daterabbit-api/src/admin/admin.controller.ts
+++ b/backend/daterabbit-api/src/admin/admin.controller.ts
@@ -172,6 +172,29 @@ export class AdminController {
     return this.adminService.updateSettings(body);
   }
 
+  // #2071 - disputes
+  @Get('disputes')
+  getDisputes(
+    @Query('status') status?: string,
+    @Query('page', new DefaultValuePipe(1), ParseIntPipe) page = 1,
+    @Query('limit', new DefaultValuePipe(20), ParseIntPipe) limit = 20,
+  ) {
+    return this.adminService.getDisputes(status, page, Math.min(limit, 100));
+  }
+
+  @Get('disputes/:id')
+  getDisputeById(@Param('id', ParseUUIDPipe) id: string) {
+    return this.adminService.getDisputeById(id);
+  }
+
+  @Patch('disputes/:id/resolve')
+  resolveDispute(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() body: { status: 'resolved' | 'closed'; adminNote?: string },
+  ) {
+    return this.adminService.resolveDispute(id, body);
+  }
+
   // #2039 - cities management
   @Get('cities')
   getCities() {

--- a/backend/daterabbit-api/src/admin/admin.module.ts
+++ b/backend/daterabbit-api/src/admin/admin.module.ts
@@ -10,12 +10,13 @@ import { Booking } from '../bookings/entities/booking.entity';
 import { Verification } from '../verification/entities/verification.entity';
 import { Review } from '../reviews/entities/review.entity';
 import { PlatformSettings } from './entities/platform-settings.entity';
+import { Dispute } from '../disputes/entities/dispute.entity';
 import { UsersModule } from '../users/users.module';
 import { CitiesModule } from '../cities/cities.module';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([User, Booking, Verification, Review, PlatformSettings]),
+    TypeOrmModule.forFeature([User, Booking, Verification, Review, PlatformSettings, Dispute]),
     JwtModule.registerAsync({
       imports: [ConfigModule],
       inject: [ConfigService],

--- a/backend/daterabbit-api/src/admin/admin.service.ts
+++ b/backend/daterabbit-api/src/admin/admin.service.ts
@@ -9,6 +9,7 @@ import { PlatformSettings } from './entities/platform-settings.entity';
 import { CitiesService } from '../cities/cities.service';
 import { CreateCityDto } from '../cities/dto/create-city.dto';
 import { UpdateCityDto } from '../cities/dto/update-city.dto';
+import { Dispute, DisputeStatus } from '../disputes/entities/dispute.entity';
 
 @Injectable()
 export class AdminService {
@@ -23,6 +24,8 @@ export class AdminService {
     private reviewsRepo: Repository<Review>,
     @InjectRepository(PlatformSettings)
     private settingsRepo: Repository<PlatformSettings>,
+    @InjectRepository(Dispute)
+    private disputesRepo: Repository<Dispute>,
     private readonly citiesService: CitiesService,
   ) {}
 
@@ -397,6 +400,63 @@ export class AdminService {
 
     await this.settingsRepo.save(settings);
     return this.getSettings();
+  }
+
+  // #2071 - disputes
+  async getDisputes(status: string | undefined, page: number, limit: number) {
+    const skip = (page - 1) * limit;
+    const where = status ? { status: status as DisputeStatus } : {};
+
+    const [items, total] = await this.disputesRepo.findAndCount({
+      where,
+      relations: ['booking', 'booking.seeker', 'booking.companion', 'openedByUser'],
+      order: { createdAt: 'DESC' },
+      skip,
+      take: limit,
+    });
+
+    return { items, total, page, limit };
+  }
+
+  async getDisputeById(id: string) {
+    const dispute = await this.disputesRepo.findOne({
+      where: { id },
+      relations: ['booking', 'booking.seeker', 'booking.companion', 'openedByUser'],
+    });
+
+    if (!dispute) {
+      throw new NotFoundException('Dispute not found');
+    }
+
+    return dispute;
+  }
+
+  async resolveDispute(
+    id: string,
+    data: { status: 'resolved' | 'closed'; adminNote?: string },
+  ) {
+    const dispute = await this.disputesRepo.findOne({ where: { id } });
+    if (!dispute) {
+      throw new NotFoundException('Dispute not found');
+    }
+
+    if (
+      dispute.status === DisputeStatus.RESOLVED ||
+      dispute.status === DisputeStatus.CLOSED
+    ) {
+      throw new BadRequestException(`Dispute is already ${dispute.status}`);
+    }
+
+    const newStatus =
+      data.status === 'resolved' ? DisputeStatus.RESOLVED : DisputeStatus.CLOSED;
+
+    await this.disputesRepo.update(id, {
+      status: newStatus,
+      adminNote: data.adminNote ?? null,
+      resolvedAt: new Date(),
+    });
+
+    return this.getDisputeById(id);
   }
 
   // #2039 - cities management

--- a/backend/daterabbit-api/src/app.module.ts
+++ b/backend/daterabbit-api/src/app.module.ts
@@ -18,6 +18,7 @@ import { CalendarModule } from './calendar/calendar.module';
 import { ReferralModule } from './referral/referral.module';
 import { PackagesModule } from './packages/packages.module';
 import { CitiesModule } from './cities/cities.module';
+import { DisputesModule } from './disputes/disputes.module';
 
 @Module({
   imports: [
@@ -68,6 +69,7 @@ import { CitiesModule } from './cities/cities.module';
     ReferralModule,
     PackagesModule,
     CitiesModule,
+    DisputesModule,
   ],
   providers: [
     {

--- a/backend/daterabbit-api/src/disputes/disputes.controller.ts
+++ b/backend/daterabbit-api/src/disputes/disputes.controller.ts
@@ -1,0 +1,31 @@
+import {
+  Controller,
+  Post,
+  Param,
+  Body,
+  UseGuards,
+  Request,
+  ParseUUIDPipe,
+  HttpException,
+  HttpStatus,
+} from '@nestjs/common';
+import { DisputesService } from './disputes.service';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+
+@Controller('bookings')
+@UseGuards(JwtAuthGuard)
+export class DisputesController {
+  constructor(private readonly disputesService: DisputesService) {}
+
+  @Post(':id/dispute')
+  async createDispute(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Request() req,
+    @Body() body: { reason: string },
+  ) {
+    if (!body.reason || !body.reason.trim()) {
+      throw new HttpException('reason is required', HttpStatus.BAD_REQUEST);
+    }
+    return this.disputesService.createDispute(id, req.user.id, body.reason.trim());
+  }
+}

--- a/backend/daterabbit-api/src/disputes/disputes.module.ts
+++ b/backend/daterabbit-api/src/disputes/disputes.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { DisputesController } from './disputes.controller';
+import { DisputesService } from './disputes.service';
+import { Dispute } from './entities/dispute.entity';
+import { Booking } from '../bookings/entities/booking.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Dispute, Booking])],
+  controllers: [DisputesController],
+  providers: [DisputesService],
+  exports: [DisputesService],
+})
+export class DisputesModule {}

--- a/backend/daterabbit-api/src/disputes/disputes.service.ts
+++ b/backend/daterabbit-api/src/disputes/disputes.service.ts
@@ -1,0 +1,65 @@
+import {
+  Injectable,
+  NotFoundException,
+  ForbiddenException,
+  ConflictException,
+  BadRequestException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, In } from 'typeorm';
+import { Dispute, DisputeStatus } from './entities/dispute.entity';
+import { Booking, BookingStatus } from '../bookings/entities/booking.entity';
+
+const DISPUTABLE_STATUSES: BookingStatus[] = [
+  BookingStatus.CONFIRMED,
+  BookingStatus.PAID,
+  BookingStatus.ACTIVE,
+  BookingStatus.COMPLETED,
+];
+
+@Injectable()
+export class DisputesService {
+  constructor(
+    @InjectRepository(Dispute)
+    private disputesRepo: Repository<Dispute>,
+    @InjectRepository(Booking)
+    private bookingsRepo: Repository<Booking>,
+  ) {}
+
+  async createDispute(bookingId: string, userId: string, reason: string): Promise<Dispute> {
+    const booking = await this.bookingsRepo.findOne({ where: { id: bookingId } });
+    if (!booking) {
+      throw new NotFoundException('Booking not found');
+    }
+
+    if (booking.seekerId !== userId && booking.companionId !== userId) {
+      throw new ForbiddenException('You are not a participant of this booking');
+    }
+
+    if (!DISPUTABLE_STATUSES.includes(booking.status)) {
+      throw new BadRequestException(
+        `Cannot open a dispute for a booking with status "${booking.status}". ` +
+        `Allowed statuses: ${DISPUTABLE_STATUSES.join(', ')}`,
+      );
+    }
+
+    const existing = await this.disputesRepo.findOne({
+      where: {
+        bookingId,
+        status: In([DisputeStatus.OPEN, DisputeStatus.UNDER_REVIEW]),
+      },
+    });
+    if (existing) {
+      throw new ConflictException('An open dispute already exists for this booking');
+    }
+
+    const dispute = this.disputesRepo.create({
+      bookingId,
+      openedByUserId: userId,
+      reason,
+      status: DisputeStatus.OPEN,
+    });
+
+    return this.disputesRepo.save(dispute);
+  }
+}

--- a/backend/daterabbit-api/src/disputes/entities/dispute.entity.ts
+++ b/backend/daterabbit-api/src/disputes/entities/dispute.entity.ts
@@ -1,0 +1,60 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  ManyToOne,
+  JoinColumn,
+} from 'typeorm';
+import { Booking } from '../../bookings/entities/booking.entity';
+import { User } from '../../users/entities/user.entity';
+
+export enum DisputeStatus {
+  OPEN = 'open',
+  UNDER_REVIEW = 'under_review',
+  RESOLVED = 'resolved',
+  CLOSED = 'closed',
+}
+
+@Entity('disputes')
+export class Dispute {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  bookingId: string;
+
+  @ManyToOne(() => Booking)
+  @JoinColumn({ name: 'bookingId' })
+  booking: Booking;
+
+  @Column()
+  openedByUserId: string;
+
+  @ManyToOne(() => User)
+  @JoinColumn({ name: 'openedByUserId' })
+  openedByUser: User;
+
+  @Column({ type: 'text' })
+  reason: string;
+
+  @Column({
+    type: 'enum',
+    enum: DisputeStatus,
+    default: DisputeStatus.OPEN,
+  })
+  status: DisputeStatus;
+
+  @Column({ type: 'text', nullable: true })
+  adminNote: string | null;
+
+  @Column({ type: 'timestamp', nullable: true })
+  resolvedAt: Date | null;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}


### PR DESCRIPTION
## Summary

Task #2071: Dispute resolution flow

- New `Dispute` entity (separate `disputes` table, no changes to `Booking`)
- `DisputeStatus` enum: `open`, `under_review`, `resolved`, `closed`
- `POST /bookings/:id/dispute` (JWT-protected) — opens a dispute; validates booking ownership, status (confirmed/paid/active/completed), and no existing open/under_review dispute (409 if conflict)
- `GET /admin/disputes` — paginated list with optional `?status=` filter
- `GET /admin/disputes/:id` — full dispute with booking + users relations
- `PATCH /admin/disputes/:id/resolve` — set status to `resolved` or `closed`, optional `adminNote`, sets `resolvedAt`
- `DisputesModule` registered in `app.module.ts`
- `Dispute` entity added to `AdminModule` TypeORM feature list

## Test plan

- [ ] POST /bookings/:id/dispute returns 201 for valid booking participant
- [ ] Returns 403 if caller is not seeker or companion
- [ ] Returns 400 if booking status is pending/cancelled
- [ ] Returns 409 if open dispute already exists
- [ ] GET /admin/disputes returns paginated list
- [ ] PATCH /admin/disputes/:id/resolve sets status + resolvedAt