### PR TITLE
fix(companions): availability filter causes 500 — TypeORM param conflict

### DIFF
--- a/backend/daterabbit-api/src/users/users.service.ts
+++ b/backend/daterabbit-api/src/users/users.service.ts
@@ -210,7 +210,9 @@ export class UsersService {
 
     if (filters.availability && filters.availability !== 'any') {
       // Filter out companions who have an active booking right now (CONFIRMED, PAID, or ACTIVE status
-      // with a time window that overlaps the current moment)
+      // with a time window that overlaps the current moment).
+      // Split into setParameter() calls to avoid TypeORM conflict between
+      // spread params (:...availStatuses) and regular params (:availNow) in one andWhere().
       query.andWhere(
         `NOT EXISTS (
           SELECT 1 FROM bookings b
@@ -219,11 +221,9 @@ export class UsersService {
             AND b."dateTime" <= :availNow
             AND b."dateTime" + (b.duration * interval '1 hour') > :availNow
         )`,
-        {
-          availStatuses: ['confirmed', 'paid', 'active'],
-          availNow: new Date(),
-        },
       );
+      query.setParameter('availStatuses', ['confirmed', 'paid', 'active']);
+      query.setParameter('availNow', new Date());
     }
 
     if (hasLocation && filters.maxDistance) {


### PR DESCRIPTION
Fixes #2105

## Root cause
TypeORM query builder throws 500 when a single `andWhere()` call mixes spread-array params (`:...availStatuses`) with regular params (`:availNow`) in the same parameter object.

## Fix
Split inline parameter object out of `andWhere()` into two separate `setParameter()` calls:
- `query.setParameter('availStatuses', ['confirmed', 'paid', 'active'])`
- `query.setParameter('availNow', new Date())`

The SQL is unchanged; only parameter passing is split.

## Verify
`GET /companions/public?availability=evenings` → 200 (was 500)
`GET /companions/public?availability=any` → 200 (unchanged)