### PR TITLE
fix(companions): availability filter 500 — correct TypeORM inline params

### DIFF
--- a/backend/daterabbit-api/src/users/users.service.ts
+++ b/backend/daterabbit-api/src/users/users.service.ts
@@ -240,9 +240,8 @@ export class UsersService {
             AND b."dateTime" <= :availNow
             AND b."dateTime" + (b.duration * interval '1 hour') > :availNow
         )`,
+        { availStatuses: ['confirmed', 'paid', 'active'], availNow: new Date() },
       );
-      query.setParameter('availStatuses', ['confirmed', 'paid', 'active']);
-      query.setParameter('availNow', new Date());
     }
 
     if (hasLocation && filters.maxDistance) {


### PR DESCRIPTION
Fixes #2106

## Problem
`GET /companions/public?availability=evenings` returned 500.

Previous fix passed array param via `setParameter('availStatuses', [...])` and scalar via `setParameter('availNow', ...)`. TypeORM 0.3 does **not** expand `:...spread` params when bound through `setParameter()` — only inline params objects in the same `andWhere()` call are processed correctly.

## Fix
Remove both `setParameter()` calls. Pass `{ availStatuses, availNow }` as the second argument of `andWhere()` directly.

## Verify
`GET https://daterabbit-api.smartlaunchhub.com/api/companions/public?availability=evenings` → should return 200 with companions array.