### PR TITLE
fix: debounce offline detection — no false banner on load (#2086)

### DIFF
--- a/app/app/_layout.tsx
+++ b/app/app/_layout.tsx
@@ -26,8 +26,11 @@ function useWebNetworkStatus() {
     const handleOffline = () => setOffline();
     window.addEventListener('online', handleOnline);
     window.addEventListener('offline', handleOffline);
-    // Sync initial state
-    if (!navigator.onLine) setOffline();
+    // Sync initial state — delayed 1s to avoid false offline on cold start
+    // (navigator.onLine can briefly read as false before the network stack is ready)
+    setTimeout(() => {
+      if (typeof navigator !== 'undefined' && !navigator.onLine) setOffline();
+    }, 1000);
     return () => {
       window.removeEventListener('online', handleOnline);
       window.removeEventListener('offline', handleOffline);

--- a/app/src/services/api.ts
+++ b/app/src/services/api.ts
@@ -12,6 +12,9 @@ const API_TIMEOUT_MS = 10_000; // 10 seconds
 const TOKEN_KEY = 'authToken';
 let authToken: string | null = null;
 
+// Debounce timer for offline detection — prevents false banner on cold start / slow API
+let offlineTimer: ReturnType<typeof setTimeout> | null = null;
+
 export async function getToken(): Promise<string | null> {
   if (authToken) return authToken;
   if (Platform.OS === 'web') {
@@ -91,12 +94,21 @@ export async function apiRequest<T>(
       throw new ApiError('Request timed out. Please try again.', 408);
     }
     // Network error (no connection, DNS failure, etc.)
-    useNetworkStore.getState().setOffline();
+    // Debounce: only mark offline after 2500ms grace period to avoid false banner on cold start
+    if (offlineTimer) clearTimeout(offlineTimer);
+    offlineTimer = setTimeout(() => {
+      useNetworkStore.getState().setOffline();
+      offlineTimer = null;
+    }, 2500);
     throw new ApiError('Network error. Please check your connection.', 0);
   }
   clearTimeout(timeoutId);
 
-  // Successful network response — mark as online
+  // Successful network response — cancel any pending offline timer and mark as online
+  if (offlineTimer) {
+    clearTimeout(offlineTimer);
+    offlineTimer = null;
+  }
   useNetworkStore.getState().setOnline();
 
   const data = await response.json().catch(() => ({}));


### PR DESCRIPTION
## Summary
- **Root cause:** race condition — API call on landing fails (cold start), catch block calls `setOffline()` immediately with no debounce
- Added 2500ms debounce to `setOffline()` in `api.ts` — any successful response within the grace period cancels the timer
- Added 1000ms delay to initial `navigator.onLine` check in `_layout.tsx` `useWebNetworkStatus` hook

## Changes
- `app/src/services/api.ts`: module-level `offlineTimer`; debounced `setOffline()` in catch block; cancel timer + `setOnline()` on success
- `app/app/_layout.tsx`: wrap initial `navigator.onLine` check in `setTimeout(..., 1000)`

## Verification
Open https://daterabbit.smartlaunchhub.com on a fresh load — offline banner must NOT appear when the API is healthy but slow on first response.