### PR TITLE
feat(companions): onboarding completion gate before profile publish

### DIFF
--- a/app/app/settings/index.tsx
+++ b/app/app/settings/index.tsx
@@ -64,6 +64,22 @@ export default function SettingsScreen() {
   };
 
   const togglePublicProfile = async (value: boolean) => {
+    // Companion profile completion gate — checked client-side before API call
+    if (value && user?.role === 'companion') {
+      const missing: string[] = [];
+      if (!user.photos || user.photos.length === 0) missing.push('Upload at least one photo');
+      if (user.verificationStatus !== 'approved') missing.push('Complete identity verification');
+      if (!user.hourlyRate || Number(user.hourlyRate) <= 0) missing.push('Set your hourly rate');
+      if (!user.bio || !user.bio.trim()) missing.push('Add a bio');
+      if (missing.length > 0) {
+        showAlert(
+          'Profile incomplete',
+          `To publish your profile, please:\n\n• ${missing.join('\n• ')}`,
+        );
+        return;
+      }
+    }
+
     const prev = isPublicProfile;
     setIsPublicProfile(value);
     const result = await updateProfile({ isPublicProfile: value });

--- a/app/src/services/api.ts
+++ b/app/src/services/api.ts
@@ -840,6 +840,7 @@ export interface User {
   verificationStatus?: import('../types').VerificationStatus;
   photos?: { id: string; url: string; order: number; isPrimary: boolean }[];
   stripeOnboardingComplete?: boolean;
+  isPublicProfile?: boolean;
   expoPushToken?: string;
   notificationsEnabled?: boolean;
   notificationPreferences?: {

--- a/app/src/store/authStore.ts
+++ b/app/src/store/authStore.ts
@@ -89,6 +89,7 @@ function mapApiUserToUser(apiUser: ApiUser): User {
     isVerified: apiUser.isVerified,
     verificationStatus: apiUser.verificationStatus as VerificationStatus | undefined,
     stripeOnboardingComplete: apiUser.stripeOnboardingComplete,
+    isPublicProfile: apiUser.isPublicProfile,
     latitude: apiUser.latitude,
     longitude: apiUser.longitude,
     notificationsEnabled: apiUser.notificationsEnabled,

--- a/backend/daterabbit-api/src/users/users.controller.ts
+++ b/backend/daterabbit-api/src/users/users.controller.ts
@@ -4,6 +4,7 @@ import { UsersService } from './users.service';
 import { UploadsService } from '../uploads/uploads.service';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { UpdateUserDto } from './dto/update-user.dto';
+import { UserRole, UserVerificationStatus } from './entities/user.entity';
 
 @Controller('users')
 export class UsersController {
@@ -46,6 +47,30 @@ export class UsersController {
       }
       if (hourlyRate >= 10000) {
         throw new BadRequestException('Hourly rate must be less than 10000');
+      }
+    }
+
+    // Companion onboarding completion gate — enforce when trying to publish profile
+    if (isPublicProfile === true) {
+      const currentUser = await this.usersService.findById(req.user.id);
+      if (currentUser && currentUser.role === UserRole.COMPANION) {
+        // Determine effective values: prefer incoming body values, fall back to current
+        const effectivePhotos = photos !== undefined ? photos : currentUser.photos;
+        const effectiveBio = bio !== undefined ? bio : currentUser.bio;
+        const effectiveHourlyRate = hourlyRate !== undefined ? hourlyRate : currentUser.hourlyRate;
+
+        if (!effectivePhotos || effectivePhotos.length === 0) {
+          throw new BadRequestException('Upload at least one photo before publishing your profile');
+        }
+        if (currentUser.verificationStatus !== UserVerificationStatus.APPROVED) {
+          throw new BadRequestException('Complete identity verification before publishing your profile');
+        }
+        if (!effectiveHourlyRate || Number(effectiveHourlyRate) <= 0) {
+          throw new BadRequestException('Set your hourly rate before publishing your profile');
+        }
+        if (!effectiveBio || !effectiveBio.trim()) {
+          throw new BadRequestException('Add a bio before publishing your profile');
+        }
       }
     }
 


### PR DESCRIPTION
## Summary

- Backend gate in `PUT /users/me`: when `isPublicProfile=true` and user is companion, validates 4 conditions before allowing publish — photo uploaded, identity verification approved, hourly rate set, bio filled
- Frontend pre-check in Settings `togglePublicProfile`: shows all missing items as bullet list before API call
- Fixes missing `isPublicProfile` field in `ApiUser` interface and `mapApiUserToUser` mapping

## Gate conditions (companion only)

1. `photos.length > 0` — at least one photo uploaded
2. `verificationStatus === 'approved'` — identity verification complete
3. `hourlyRate > 0` — hourly rate configured
4. `bio.trim() !== ''` — bio is non-empty

Seekers are unaffected. All conditions use effective values (incoming body takes precedence over DB values for the current request).

## Test plan

- [ ] Companion with empty profile tries to toggle Public Profile ON → blocked with list of missing items
- [ ] Companion fills all 4 fields → can publish profile successfully
- [ ] Seeker can update profile without any gate checks
- [ ] Direct API call `PUT /users/me` with `isPublicProfile: true` on incomplete companion profile → 400 with clear message

Closes #2074

🤖 Generated with [Claude Code](https://claude.com/claude-code)