### PR TITLE
fix: companion photos join in getCompanions (#2092)

### DIFF
--- a/backend/daterabbit-api/src/companions/companions.controller.ts
+++ b/backend/daterabbit-api/src/companions/companions.controller.ts
@@ -45,7 +45,9 @@ export class CompanionsController {
         age: c.age,
         location: c.location,
         shortBio: c.bio ? c.bio.substring(0, 100) : null,
-        primaryPhoto: c.photos?.[0]?.url || null,
+        primaryPhoto: (Array.isArray(c.photos) && c.photos.length > 0)
+          ? (c.photos.find((p: any) => p.isPrimary) ?? c.photos[0])?.url ?? null
+          : null,
         hourlyRate: c.hourlyRate != null ? Number(c.hourlyRate) : 0,
         rating: c.rating ? Number(c.rating) : null,
         reviewCount: c.reviewCount || 0,
@@ -122,7 +124,9 @@ export class CompanionsController {
         age: c.age,
         location: c.location,
         shortBio: c.bio ? c.bio.substring(0, 100) : null,
-        primaryPhoto: c.photos?.[0]?.url || null,
+        primaryPhoto: (Array.isArray(c.photos) && c.photos.length > 0)
+          ? (c.photos.find((p: any) => p.isPrimary) ?? c.photos[0])?.url ?? null
+          : null,
         hourlyRate: c.hourlyRate != null ? Number(c.hourlyRate) : 0,
         rating: c.rating ? Number(c.rating) : null,
         reviewCount: c.reviewCount || 0,

--- a/backend/daterabbit-api/src/users/users.service.ts
+++ b/backend/daterabbit-api/src/users/users.service.ts
@@ -159,6 +159,8 @@ export class UsersService {
       .andWhere('user.isPublicProfile = true');
 
     if (hasLocation) {
+      // Explicitly select all entity columns first so addSelect doesn't drop them in getRawAndEntities
+      query.addSelect('user.photos');
       query.addSelect(distanceExpr, 'distance');
       query.setParameters({ lat: filters.latitude, lng: filters.longitude });
     }


### PR DESCRIPTION
## Summary
- Add explicit `user.photos` select in `getCompanions` when location filters are active — TypeORM's `addSelect()` for a virtual distance expression can cause jsonb columns to be dropped from entity hydration in `getRawAndEntities()`
- Fix `primaryPhoto` mapping in both companions endpoints to find photo with `isPrimary: true` first, falling back to `photos[0]` — fixes cases where primary photo is not at index 0

## Root cause
`getCompanions` uses `createQueryBuilder` with `addSelect(distanceExpr, 'distance')`. When `getRawAndEntities()` is called, TypeORM hydrates entities from raw results. Without an explicit `addSelect('user.photos')`, the jsonb `photos` column can be dropped from the raw→entity mapping, leaving `companion.photos` as `undefined` in the API response, so `primaryPhoto` is always `null`.

## Test plan
- [ ] `curl https://daterabbit-api.smartlaunchhub.com/api/companions` — check `primaryPhoto` is non-null for companions with photos
- [ ] `curl https://daterabbit-api.smartlaunchhub.com/api/companions/public` — same check on public endpoint
- [ ] Verify frontend companion cards show photos

🤖 Generated with [Claude Code](https://claude.com/claude-code)