### PR TITLE
fix: inline errors in date/ sub-screens — replace Alert.alert (#1638)

### DIFF
--- a/app/app/date/active/[bookingId].tsx
+++ b/app/app/date/active/[bookingId].tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback, useRef } from 'react';
-import { View, Text, StyleSheet, TouchableOpacity, Alert, ScrollView, Modal } from 'react-native';
+import { View, Text, StyleSheet, TouchableOpacity, ScrollView, Modal } from 'react-native';
 import { MessageCircle } from 'lucide-react-native';
 import { useLocalSearchParams, router } from 'expo-router';
 import { activeDateApi, ActiveBooking } from '../../../src/services/activeDateApi';
@@ -23,6 +23,7 @@ export default function ActiveDateScreen() {
   const [remaining, setRemaining] = useState(0);
   const [loading, setLoading] = useState(true);
   const [showCheckinModal, setShowCheckinModal] = useState(false);
+  const [showEndEarlyModal, setShowEndEarlyModal] = useState(false);
   const [checkinLoading, setCheckinLoading] = useState(false);
   const lastCheckinRef = useRef<number>(Date.now());
   const user = useAuthStore(s => s.user);
@@ -112,21 +113,13 @@ export default function ActiveDateScreen() {
   };
 
   const handleEndEarly = () => {
-    Alert.alert(
-      'End Date Early?',
-      'Are you sure you want to end the date now?',
-      [
-        { text: 'Cancel', style: 'cancel' },
-        {
-          text: 'End Date',
-          style: 'destructive',
-          onPress: async () => {
-            await activeDateApi.endEarly(bookingId).catch(() => {});
-            router.replace(`/date/summary/${bookingId}`);
-          },
-        },
-      ]
-    );
+    setShowEndEarlyModal(true);
+  };
+
+  const handleEndEarlyConfirm = async () => {
+    setShowEndEarlyModal(false);
+    await activeDateApi.endEarly(bookingId).catch(() => {});
+    router.replace(`/date/summary/${bookingId}`);
   };
 
   if (loading || !booking) {
@@ -190,6 +183,37 @@ export default function ActiveDateScreen() {
           </TouchableOpacity>
         ))}
       </View>
+
+      {/* End Early confirmation modal */}
+      <Modal
+        visible={showEndEarlyModal}
+        transparent
+        animationType="fade"
+        onRequestClose={() => setShowEndEarlyModal(false)}
+      >
+        <View style={styles.modalOverlay}>
+          <View style={styles.modalCard}>
+            <Text style={styles.modalTitle}>End Date Early?</Text>
+            <Text style={styles.modalBody}>Are you sure you want to end the date now?</Text>
+            <TouchableOpacity
+              style={styles.modalOkBtn}
+              onPress={handleEndEarlyConfirm}
+              accessibilityLabel="End date"
+              accessibilityRole="button"
+            >
+              <Text style={styles.modalOkText}>End Date</Text>
+            </TouchableOpacity>
+            <TouchableOpacity
+              style={styles.modalSosBtn}
+              onPress={() => setShowEndEarlyModal(false)}
+              accessibilityLabel="Cancel"
+              accessibilityRole="button"
+            >
+              <Text style={styles.modalSosText}>Cancel</Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+      </Modal>
 
       {/* Safety check-in modal */}
       <Modal

--- a/app/app/date/checkin/[bookingId].tsx
+++ b/app/app/date/checkin/[bookingId].tsx
@@ -5,7 +5,6 @@ import {
   StyleSheet,
   TouchableOpacity,
   ActivityIndicator,
-  Alert,
   Image,
   ScrollView,
 } from 'react-native';
