### PR TITLE
feat(legal): Terms / Privacy / Safety real content + Safety links everywhere

### DIFF
--- a/app/app/(tabs)/female/profile.tsx
+++ b/app/app/(tabs)/female/profile.tsx
@@ -116,6 +116,8 @@ export default function FemaleProfileScreen() {
           <MenuItem icon="file-text" label="Terms of Service" onPress={() => router.push('/terms')} colors={colors} />
           <View style={[styles.divider, { backgroundColor: colors.border }]} />
           <MenuItem icon="shield" label="Privacy Policy" onPress={() => router.push('/privacy')} colors={colors} />
+          <View style={[styles.divider, { backgroundColor: colors.border }]} />
+          <MenuItem icon="alert" label="Safety Guidelines" onPress={() => router.push('/safety')} colors={colors} />
         </Card>
       </View>
 

--- a/app/app/(tabs)/male/profile.tsx
+++ b/app/app/(tabs)/male/profile.tsx
@@ -148,6 +148,8 @@ export default function MaleProfileScreen() {
           <MenuItem icon="file-text" label="Terms of Service" onPress={() => router.push('/terms')} colors={colors} />
           <View style={[styles.divider, { backgroundColor: colors.border }]} />
           <MenuItem icon="shield" label="Privacy Policy" onPress={() => router.push('/privacy')} colors={colors} />
+          <View style={[styles.divider, { backgroundColor: colors.border }]} />
+          <MenuItem icon="alert" label="Safety Guidelines" onPress={() => router.push('/safety')} colors={colors} />
         </Card>
       </View>
 

--- a/app/app/privacy.tsx
+++ b/app/app/privacy.tsx
@@ -23,54 +23,56 @@ export default function PrivacyScreen() {
         style={styles.scrollView}
         contentContainerStyle={[styles.content, { paddingBottom: insets.bottom + spacing.xl }]}
       >
-        <Text style={[styles.lastUpdated, { color: colors.textSecondary }]}>Last updated: February 2026</Text>
+        <Text style={[styles.lastUpdated, { color: colors.textSecondary }]}>Last updated: April 2026</Text>
 
         <Section title="1. Information We Collect" colors={colors}>
-          We collect information you provide during registration (name, email, date of birth, location), profile data (photos, bio, hourly rate for companions), and usage data (bookings, messages, reviews).
+          We collect the following categories of data: (a) Account data — name, email address, date of birth, city/location; (b) Profile data — photos, bio, and hourly rate (Companions only); (c) Identity documents — government-issued ID and selfie, processed by Stripe Identity for verification purposes; (d) Payment data — billing details processed by Stripe (we never store card numbers); (e) Usage data — bookings, in-app messages, reviews, and activity logs; (f) Device data — push notification tokens via Expo, IP address, and device type for security and support.
         </Section>
 
         <Section title="2. How We Use Your Information" colors={colors}>
-          Your information is used to: provide and improve our services, facilitate bookings between users, process payments, send important notifications, and ensure platform safety.
+          We use your data to: provide and operate the Platform; match Seekers with Companions based on location and preferences; process payments and payouts via Stripe; send transactional emails (OTP codes, booking confirmations) via Brevo; deliver push notifications via Expo; enforce safety policies and investigate reports; comply with legal obligations; and improve Platform features through anonymized analytics.
         </Section>
 
-        <Section title="3. Identity Verification" colors={colors}>
-          For safety, we require identity verification (government ID and selfie). Verification data is processed securely and used solely for identity confirmation. We do not store raw ID images after verification is complete.
+        <Section title="3. Identity Verification & ID Documents" colors={colors}>
+          Identity verification is required for all users. Government-issued ID and selfie images are submitted to Stripe Identity, which performs the verification check. DateRabbit does not store raw ID images on our servers after verification is complete. Stripe's handling of your documents is governed by Stripe's Privacy Policy (stripe.com/privacy). Verification status (approved/rejected) is stored by DateRabbit to enforce access controls.
         </Section>
 
-        <Section title="4. Information Sharing" colors={colors}>
-          We share limited profile information with other users (name, photos, bio, rating). Payment information is processed by Stripe and never stored on our servers. We do not sell your personal data to third parties.
+        <Section title="4. Third-Party Service Providers" colors={colors}>
+          We share data with trusted service providers solely to operate the Platform: Stripe (payment processing and identity verification), Brevo (transactional email delivery), and Expo (push notification delivery). These providers act as data processors under our instruction. We do not sell your personal data to advertisers or data brokers.
+
+          Limited profile information (name, photos, bio, city, and rating) is visible to other logged-in users of the Platform as part of normal matching functionality.
         </Section>
 
         <Section title="5. Location Data" colors={colors}>
-          Location data is used to show nearby companions and calculate distances. You can control location permissions through your device settings. We do not track your location in the background.
+          Location data (city-level) is collected at registration to show nearby Companions. Precise real-time location is requested only if you choose to enable location features. We do not track your precise location in the background. You can revoke location permissions at any time through your device settings.
         </Section>
 
         <Section title="6. Messages & Communications" colors={colors}>
-          Messages between users are stored securely on our servers. We may review messages if a safety concern is reported. We send transactional emails (booking confirmations, OTP codes) to your registered email.
+          In-app messages between users are stored securely on our servers and encrypted in transit. We may review message content if a safety concern is reported or if required by law. We send transactional emails (OTP codes, booking confirmations, payout notifications) to your registered email. We do not send marketing emails without your explicit consent.
         </Section>
 
         <Section title="7. Data Retention" colors={colors}>
-          Account data is retained while your account is active. Upon account deletion, personal data is removed within 30 days. Anonymized usage data may be retained for analytics.
+          We retain your personal data for as long as your account is active. Upon account deletion, personal data is removed from active systems within 30 days. Certain records may be retained for up to 3 years after account deletion to comply with legal and financial obligations (e.g., payment records, dispute logs). Anonymized usage data may be retained indefinitely for analytics purposes.
         </Section>
 
         <Section title="8. Data Security" colors={colors}>
-          We use industry-standard security measures including encryption in transit (TLS), secure password hashing, and access controls. Despite our efforts, no system is 100% secure.
+          We use industry-standard security measures including: TLS encryption for all data in transit; AES-256 encryption for sensitive data at rest; strict access controls limiting employee access to personal data; regular security assessments. Despite these measures, no system is 100% secure. If you discover a security vulnerability, please report it to security@daterabbit.app immediately.
         </Section>
 
-        <Section title="9. Your Rights" colors={colors}>
-          You have the right to: access your personal data, correct inaccurate data, delete your account and data, export your data, and opt out of marketing communications.
+        <Section title="9. Your Privacy Rights" colors={colors}>
+          You have the right to: access a copy of your personal data; correct inaccurate information in your profile; request deletion of your account and associated data; export your data in a portable format; opt out of marketing communications; and withdraw consent for optional data processing. To exercise these rights, contact privacy@daterabbit.app or use the account settings in the app.
         </Section>
 
-        <Section title="10. Cookies & Analytics" colors={colors}>
-          We use essential cookies for authentication and session management. We may use analytics tools to understand usage patterns. You can control cookies through your browser settings.
+        <Section title="10. Children's Privacy" colors={colors}>
+          DateRabbit is strictly for adults. We do not knowingly collect personal data from anyone under 18 years of age. If we become aware that an underage user has created an account, we will immediately terminate the account and delete all associated data. If you believe a minor has registered, please contact us at privacy@daterabbit.app.
         </Section>
 
-        <Section title="11. Children's Privacy" colors={colors}>
-          DateRabbit is not intended for users under 18. We do not knowingly collect data from minors. If we discover an underage account, it will be immediately terminated.
+        <Section title="11. Changes to This Policy" colors={colors}>
+          We may update this Privacy Policy from time to time. Material changes will be communicated via email or in-app notification at least 14 days before taking effect. Continued use of the Platform after changes constitutes acceptance of the updated policy.
         </Section>
 
         <Section title="12. Contact" colors={colors}>
-          For privacy inquiries, contact us at privacy@daterabbit.com.
+          {'For privacy inquiries, data requests, or to report concerns:\nprivacy@daterabbit.app\n\nDateRabbit, Inc. (Delaware)'}
         </Section>
       </ScrollView>
     </View>

--- a/app/app/safety.tsx
+++ b/app/app/safety.tsx
@@ -23,38 +23,46 @@ export default function SafetyScreen() {
         style={styles.scrollView}
         contentContainerStyle={[styles.content, { paddingBottom: insets.bottom + spacing.xl }]}
       >
-        <Text style={[styles.lastUpdated, { color: colors.textSecondary }]}>Last updated: March 2026</Text>
+        <Text style={[styles.lastUpdated, { color: colors.textSecondary }]}>Last updated: April 2026</Text>
 
-        <Section title="1. Identity Verification" colors={colors}>
-          All companions are required to verify their identity with a government-issued ID and a live selfie before they can accept bookings. Seekers also complete verification to ensure a safe experience for everyone.
+        <Section title="1. Identity Verification for Everyone" colors={colors}>
+          All Companions must verify their identity with a government-issued ID and a live selfie before accepting bookings. All Seekers (men booking dates) must complete ID verification via Stripe Identity before making their first booking. This two-way verification ensures both parties know who they're meeting. Verified status is displayed on every profile.
         </Section>
 
-        <Section title="2. Secure Payments" colors={colors}>
-          All payments are processed through Stripe. We never store your card details on our servers. Funds are held securely until the date is confirmed complete.
+        <Section title="2. Meet in Public First" colors={colors}>
+          Always meet your date in a public, well-lit location for the first time. Choose restaurants, cafes, or other busy venues. Avoid meeting at private residences for initial bookings. DateRabbit recommends selecting public venues when submitting booking details. Trust your instincts — if something feels off, it's okay to leave.
         </Section>
 
-        <Section title="3. Safety Check-Ins" colors={colors}>
-          During active dates, both parties receive periodic safety check-ins. If a check-in is missed or a concern is flagged, our support team is notified immediately.
+        <Section title="3. Share Your Plans" colors={colors}>
+          Before every date, share the booking details with a trusted friend or family member: the other person's name, profile, meeting location, and expected return time. DateRabbit's app allows you to share your date summary directly from the booking screen. Check in with your contact after the date ends.
         </Section>
 
-        <Section title="4. Reporting & Blocking" colors={colors}>
-          You can report or block any user at any time. Reports are reviewed by our team within 24 hours. Serious violations result in immediate account suspension.
+        <Section title="4. Safety Check-Ins During Active Dates" colors={colors}>
+          During an active booking, both Seekers and Companions receive periodic safety check-ins through the app. If a check-in is missed or you flag a concern, our support team is notified immediately. The in-app SOS button connects you directly to emergency services and alerts DateRabbit's safety team simultaneously. Use it if you ever feel in danger — no questions asked.
         </Section>
 
-        <Section title="5. Date Details Shared Safely" colors={colors}>
-          Date location and time details are only shared with confirmed booking participants. You can share your date details with a trusted contact for added peace of mind.
+        <Section title="5. No Cash. Platform Payments Only." colors={colors}>
+          All payments must go through DateRabbit. Never accept or make cash payments outside the Platform. Accepting off-platform payments puts you at risk of fraud and violates our Terms of Service. If anyone pressures you to pay or accept cash, report it immediately. Companions are paid automatically by Stripe — no cash handling required.
         </Section>
 
-        <Section title="6. 24/7 Support" colors={colors}>
-          Our safety and support team is available around the clock. If you ever feel unsafe, you can reach us instantly through the app.
+        <Section title="6. Secure Payments via Stripe" colors={colors}>
+          DateRabbit uses Stripe to process all payments. We never store your card number or full payment details on our servers. Companion earnings are held securely until the date is confirmed complete, then released to the Companion's Stripe account. Seekers receive a full refund if a Companion cancels or fails to appear.
         </Section>
 
-        <Section title="7. Community Guidelines" colors={colors}>
-          All users must follow our community guidelines, which prohibit harassment, discrimination, and inappropriate behavior. Violations lead to warnings, suspensions, or permanent bans.
+        <Section title="7. Reporting & Blocking" colors={colors}>
+          You can report or block any user at any time, directly from their profile or from within a booking. All reports are reviewed by our safety team within 24 hours. Serious violations — including harassment, threatening behavior, solicitation, or assault — result in immediate account suspension and may be reported to law enforcement. Your identity is never disclosed to the user you report.
         </Section>
 
-        <Section title="8. Contact" colors={colors}>
-          For safety concerns, contact us at safety@daterabbit.com.
+        <Section title="8. Zero Tolerance Policies" colors={colors}>
+          DateRabbit has zero tolerance for: sexual solicitation or sex work of any kind; physical or sexual assault; harassment, stalking, or threatening behavior; sharing another user's personal information without consent; and discrimination based on race, gender, sexuality, religion, or national origin. Violations result in permanent account bans and may be escalated to law enforcement.
+        </Section>
+
+        <Section title="9. Community Standards" colors={colors}>
+          All users must treat each other with respect. Companions have the right to decline or cancel any booking at any time without explanation. Seekers must respect Companion boundaries and cancellation decisions. Rudeness, pressure, or intimidation of any kind is prohibited. DateRabbit's community thrives when everyone feels safe and respected.
+        </Section>
+
+        <Section title="10. 24/7 Safety Support" colors={colors}>
+          {'Our safety and support team is available 24 hours a day, 7 days a week.\n\nIn-app: Use the Help button in any active booking\nEmail: support@daterabbit.app\nEmergency: Always call 911 if you are in immediate danger'}
         </Section>
       </ScrollView>
     </View>

--- a/app/app/settings/index.tsx
+++ b/app/app/settings/index.tsx
@@ -198,6 +198,13 @@ export default function SettingsScreen() {
               onPress={() => router.push('/privacy')}
               colors={colors}
             />
+            <View style={[styles.divider, { backgroundColor: colors.divider }]} />
+            <SettingsMenuItem
+              icon="alert"
+              label="Safety Guidelines"
+              onPress={() => router.push('/safety')}
+              colors={colors}
+            />
           </Card>
         </View>
 

--- a/app/app/terms.tsx
+++ b/app/app/terms.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View, Text, StyleSheet, ScrollView, TouchableOpacity, Platform } from 'react-native';
+import { View, Text, StyleSheet, ScrollView, TouchableOpacity } from 'react-native';
 import { router } from 'expo-router';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Icon } from '../src/components/Icon';
@@ -23,50 +23,60 @@ export default function TermsScreen() {
         style={styles.scrollView}
         contentContainerStyle={[styles.content, { paddingBottom: insets.bottom + spacing.xl }]}
       >
-        <Text style={[styles.lastUpdated, { color: colors.textSecondary }]}>Last updated: February 2026</Text>
+        <Text style={[styles.lastUpdated, { color: colors.textSecondary }]}>Last updated: April 2026</Text>
 
         <Section title="1. Acceptance of Terms" colors={colors}>
-          By accessing or using DateRabbit ("the Platform"), you agree to be bound by these Terms of Service. If you do not agree, do not use the Platform.
+          By accessing or using DateRabbit ("the Platform," "we," "us," or "our"), you agree to be bound by these Terms of Service ("Terms"). If you do not agree to these Terms in their entirety, you must not access or use the Platform. These Terms constitute a legally binding agreement between you and DateRabbit, Inc., a Delaware corporation.
         </Section>
 
         <Section title="2. Eligibility" colors={colors}>
-          You must be at least 18 years old to use DateRabbit. By registering, you confirm that you meet this age requirement and that all information you provide is accurate.
+          You must be at least 18 years of age to use DateRabbit. Seekers (users who book Companions) must be at least 21 years of age and complete government-issued ID verification before their first booking. The Platform is available only to residents of the United States. By registering, you represent and warrant that you meet all eligibility requirements and that all information you provide is accurate, current, and complete.
         </Section>
 
-        <Section title="3. Account Registration" colors={colors}>
-          You are responsible for maintaining the confidentiality of your account credentials. You agree to notify us immediately of any unauthorized use of your account.
+        <Section title="3. Platform Description" colors={colors}>
+          DateRabbit is a paid companion platform that connects Seekers with Companions for in-person social and dating experiences in the United States. Seekers are users who pay to book time with Companions. Companions are users who set their own rates and availability and earn income through the Platform. DateRabbit facilitates bookings, handles payments via Stripe, and provides safety tools — but is not a party to any arrangement, agreement, or interaction between users.
         </Section>
 
-        <Section title="4. Platform Services" colors={colors}>
-          DateRabbit connects seekers with companions for social experiences. The Platform facilitates bookings, payments, and communication between users. DateRabbit is not a party to any arrangement between users.
+        <Section title="4. User Roles" colors={colors}>
+          Seekers: Browse Companion profiles, book sessions, and pay through the Platform. Seekers must complete ID verification (Stripe Identity) before their first booking. Cancellation policies apply per each booking as disclosed at checkout.
+
+          Companions: Set hourly rates, availability, and session preferences. Companions must complete identity verification (government ID + selfie) before accepting bookings. Companions are independent contractors, not employees of DateRabbit.
         </Section>
 
-        <Section title="5. Companion Guidelines" colors={colors}>
-          Companions set their own hourly rates and availability. Companions must complete identity verification before accepting bookings. All interactions must remain respectful and within legal boundaries.
+        <Section title="5. Payments & Platform Fee" colors={colors}>
+          All payments are processed securely via Stripe. DateRabbit charges a 15% platform service fee on each booking, deducted from the Companion's earnings. Seekers are charged the full booking amount at the time of booking. Companions receive payouts within 2 business days of a completed date, subject to Stripe's payout schedule. No cash exchanges between users are permitted. Circumventing the Platform's payment system is grounds for immediate account termination.
         </Section>
 
-        <Section title="6. Seeker Guidelines" colors={colors}>
-          Seekers must complete identity verification before booking. Cancellation policies apply as described in each booking. Harassment or inappropriate behavior will result in account termination.
+        <Section title="6. Prohibited Conduct" colors={colors}>
+          Users are strictly prohibited from: (a) soliciting, facilitating, or engaging in any form of sexual services or sex work; (b) exchanging money outside the Platform; (c) harassing, threatening, or discriminating against other users; (d) creating fake accounts or misrepresenting identity; (e) sharing another user's personal information without consent; (f) using the Platform for any illegal activity; (g) attempting to circumvent safety or verification systems; or (h) violating any applicable federal, state, or local law. Violations will result in immediate account suspension and may be reported to law enforcement.
         </Section>
 
-        <Section title="7. Payments & Fees" colors={colors}>
-          A 15% service fee is applied to all bookings. Payments are processed securely through Stripe. Refunds are handled on a case-by-case basis according to our cancellation policy.
+        <Section title="7. Identity Verification" colors={colors}>
+          DateRabbit uses Stripe Identity for identity verification. By submitting verification documents, you consent to Stripe's processing of your personal data per Stripe's Privacy Policy. DateRabbit does not store raw ID images after verification is complete. Falsifying identity documents or providing false information during verification is a violation of these Terms and may constitute a federal crime.
         </Section>
 
-        <Section title="8. Prohibited Conduct" colors={colors}>
-          Users may not: solicit illegal activities, harass other users, create fake accounts, circumvent Platform payments, or share another user's personal information without consent.
+        <Section title="8. Safety & Reporting" colors={colors}>
+          DateRabbit provides in-app safety tools including safety check-ins and an SOS feature during active bookings. Users are encouraged to meet in public places and share date details with trusted contacts. Any user who experiences or witnesses unsafe behavior must report it immediately via the in-app report function. DateRabbit reviews all reports within 24 hours. Serious safety violations result in immediate account suspension.
         </Section>
 
         <Section title="9. Account Termination" colors={colors}>
-          We reserve the right to suspend or terminate accounts that violate these Terms. You may delete your account at any time through the Settings page.
+          DateRabbit reserves the right to suspend, restrict, or permanently terminate any account at our sole discretion, with or without notice, for violation of these Terms or for any conduct we deem harmful to the Platform or its users. You may delete your account at any time through Settings. Upon deletion, your data is removed within 30 days in accordance with our Privacy Policy.
         </Section>
 
-        <Section title="10. Limitation of Liability" colors={colors}>
-          DateRabbit is not liable for any interactions between users. We provide the Platform "as is" without warranties of any kind.
+        <Section title="10. Disclaimers & Limitation of Liability" colors={colors}>
+          The Platform is provided "as is" without warranties of any kind, express or implied. DateRabbit is not responsible for the conduct, actions, or safety of any user. To the maximum extent permitted by law, DateRabbit's liability to you for any claim arising out of these Terms or your use of the Platform shall not exceed the greater of $100 or the amount you paid to DateRabbit in the past 12 months. DateRabbit is not liable for indirect, incidental, punitive, or consequential damages.
         </Section>
 
-        <Section title="11. Contact" colors={colors}>
-          For questions about these Terms, contact us at support@daterabbit.com.
+        <Section title="11. Dispute Resolution & Governing Law" colors={colors}>
+          These Terms are governed by and construed in accordance with the laws of the State of Delaware, without regard to conflict of law principles. Any disputes arising out of or relating to these Terms or the Platform shall first be submitted to DateRabbit's in-app dispute resolution system. Unresolved disputes shall be settled by binding individual arbitration in Wilmington, Delaware, under the rules of the American Arbitration Association. You waive the right to participate in class action lawsuits.
+        </Section>
+
+        <Section title="12. Changes to Terms" colors={colors}>
+          We may update these Terms at any time. Continued use of the Platform after changes constitutes acceptance of the updated Terms. Material changes will be communicated via email or in-app notification at least 14 days before taking effect.
+        </Section>
+
+        <Section title="13. Contact" colors={colors}>
+          {'DateRabbit, Inc. (Delaware)\nFor questions about these Terms: legal@daterabbit.app\nFor general support: support@daterabbit.app'}
         </Section>
       </ScrollView>
     </View>


### PR DESCRIPTION
## Summary

- **terms.tsx**: Full US legal content — 13 sections covering platform description, user roles (Seekers 21+ / Companions), payment terms (15% fee via Stripe), prohibited conduct (no sex work, no off-platform cash), Delaware governing law, AAA arbitration, limitation of liability
- **privacy.tsx**: Comprehensive Privacy Policy — data collected (name, email, ID via Stripe Identity), third parties (Stripe, Brevo, Expo), 3-year post-deletion retention, user rights (access/delete/export), security (TLS + AES-256), children's privacy
- **safety.tsx**: Actionable Safety Guidelines — 10 sections covering meet-in-public rule, share plans, safety check-ins + SOS button, no cash policy, Stripe payments, reporting/blocking, zero tolerance policies, 24/7 support contacts
- **settings/index.tsx**: Added "Safety Guidelines" menu item in Legal section
- **(tabs)/male/profile.tsx**: Added "Safety Guidelines" link in legal card
- **(tabs)/female/profile.tsx**: Added "Safety Guidelines" link in legal card

## What was already working
- Routes `/terms`, `/privacy`, `/safety` auto-work via Expo Router (files exist in `app/`)
- Footer in landing page already had all 3 links
- Register screen already had Terms + Privacy consent links
- Settings already had Terms + Privacy (Safety was missing)

## Test plan
- [ ] Navigate to Settings → Legal → verify all 3 links work
- [ ] Open male profile tab → bottom legal card → verify 3 links
- [ ] Open female profile tab → bottom legal card → verify 3 links
- [ ] Visit /terms, /privacy, /safety — verify content renders, back button works

🤖 Generated with [Claude Code](https://claude.com/claude-code)