### PR TITLE
fix(security): add JwtAuthGuard to GET /users/:id

### DIFF
--- a/backend/daterabbit-api/src/users/users.controller.ts
+++ b/backend/daterabbit-api/src/users/users.controller.ts
@@ -215,6 +215,7 @@ export class UsersController {
     return { success: true };
   }
 
+  @UseGuards(JwtAuthGuard)
   @Get(':id')
   async getUserById(@Param('id', ParseUUIDPipe) id: string) {
     const user = await this.usersService.findById(id);


### PR DESCRIPTION
## Summary
- GET /users/:id was missing `@UseGuards(JwtAuthGuard)`, allowing unauthenticated access to PII (name, role, age, location, bio, photos, hourlyRate, isVerified)
- Added `@UseGuards(JwtAuthGuard)` decorator to `getUserById` method — no other changes
- JwtAuthGuard was already imported; no new imports needed
- Route order preserved — decorator added in-place above existing `@Get(':id')`

## Test plan
- [ ] `curl -s -o /dev/null -w "%{http_code}" https://daterabbit-api.smartlaunchhub.com/api/users/<uuid>` → must return 401
- [ ] Same request with valid `Authorization: Bearer <token>` → must return 200 with profile data

Fixes #2080