### PR TITLE
fix(security): restrict WebSocket CORS origin + add role guard on /payments/earnings

### DIFF
--- a/backend/daterabbit-api/src/messages/chat.gateway.ts
+++ b/backend/daterabbit-api/src/messages/chat.gateway.ts
@@ -15,7 +15,7 @@ import { MessagesService } from './messages.service';
 
 @WebSocketGateway({
   cors: {
-    origin: '*',
+    origin: process.env.FRONTEND_URL || 'https://daterabbit.smartlaunchhub.com',
     credentials: true,
   },
   namespace: '/chat',

--- a/backend/daterabbit-api/src/payments/payments.service.ts
+++ b/backend/daterabbit-api/src/payments/payments.service.ts
@@ -3,7 +3,7 @@ import { ConfigService } from '@nestjs/config';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import Stripe from 'stripe';
-import { User } from '../users/entities/user.entity';
+import { User, UserRole } from '../users/entities/user.entity';
 import { Booking, BookingStatus } from '../bookings/entities/booking.entity';
 
 @Injectable()
@@ -307,6 +307,11 @@ export class PaymentsService {
     pendingPayouts: number;
     completedBookings: number;
   }> {
+    const caller = await this.usersRepo.findOne({ where: { id: userId } });
+    if (!caller || caller.role !== UserRole.COMPANION) {
+      throw new HttpException('Access restricted to companions', HttpStatus.FORBIDDEN);
+    }
+
     const completedBookings = await this.bookingsRepo
       .createQueryBuilder('b')
       .where('b.companionId = :userId', { userId })


### PR DESCRIPTION
## Summary
- **#2100**: `chat.gateway.ts` — replaced wildcard `cors: { origin: '*' }` with `process.env.FRONTEND_URL || 'https://daterabbit.smartlaunchhub.com'`
- **#2101**: `payments.service.ts` — `getEarnings()` now throws `403 Forbidden` if caller is not a `companion`

## Test plan
- [ ] WebSocket connects from `FRONTEND_URL` origin — works
- [ ] WebSocket connect from unknown origin — rejected by browser CORS
- [ ] Companion calls `GET /payments/earnings` — returns data
- [ ] Seeker calls `GET /payments/earnings` — returns 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)