### PR TITLE
fix(companions): quote user alias in raw SQL subqueries — reserved word

### DIFF
--- a/backend/daterabbit-api/src/users/users.service.ts
+++ b/backend/daterabbit-api/src/users/users.service.ts
@@ -219,7 +219,7 @@ export class UsersService {
         `EXISTS (
           SELECT 1 FROM date_packages dp
           INNER JOIN date_package_templates dpt ON dpt.id = dp."templateId"
-          WHERE dp."companionId" = user.id
+          WHERE dp."companionId" = "user"."id"
             AND dp."isActive" = true
             AND dpt."defaultActivity" IN (:...activityTypes)
         )`,
@@ -235,7 +235,7 @@ export class UsersService {
       query.andWhere(
         `NOT EXISTS (
           SELECT 1 FROM bookings b
-          WHERE b."companionId" = user.id
+          WHERE b."companionId" = "user"."id"
             AND b.status IN (:...availStatuses)
             AND b."dateTime" <= :availNow
             AND b."dateTime" + (b.duration * interval '1 hour') > :availNow


### PR DESCRIPTION
## Root cause

PostgreSQL error 42601 `syntax error at or near "."` at position 228 — the dot in `user.id`.

PostgreSQL treats unquoted `user` as the SESSION_USER function (reserved keyword), not a table alias. Both correlated subqueries in `UsersService.getCompanions()` used `user.id` in raw SQL, causing a hard 500.

Confirmed from `/root/.pm2/logs/daterabbit-error-1856.log`:
```
QueryFailedError: syntax error at or near "."
WHERE b."companionId" = user.id   ← position 228 = the dot after 'user'
```

## Fix

Two lines changed in `users.service.ts`:
- `activityTypes` filter: `user.id` → `"user"."id"`
- `availability` filter: `user.id` → `"user"."id"`

## Why 588a5e4 didn't fix it

588a5e4 fixed the TypeORM `setParameter()` vs inline params binding issue, but the `user.id` reserved-word problem was always present and causes the 500 independently.

## Verification

`curl "https://daterabbit-api.smartlaunchhub.com/api/companions/public?availability=evenings"` must return 200.