### PR TITLE
fix(auth): invalidate OTP after 3 failed attempts to prevent brute-force

### DIFF
--- a/backend/daterabbit-api/src/auth/auth.service.ts
+++ b/backend/daterabbit-api/src/auth/auth.service.ts
@@ -11,7 +11,7 @@ import { sanitizeText } from '../common/sanitize';
 export class AuthService {
   // Per-email OTP attempt tracking to prevent brute force
   private otpAttempts = new Map<string, { count: number; lockedUntil: number }>();
-  private readonly MAX_OTP_ATTEMPTS = 5;
+  private readonly MAX_OTP_ATTEMPTS = 3;
   private readonly LOCKOUT_MINUTES = 15;
 
   constructor(
@@ -108,10 +108,13 @@ export class AuthService {
       if (current.count >= this.MAX_OTP_ATTEMPTS) {
         current.lockedUntil = Date.now() + this.LOCKOUT_MINUTES * 60 * 1000;
         current.count = 0;
+        this.otpAttempts.set(email, current);
+        // Invalidate OTP so it cannot be used even if rate limit is bypassed
+        await this.usersService.clearOtp(user.id);
+        return { success: false, error: 'Too many failed attempts. Please request a new code.' };
       }
       this.otpAttempts.set(email, current);
 
-      // Don't clear OTP on failed attempt -- let users retry until 10-min TTL expires
       return { success: false, error: 'Invalid OTP' };
     }
 


### PR DESCRIPTION
## Summary
- Reduce MAX_OTP_ATTEMPTS from 5 to 3
- On 3rd failed attempt: set lockout timer, **clear OTP from DB**, return `Too many failed attempts. Please request a new code.`
- On success: existing logic unchanged (clear attempts + OTP, return JWT)

## Security impact
A distributed attacker rotating IPs could previously try all 1,000,000 codes within the 10-min OTP window. After this fix, the OTP is invalidated after 3 wrong guesses, forcing a fresh send-otp cycle — making brute-force infeasible.

## Test plan
- [ ] 3 wrong codes → get lockout error, next attempt returns "No OTP requested"
- [ ] Correct code on 1st or 2nd try → login succeeds normally
- [ ] After lockout expires (15 min), new send-otp → new OTP works

Fixes #2098

🤖 Generated with [Claude Code](https://claude.com/claude-code)