### PR TITLE
fix: companion cards expo-image with onError fallback (#2093)

### DIFF
--- a/app/app/landing/index.tsx
+++ b/app/app/landing/index.tsx
@@ -8,6 +8,7 @@ import {
   ScrollView,
   TouchableOpacity,
 } from 'react-native';
+import { Image as ExpoImage } from 'expo-image';
 import { router } from 'expo-router';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { LinearGradient } from 'expo-linear-gradient';
@@ -310,6 +311,7 @@ function FemaleLanding() {
 function MaleLanding() {
   const [companions, setCompanions] = useState<CompanionListItem[]>([]);
   const [loadingCompanions, setLoadingCompanions] = useState(true);
+  const [failedPhotos, setFailedPhotos] = useState<Set<string>>(new Set());
 
   useEffect(() => {
     const fetchCompanions = async () => {
@@ -411,11 +413,12 @@ function MaleLanding() {
                 accessibilityRole="button"
               >
                 {/* Photo or initial circle */}
-                {p.photo ? (
-                  <Image
+                {p.photo && !failedPhotos.has(p.id) ? (
+                  <ExpoImage
                     source={{ uri: p.photo }}
                     style={styles.profileCardPhoto}
-                    resizeMode="cover"
+                    contentFit="cover"
+                    onError={() => setFailedPhotos(prev => { const next = new Set(prev); next.add(p.id); return next; })}
                   />
                 ) : (
                   <View style={[styles.profileCardPhoto, styles.profileCardPhotoPlaceholder, { backgroundColor: p.color + '20' }]}>


### PR DESCRIPTION
## Summary
- Switches companion photo display in `MaleLanding` from RN `Image` to `expo-image`'s `Image`
- Adds `failedPhotos: Set<string>` state per component instance
- On photo load error, card's id is added to `failedPhotos` and the initial-letter placeholder is shown instead

## Test plan
- [ ] Open landing page as male view
- [ ] Cards with valid photos should display normally
- [ ] Cards whose photo URL returns 4xx/5xx should show the initial-letter circle fallback
- [ ] No visual regression on cards without photos (placeholders still show initials)