### PR TITLE
feat: role-select value prop + card height fix (#2088)

### DIFF
--- a/app/app/(auth)/role-select.tsx
+++ b/app/app/(auth)/role-select.tsx
@@ -26,6 +26,12 @@ export default function RoleSelectScreen() {
         <Text style={[styles.backText, { color: colors.primary }]}> Back</Text>
       </TouchableOpacity>
 
+      <View style={styles.hero}>
+        <Text style={[styles.heroLogo, { color: colors.primary }]}>DateRabbit</Text>
+        <Text style={[styles.heroTagline, { color: colors.text }]}>Real dates. Real connections.</Text>
+        <Text style={[styles.heroSubtext, { color: colors.textMuted }]}>Verified companions. On your schedule.</Text>
+      </View>
+
       <View style={styles.content}>
         <Text style={[styles.title, { color: colors.text }]}>Join as...</Text>
         <Text style={[styles.subtitle, { color: colors.textSecondary }]}>
@@ -99,6 +105,30 @@ const styles = StyleSheet.create({
     fontFamily: typography.fonts.bodyMedium,
     fontSize: typography.sizes.md,
   },
+  hero: {
+    alignItems: 'center',
+    marginBottom: spacing.xl,
+    paddingVertical: spacing.md,
+  },
+  heroLogo: {
+    fontFamily: typography.fonts.heading,
+    fontSize: typography.sizes.display,
+    fontWeight: '700',
+    letterSpacing: -1,
+    marginBottom: spacing.xs,
+  },
+  heroTagline: {
+    fontFamily: typography.fonts.headingMedium,
+    fontSize: typography.sizes.lg,
+    fontWeight: '600',
+    textAlign: 'center',
+    marginBottom: spacing.xs,
+  },
+  heroSubtext: {
+    fontFamily: typography.fonts.body,
+    fontSize: typography.sizes.sm,
+    textAlign: 'center',
+  },
   content: {
     flex: 1,
   },
@@ -137,6 +167,7 @@ const styles = StyleSheet.create({
   },
   roleInfo: {
     marginBottom: spacing.md,
+    minHeight: 60,
   },
   roleTitle: {
     fontFamily: typography.fonts.headingMedium,


### PR DESCRIPTION
## Summary

- Adds centered hero section above role cards: logo text "DateRabbit" (primary color), tagline "Real dates. Real connections.", subtext "Verified companions. On your schedule."
- Fixes card height asymmetry: adds `minHeight: 60` to `roleInfo` style so both cards render at identical heights regardless of description line count

## UI-only change — no logic, routing, or functionality touched

## Test plan
- [ ] Open role-select screen — hero section visible above cards
- [ ] Both "Date Companion" and "Date Seeker" cards have equal height
- [ ] Tagline and subtext use correct theme colors (primary / textMuted)

Closes #2088