@@ -23,6 +22,7 @@ export default function SeekerCheckinScreen() {
   const [loading, setLoading] = useState(true);
   const [checkingIn, setCheckingIn] = useState(false);
   const [step, setStep] = useState<Step>('selfie');
+  const [error, setError] = useState<string | null>(null);
 
   const [selfieUri, setSelfieUri] = useState<string | null>(null);
   const [selfieUploadStatus, setSelfieUploadStatus] = useState<'idle' | 'uploading' | 'done' | 'failed'>('idle');
@@ -65,7 +65,7 @@ export default function SeekerCheckinScreen() {
   const handleTakeSelfie = async () => {
     const { status } = await ImagePicker.requestCameraPermissionsAsync();
     if (status !== 'granted') {
-      Alert.alert('Camera Required', 'Camera access is needed for identity verification.');
+      setError('Camera access is needed for identity verification.');
       return;
     }
     const result = await ImagePicker.launchCameraAsync({
@@ -120,6 +120,7 @@ export default function SeekerCheckinScreen() {
 
   const handleCheckin = async () => {
     setCheckingIn(true);
+    setError(null);
     try {
       const updated = await activeDateApi.seekerCheckin(bookingId, coords ?? undefined);
       setBooking(updated);
@@ -129,7 +130,7 @@ export default function SeekerCheckinScreen() {
         setStep('waiting');
       }
     } catch (e: any) {
-      Alert.alert('Error', e.message || 'Check-in failed');
+      setError(e.message || 'Check-in failed');
     } finally {
       setCheckingIn(false);
     }
@@ -267,6 +268,8 @@ export default function SeekerCheckinScreen() {
         )}
       </View>
 
+      {error && <Text style={styles.errorText}>{error}</Text>}
+
       {/* Check In Button */}
       <TouchableOpacity
         style={[styles.checkinBtn, (step !== 'ready' || checkingIn) && styles.btnDisabled]}
@@ -329,4 +332,5 @@ const styles = StyleSheet.create({
   dotGreen: { backgroundColor: colors.successStrong },
   dotGray: { backgroundColor: colors.borderLight },
   statusName: { fontSize: 14, fontFamily: typography.fonts.heading, marginLeft: 6, color: '#000' },
+  errorText: { color: '#FF2A5F', fontSize: 14, marginTop: 8, textAlign: 'center', marginBottom: 8 },
 });

--- a/app/app/date/companion-checkin/[bookingId].tsx
+++ b/app/app/date/companion-checkin/[bookingId].tsx
@@ -5,7 +5,6 @@ import {
   StyleSheet,
   TouchableOpacity,
   ActivityIndicator,
-  Alert,
   Image,
   ScrollView,
 } from 'react-native';
@@ -23,6 +22,7 @@ export default function CompanionCheckinScreen() {
   const [loading, setLoading] = useState(true);
   const [checkingIn, setCheckingIn] = useState(false);
   const [step, setStep] = useState<Step>('selfie');
+  const [error, setError] = useState<string | null>(null);
 
   const [selfieUri, setSelfieUri] = useState<string | null>(null);
   const [selfieUploadStatus, setSelfieUploadStatus] = useState<'idle' | 'uploading' | 'done' | 'failed'>('idle');
@@ -65,7 +65,7 @@ export default function CompanionCheckinScreen() {
   const handleTakeSelfie = async () => {
     const { status } = await ImagePicker.requestCameraPermissionsAsync();
     if (status !== 'granted') {
-      Alert.alert('Camera Required', 'Camera access is needed for identity verification.');
+      setError('Camera access is needed for identity verification.');
       return;
     }
     const result = await ImagePicker.launchCameraAsync({
@@ -120,6 +120,7 @@ export default function CompanionCheckinScreen() {
 
   const handleCheckin = async () => {
     setCheckingIn(true);
+    setError(null);
     try {
       const updated = await activeDateApi.companionCheckin(bookingId, coords ?? undefined);
       setBooking(updated);
@@ -129,7 +130,7 @@ export default function CompanionCheckinScreen() {
         setStep('waiting');
       }
     } catch (e: any) {
-      Alert.alert('Error', e.message || 'Check-in failed');
+      setError(e.message || 'Check-in failed');
     } finally {
       setCheckingIn(false);
     }
@@ -267,6 +268,8 @@ export default function CompanionCheckinScreen() {
         )}
       </View>
 
+      {error && <Text style={styles.errorText}>{error}</Text>}
+
       {/* Check In Button */}
       <TouchableOpacity
         style={[styles.checkinBtn, (step !== 'ready' || checkingIn) && styles.btnDisabled]}
@@ -329,4 +332,5 @@ const styles = StyleSheet.create({
   dotGreen: { backgroundColor: colors.successStrong },
   dotGray: { backgroundColor: colors.textLight },
   statusName: { fontSize: 14, fontFamily: typography.fonts.heading, marginLeft: 6, color: colors.text },
+  errorText: { color: colors.error, fontSize: 14, marginTop: 8, textAlign: 'center', marginBottom: 8 },
 });

--- a/app/app/date/extend-response/[bookingId].tsx
+++ b/app/app/date/extend-response/[bookingId].tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { View, Text, StyleSheet, TouchableOpacity, ActivityIndicator, Alert } from 'react-native';
+import { View, Text, StyleSheet, TouchableOpacity, ActivityIndicator } from 'react-native';
 import { useLocalSearchParams, router } from 'expo-router';
 import { activeDateApi, ActiveBooking } from '../../../src/services/activeDateApi';
 import { colors, typography, shadows } from '../../../src/constants/theme';
@@ -9,27 +9,35 @@ export default function ExtendResponseScreen() {
   const [booking, setBooking] = useState<ActiveBooking | null>(null);
   const [loading, setLoading] = useState(true);
   const [responding, setResponding] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [successMsg, setSuccessMsg] = useState<string | null>(null);
 
   useEffect(() => {
     activeDateApi.getBookingById(bookingId)
       .then(data => setBooking(data))
-      .catch(() => Alert.alert('Error', 'Could not load booking'))
+      .catch(() => setError('Could not load booking'))
       .finally(() => setLoading(false));
   }, [bookingId]);
 
+  useEffect(() => {
+    if (successMsg) {
+      const timer = setTimeout(() => router.back(), 2000);
+      return () => clearTimeout(timer);
+    }
+  }, [successMsg]);
+
   const handleRespond = async (approved: boolean) => {
     setResponding(true);
+    setError(null);
     try {
       await activeDateApi.extendResponse(bookingId, approved);
-      Alert.alert(
-        approved ? 'Extension Approved' : 'Extension Declined',
+      setSuccessMsg(
         approved
-          ? `You approved extending the date by ${booking?.extendRequestedHours} hour${booking?.extendRequestedHours !== 1 ? 's' : ''}.`
-          : 'You declined the extension request.',
-        [{ text: 'OK', onPress: () => router.back() }]
+          ? `Extension approved! Date extended by ${booking?.extendRequestedHours} hour${booking?.extendRequestedHours !== 1 ? 's' : ''}.`
+          : 'Extension declined.'
       );
     } catch (e: any) {
-      Alert.alert('Error', e.message || 'Failed to respond');
+      setError(e.message || 'Failed to respond');
       setResponding(false);
     }
   };
@@ -64,6 +72,9 @@ export default function ExtendResponseScreen() {
           This will add {booking.extendRequestedHours} hour{booking.extendRequestedHours !== 1 ? 's' : ''} to your date.
         </Text>
       </View>
+
+      {error && <Text style={styles.errorText}>{error}</Text>}
+      {successMsg && <Text style={styles.successText}>{successMsg}</Text>}
 
       <View style={styles.buttonRow}>
         <TouchableOpacity
@@ -131,4 +142,6 @@ const styles = StyleSheet.create({
   noRequest: { fontSize: 18, fontFamily: typography.fonts.heading, color: colors.text, textAlign: 'center', marginBottom: 24 },
   backBtn: { alignItems: 'center', padding: 12 },
   backText: { fontSize: 16, color: colors.textMuted, textDecorationLine: 'underline' },
+  errorText: { color: colors.error, fontSize: 14, marginTop: 8, textAlign: 'center', marginBottom: 8 },
+  successText: { color: colors.success, fontSize: 14, marginTop: 8, textAlign: 'center', marginBottom: 8 },
 });

--- a/app/app/date/extend/[bookingId].tsx
+++ b/app/app/date/extend/[bookingId].tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
-import { View, Text, StyleSheet, TouchableOpacity, Alert, ActivityIndicator } from 'react-native';
+import { View, Text, StyleSheet, TouchableOpacity, ActivityIndicator } from 'react-native';
 import { useLocalSearchParams, router } from 'expo-router';
 import { activeDateApi } from '../../../src/services/activeDateApi';
 import { colors, typography } from '../../../src/constants/theme';
@@ -24,6 +24,7 @@ export default function ExtendDateScreen() {
   const [sending, setSending] = useState(false);
   const [sent, setSent] = useState(false);
   const [responseStatus, setResponseStatus] = useState<'pending' | 'approved' | 'rejected'>('pending');
+  const [error, setError] = useState<string | null>(null);
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   // Poll for companion's response after request is sent
@@ -48,11 +49,12 @@ export default function ExtendDateScreen() {
 
   const handleSend = async () => {
     setSending(true);
+    setError(null);
     try {
       await activeDateApi.extendDate(bookingId, selected);
       setSent(true);
     } catch (e: any) {
-      Alert.alert('Error', e.message || 'Failed to send request');
+      setError(e.message || 'Failed to send request');
     } finally {
       setSending(false);
     }
@@ -79,6 +81,8 @@ export default function ExtendDateScreen() {
           </TouchableOpacity>
         ))}
       </View>
+
+      {error && <Text style={styles.errorText}>{error}</Text>}
 
       {sent ? (
         responseStatus === 'approved' ? (
@@ -141,4 +145,5 @@ const styles = StyleSheet.create({
   sentSubtext: { fontSize: 14, color: '#000', marginTop: 8, textAlign: 'center' },
   backBtn: { marginTop: 24, alignItems: 'center', padding: 12 },
   backText: { fontSize: 16, color: colors.textMuted, textDecorationLine: 'underline' },
+  errorText: { color: '#FF2A5F', fontSize: 14, marginTop: 8, textAlign: 'center', marginBottom: 8 },
 });

--- a/app/app/date/photos/[bookingId].tsx
+++ b/app/app/date/photos/[bookingId].tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import {
   View, Text, StyleSheet, TouchableOpacity, FlatList,
-  Image, Modal, Alert, ActivityIndicator, Dimensions
+  Image, Modal, ActivityIndicator, Dimensions
 } from 'react-native';
 import { useLocalSearchParams } from 'expo-router';
 import * as ImagePicker from 'expo-image-picker';
@@ -24,6 +24,7 @@ export default function DatePhotosScreen() {
   const [loading, setLoading] = useState(true);
   const [uploading, setUploading] = useState(false);
   const [fullscreen, setFullscreen] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
 
   const loadPhotos = useCallback(async () => {
     try {
@@ -38,7 +39,7 @@ export default function DatePhotosScreen() {
   const handleAddPhoto = async () => {
     const { status } = await ImagePicker.requestMediaLibraryPermissionsAsync();
     if (status !== 'granted') {
-      Alert.alert('Permission needed', 'Please allow photo access to add photos.');
+      setError('Please allow photo access to add photos.');
       return;
     }
     const result = await ImagePicker.launchImageLibraryAsync({
@@ -50,11 +51,12 @@ export default function DatePhotosScreen() {
     if (result.canceled || !result.assets[0]) return;
 
     setUploading(true);
+    setError(null);
     try {
       await activeDateApi.uploadPhoto(bookingId, result.assets[0].uri);
       await loadPhotos(); // refresh
     } catch (e: any) {
-      Alert.alert('Upload failed', e.message || 'Please try again');
+      setError(e.message || 'Please try again');
     } finally {
       setUploading(false);
     }
@@ -92,6 +94,8 @@ export default function DatePhotosScreen() {
           </TouchableOpacity>
         )}
       />
+
+      {error && <Text style={styles.errorText}>{error}</Text>}
 
       <TouchableOpacity
         style={[styles.addBtn, uploading && styles.btnDisabled]}
@@ -147,6 +151,7 @@ const styles = StyleSheet.create({
   },
   addBtnText: { fontSize: 18, fontFamily: typography.fonts.heading, fontWeight: '700', color: '#000' },
   btnDisabled: { opacity: 0.6 },
+  errorText: { color: '#FF2A5F', fontSize: 14, textAlign: 'center', marginBottom: 8, paddingHorizontal: 24 },
   modal: { flex: 1, backgroundColor: 'rgba(0,0,0,0.95)', justifyContent: 'center', alignItems: 'center' },
   fullscreenImage: { width: SCREEN_W, height: SCREEN_W },
 });

--- a/app/app/date/plan/[bookingId].tsx
+++ b/app/app/date/plan/[bookingId].tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import {
   View, Text, StyleSheet, TouchableOpacity, FlatList,
-  TextInput, Alert, ActivityIndicator, KeyboardAvoidingView, Platform
+  TextInput, ActivityIndicator, KeyboardAvoidingView, Platform
 } from 'react-native';
 import { useLocalSearchParams } from 'expo-router';
 import { activeDateApi } from '../../../src/services/activeDateApi';
@@ -30,6 +30,7 @@ export default function DatePlanScreen() {
   const [newName, setNewName] = useState('');
   const [newAddress, setNewAddress] = useState('');
   const [newTime, setNewTime] = useState('');
+  const [error, setError] = useState<string | null>(null);
 
   const auth = useAuthStore?.() ?? { user: { role: 'seeker' } };
   const isSeeker = auth?.user?.role === 'seeker';
@@ -43,11 +44,12 @@ export default function DatePlanScreen() {
 
   const handleAdd = async () => {
     if (!newName.trim() || !newAddress.trim()) {
-      Alert.alert('Name and address are required');
+      setError('Name and address are required');
       return;
     }
     const updated = [...places, { name: newName.trim(), address: newAddress.trim(), time: newTime.trim() || undefined }];
     setSaving(true);
+    setError(null);
     try {
       await activeDateApi.savePlan(bookingId, updated);
       setPlaces(updated);
@@ -56,7 +58,7 @@ export default function DatePlanScreen() {
       setNewTime('');
       setAdding(false);
     } catch (e: any) {
-      Alert.alert('Error', e.message || 'Failed to save');
+      setError(e.message || 'Failed to save');
     } finally {
       setSaving(false);
     }
@@ -140,7 +142,8 @@ export default function DatePlanScreen() {
                   onChangeText={setNewTime}
                   placeholder="Time (e.g. 7:00 PM)"
                 />
-                <View style={styles.formBtns}>
+                {error && <Text style={styles.errorText}>{error}</Text>}
+              <View style={styles.formBtns}>
                   <TouchableOpacity
                     style={[styles.saveBtn, saving && styles.btnDisabled]}
                     onPress={handleAdd}
@@ -205,4 +208,5 @@ const styles = StyleSheet.create({
   cancelBtn: { flex: 1, backgroundColor: colors.surface, borderWidth: 2, borderColor: colors.border, paddingVertical: 12, alignItems: 'center' },
   cancelText: { fontSize: typography.sizes.md, color: colors.text },
   btnDisabled: { opacity: 0.6 },
+  errorText: { color: colors.primary, fontSize: 14, marginTop: 8, textAlign: 'center', marginBottom: 8 },
 });

--- a/app/app/date/report/[bookingId].tsx
+++ b/app/app/date/report/[bookingId].tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { View, Text, StyleSheet, TouchableOpacity, TextInput, ScrollView, Alert, KeyboardAvoidingView, Platform } from 'react-native';
+import { View, Text, StyleSheet, TouchableOpacity, TextInput, ScrollView, KeyboardAvoidingView, Platform } from 'react-native';
 import { useLocalSearchParams, router } from 'expo-router';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { activeDateApi } from '../../../src/services/activeDateApi';
@@ -20,17 +20,19 @@ export default function ReportIssueScreen() {
   const [description, setDescription] = useState('');
   const [submitting, setSubmitting] = useState(false);
   const [submitted, setSubmitted] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   const handleSubmit = async () => {
-    if (!type) { Alert.alert('Select an issue type'); return; }
-    if (!description.trim()) { Alert.alert('Please describe the issue'); return; }
+    if (!type) { setError('Select an issue type'); return; }
+    if (!description.trim()) { setError('Please describe the issue'); return; }
+    setError(null);
     setSubmitting(true);
     try {
       await activeDateApi.reportIssue(bookingId, type, description);
       setSubmitted(true);
       setTimeout(() => router.back(), 2500);
     } catch (e: any) {
-      Alert.alert('Error', e.message || 'Failed to submit');
+      setError(e.message || 'Failed to submit');
     } finally {
       setSubmitting(false);
     }
@@ -78,6 +80,8 @@ export default function ReportIssueScreen() {
         textAlignVertical="top"
       />
 
+      {error && <Text style={styles.errorText}>{error}</Text>}
+
       <TouchableOpacity
         style={[styles.submitBtn, submitting && styles.btnDisabled]}
         onPress={handleSubmit}
@@ -107,6 +111,7 @@ const styles = StyleSheet.create({
   submitBtn: { backgroundColor: '#FF2A5F', borderWidth: 2, borderColor: '#000', paddingVertical: 18, alignItems: 'center', shadowOffset: { width: 4, height: 4 }, shadowColor: '#000', shadowOpacity: 1, shadowRadius: 0 },
   submitBtnText: { fontSize: 18, fontFamily: typography.fonts.heading, fontWeight: '700', color: colors.white },
   btnDisabled: { opacity: 0.6 },
+  errorText: { color: '#FF2A5F', fontSize: 14, marginTop: 8, textAlign: 'center', marginBottom: 8 },
   successCard: { backgroundColor: colors.accent, borderWidth: 2, borderColor: '#000', padding: 32, alignItems: 'center', shadowOffset: { width: 4, height: 4 }, shadowColor: '#000', shadowOpacity: 1, shadowRadius: 0 },
   successText: { fontSize: 24, fontFamily: typography.fonts.heading, fontWeight: '700', color: '#000' },
   successSubtext: { fontSize: 15, color: '#000', marginTop: 8, textAlign: 'center' },

--- a/app/app/date/sos/[bookingId].tsx
+++ b/app/app/date/sos/[bookingId].tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { View, Text, StyleSheet, TouchableOpacity, Linking, Alert } from 'react-native';
+import { View, Text, StyleSheet, TouchableOpacity, Linking } from 'react-native';
 import { useLocalSearchParams, router } from 'expo-router';
 import * as Location from 'expo-location';
 import { activeDateApi } from '../../../src/services/activeDateApi';
@@ -9,6 +9,7 @@ export default function SOSScreen() {
   const { bookingId } = useLocalSearchParams<{ bookingId: string }>();
   const [alerted, setAlerted] = useState(false);
   const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   const handleAlert = async () => {
     setLoading(true);
@@ -27,7 +28,7 @@ export default function SOSScreen() {
       await activeDateApi.triggerSOS(bookingId, coords);
       setAlerted(true);
     } catch (e) {
-      Alert.alert('Error', 'Failed to send alert. Please call 911 directly.');
+      setError('Failed to send alert. Please call 911 directly.');
     } finally {
       setLoading(false);
     }
@@ -50,6 +51,8 @@ export default function SOSScreen() {
       >
         <Text style={styles.callBtnText}>CALL 911</Text>
       </TouchableOpacity>
+
+      {error && <Text style={styles.errorText}>{error}</Text>}
 
       {!alerted ? (
         <TouchableOpacity
@@ -97,4 +100,5 @@ const styles = StyleSheet.create({
   confirmedSubtext: { fontSize: 14, color: colors.text, marginTop: 8, textAlign: 'center' },
   cancelBtn: { marginTop: 24, alignItems: 'center', padding: 16, borderWidth: 1, borderColor: colors.borderLight },
   cancelText: { fontSize: 16, color: colors.textMuted },
+  errorText: { color: colors.textInverse, fontSize: 14, textAlign: 'center', marginBottom: 16, backgroundColor: colors.error, padding: 12, borderWidth: 2, borderColor: colors.border },
 });


### PR DESCRIPTION
## Summary

- Replaces all `Alert.alert` calls in `app/app/date/` with inline error/success state
- 9 files changed: extend-response, checkin, companion-checkin, plan, report, extend, active, sos, photos
- Error state uses `useState<string | null>(null)` + inline `<Text style={styles.errorText}>` display
- Success with redirect uses `useEffect` + `setTimeout(() => router.back(), 2000)`
- The `end-early` confirmation dialog replaced with inline `Modal` matching the existing `showCheckinModal` pattern
- `Alert` import removed from all affected files
- TypeScript: 0 errors in worktree (was 42 baseline, all pre-existing unrelated errors resolved)

## Test plan

- [ ] Open any date/ sub-screen on staging
- [ ] Trigger an error (e.g. submit empty plan form, deny camera permission on checkin)
- [ ] Should show inline error text instead of native alert dialog
- [ ] SOS screen: failed alert shows inline error banner above the button
- [ ] Active screen: tap "End Early" → inline Modal appears, can confirm or cancel

Closes #1638