### PR TITLE
fix: remove fingerprintStatus browse gate (Checkr deferred to v2)

### DIFF
--- a/app/app/_layout.tsx
+++ b/app/app/_layout.tsx
@@ -106,6 +106,8 @@ const NON_TAB_AUTH_ROUTES = [
 ];
 
 // Routes that REQUIRE verification — unverified users get redirected to verification prompt
+// NOTE: browse/(tabs) is intentionally NOT in this list.
+// Checkr background check deferred to v2. Browse = JWT auth only. Seeker verified = Stripe Identity passed.
 const VERIFICATION_REQUIRED_ROUTES = [
   'payment',
   'stripe',

--- a/backend/daterabbit-api/src/companions/companions.controller.ts
+++ b/backend/daterabbit-api/src/companions/companions.controller.ts
@@ -63,6 +63,8 @@ export class CompanionsController {
     };
   }
 
+  // Browse requires JWT auth only — no fingerprintStatus/Checkr gate.
+  // Checkr background check deferred to v2. Seeker verified = Stripe Identity passed only.
   @UseGuards(JwtAuthGuard)
   @Get()
   async searchCompanions(


### PR DESCRIPTION
## Summary

Task #2120: Confirm and document that fingerprintStatus/Checkr gate does not block seeker browse access.

- Verified no `fingerprintStatus` field exists anywhere in the codebase
- `GET /companions` endpoint uses JWT auth only — no verification status check
- Browse tabs `(tabs)` are accessible to unverified seekers (not in VERIFICATION_REQUIRED_ROUTES)
- Added explicit comments in `companions.controller.ts` and `_layout.tsx` documenting this is intentional
- Checkr background check deferred to v2; seeker verified = Stripe Identity passed only
- TSC: 0 errors

## Files Changed

- `backend/daterabbit-api/src/companions/companions.controller.ts` — comment on browse endpoint
- `app/app/_layout.tsx` — comment on VERIFICATION_REQUIRED_ROUTES

## Test Plan

- [ ] Login as seeker with `verificationStatus !== 'approved'`
- [ ] Navigate to browse tab — should load companions without redirect
- [ ] Confirm no fingerprint/Checkr gate blocks the browse flow