### PR TITLE
fix(messages,companions): 404 for unknown user; city filter on /companions/public

### DIFF
--- a/backend/daterabbit-api/src/companions/companions.controller.ts
+++ b/backend/daterabbit-api/src/companions/companions.controller.ts
@@ -16,6 +16,7 @@ export class CompanionsController {
     @Query('priceMax') priceMax?: string,
     @Query('sortBy') sortBy?: string,
     @Query('search') search?: string,
+    @Query('city') city?: string,
     @Query('limit') limit?: string,
     @Query('offset') offset?: string,
     @Query('page') page?: string,
@@ -32,6 +33,7 @@ export class CompanionsController {
       priceMax: priceMax ? parseFloat(priceMax) : undefined,
       sortBy,
       search,
+      city,
       limit: parsedLimit,
       offset: parsedOffset,
     });

--- a/backend/daterabbit-api/src/messages/messages.controller.ts
+++ b/backend/daterabbit-api/src/messages/messages.controller.ts
@@ -106,6 +106,12 @@ export class MessagesController {
       throw new HttpException('Message too long (max 5000 chars)', HttpStatus.BAD_REQUEST);
     }
 
+    // Ensure recipient user exists
+    const recipient = await this.usersService.findById(receiverId);
+    if (!recipient) {
+      throw new HttpException('User not found', HttpStatus.NOT_FOUND);
+    }
+
     // Prevent messaging blocked users (in either direction)
     const [blockedByMe, blockedByThem] = await Promise.all([
       this.usersService.isBlocked(req.user.id, receiverId),

--- a/backend/daterabbit-api/src/users/users.service.ts
+++ b/backend/daterabbit-api/src/users/users.service.ts
@@ -143,6 +143,7 @@ export class UsersService {
     ageMax?: number;
     sortBy?: string;
     search?: string;
+    city?: string;
     activityTypes?: string[];
     availability?: string;
     limit?: number;
@@ -188,6 +189,9 @@ export class UsersService {
       query.andWhere('(user.name ILIKE :search OR user.location ILIKE :search)', {
         search: `%${filters.search}%`,
       });
+    }
+    if (filters.city) {
+      query.andWhere('user.location ILIKE :city', { city: `%${filters.city}%` });
     }
 
     if (filters.activityTypes && filters.activityTypes.length > 0) {


### PR DESCRIPTION
## Summary
- **#2097** POST /messages/:userId now returns 404 when recipient user does not exist (previously 500)
- **#2096** GET /companions/public now accepts `city` query param and filters by `user.location ILIKE :city`

## Changes
- `messages.controller.ts` — check `usersService.findById(receiverId)` before sending, throw 404 if null
- `companions.controller.ts` — add `@Query('city')` to `searchPublicCompanions`, pass to `getCompanions`
- `users.service.ts` — add `city?: string` to filter type, add `andWhere('user.location ILIKE :city')` in query builder

## Test plan
- [ ] POST /messages/:nonExistentUserId → 404 User not found
- [ ] GET /companions/public?city=Moscow → only companions with "Moscow" in location
- [ ] GET /companions/public (no city) → all companions as before (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)