### PR TITLE
fix(ci): enable DEV_AUTH=true on staging for E2E OTP bypass

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -86,7 +86,7 @@ jobs:
             cat > /var/www/daterabbit/api/.env << 'ENVEOF'
           PORT=3004
           NODE_ENV=staging
-          DEV_AUTH=false
+          DEV_AUTH=true
           DB_HOST=localhost
           DB_PORT=5432
           DB_USERNAME=daterabbit
@@ -162,11 +162,11 @@ jobs:
               echo "BREVO_API_KEY=${BREVO_API_KEY}" >> "$ENV_FILE"
             fi
           fi
-          # Disable DEV_AUTH so real emails are sent via Brevo
+          # Enable DEV_AUTH on staging for E2E testing (OTP bypass 000000)
           if grep -q "^DEV_AUTH=" "$ENV_FILE"; then
-            sed -i "s|^DEV_AUTH=.*|DEV_AUTH=false|" "$ENV_FILE"
+            sed -i "s|^DEV_AUTH=.*|DEV_AUTH=true|" "$ENV_FILE"
           else
-            echo "DEV_AUTH=false" >> "$ENV_FILE"
+            echo "DEV_AUTH=true" >> "$ENV_FILE"
           fi
           # Set sender email for Brevo
           if grep -q "^BREVO_SENDER_EMAIL=" "$ENV_FILE"; then


### PR DESCRIPTION
## Summary
- Staging deploy was hardcoding `DEV_AUTH=false` on every run, breaking OTP bypass `000000` and all E2E tests
- Fixed two places in the `deploy-staging` job: fallback `.env` creation and the `Update env vars from secrets` step
- Production job (`deploy-production`) is untouched — `DEV_AUTH=false` remains there

## Root cause
Lines 89 and 165-170 in deploy.yml both forced `DEV_AUTH=false` regardless of any other config.

## Test plan
- [ ] Merge to `development` → CI deploys staging
- [ ] `POST /api/auth/request-otp` with any email → success (no real email sent)
- [ ] `POST /api/auth/verify-otp` with code `000000` → returns JWT
- [ ] E2E tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)