### PR TITLE
fix: onboarding NEXT button -> brand primary color (#2091)

### DIFF
--- a/app/src/components/Button.tsx
+++ b/app/src/components/Button.tsx
@@ -187,9 +187,9 @@ export function Button({
     );
   };
 
-  // Primary button with dark gradient
+  // Primary button with brand pink gradient
   if (variant === 'primary') {
-    return renderGradientButton(colors.gradient.dark as readonly [string, string, ...string[]]);
+    return renderGradientButton(colors.gradient.primary as readonly [string, string, ...string[]]);
   }
 
   // Pink button with pink gradient


### PR DESCRIPTION
## Summary
- NEXT button in onboarding was using `colors.gradient.dark` (#1A1A1A → #333333), making it appear black
- Changed `primary` variant to use `colors.gradient.primary` (#FF2A5F → #E0224F), matching brand color
- Affects all screens that use `<Button variant="primary">` including onboarding

## Root cause
`Button.tsx` line 192 had `colors.gradient.dark` for `primary` variant instead of `colors.gradient.primary`. The `pink` variant already used the correct gradient — `primary` should behave the same way.

## Test plan
- [ ] Open app onboarding flow
- [ ] Verify NEXT button shows brand pink (#FF2A5F) instead of black
- [ ] Verify other primary buttons across app are also now pink

Fixes #2091