### PR TITLE
fix(companions): apply availability filter on GET /companions/public

### DIFF
--- a/backend/daterabbit-api/src/companions/companions.controller.ts
+++ b/backend/daterabbit-api/src/companions/companions.controller.ts
@@ -17,6 +17,7 @@ export class CompanionsController {
     @Query('sortBy') sortBy?: string,
     @Query('search') search?: string,
     @Query('city') city?: string,
+    @Query('availability') availability?: string,
     @Query('limit') limit?: string,
     @Query('offset') offset?: string,
     @Query('page') page?: string,
@@ -34,6 +35,7 @@ export class CompanionsController {
       sortBy,
       search,
       city,
+      availability,
       limit: parsedLimit,
       offset: parsedOffset,
     });


### PR DESCRIPTION
## Summary
- `GET /companions/public?availability=now` was ignoring the `availability` query param
- Root cause: the `searchPublicCompanions` handler never declared `@Query('availability')` and never passed it to `getCompanions()`
- The authenticated `GET /companions` endpoint and the service-level filter logic were both already correct
- Fix: add `@Query('availability') availability?: string` to the public handler and pass it through — 2 lines, no service changes

## Test plan
- [ ] `GET /companions/public?availability=now` returns only companions not currently in a confirmed/paid/active booking
- [ ] `GET /companions/public` (no param) returns full list as before
- [ ] Authenticated `GET /companions?availability=now` still works unchanged

Fixes #2103