### PR TITLE
fix: enforce 21+ minimum age (legal compliance, USA platform)

### DIFF
--- a/app/src/components/FilterModal.tsx
+++ b/app/src/components/FilterModal.tsx
@@ -212,7 +212,7 @@ export function FilterModal({
             <View style={styles.sliderContainer}>
               <Slider
                 style={styles.slider}
-                minimumValue={18}
+                minimumValue={21}
                 maximumValue={60}
                 step={1}
                 value={filters.ageRange[0]}
@@ -228,7 +228,7 @@ export function FilterModal({
               />
               <Slider
                 style={styles.slider}
-                minimumValue={18}
+                minimumValue={21}
                 maximumValue={60}
                 step={1}
                 value={filters.ageRange[1]}

--- a/backend/daterabbit-api/src/admin/admin.service.ts
+++ b/backend/daterabbit-api/src/admin/admin.service.ts
@@ -392,8 +392,8 @@ export class AdminService {
       settings.requirePhotoForCompanion = data.requirePhotoForCompanion;
     }
     if (data.minimumAge !== undefined) {
-      if (data.minimumAge < 18) {
-        throw new BadRequestException('Minimum age cannot be less than 18');
+      if (data.minimumAge < 21) {
+        throw new BadRequestException('Minimum age cannot be less than 21');
       }
       settings.minimumAge = data.minimumAge;
     }

--- a/backend/daterabbit-api/src/companions/companions.controller.ts
+++ b/backend/daterabbit-api/src/companions/companions.controller.ts
@@ -110,7 +110,7 @@ export class CompanionsController {
       latitude: latitude ? parseFloat(latitude) : undefined,
       longitude: longitude ? parseFloat(longitude) : undefined,
       minRating: minRating ? parseFloat(minRating) : undefined,
-      ageMin: ageMin ? parseInt(ageMin) : undefined,
+      ageMin: ageMin ? Math.max(parseInt(ageMin), 21) : undefined,
       ageMax: ageMax ? parseInt(ageMax) : undefined,
       sortBy,
       search,


### PR DESCRIPTION
## Summary
- **Task #2142**: Platform is 21+ for Seekers per ToS — age floor was incorrectly set to 18
- `FilterModal.tsx`: both age range sliders `minimumValue` changed from `18` → `21`
- `companions.controller.ts`: backend clamps `ageMin` to `Math.max(value, 21)` — no client can bypass by sending raw query param
- `admin.service.ts`: platform `minimumAge` setting validation floor raised from `18` to `21`

## What was NOT changed (intentional)
- `profile-setup.tsx` age validation (`< 18`) — companions can be 18+ per ToS section 2
- `ConsentForm.tsx` text — references general user age (18+), correct per ToS
- `terms.tsx` / `privacy.tsx` — legal copy already correct

## Test plan
- [ ] Open Filter modal in Browse screen → age range min slider cannot go below 21
- [ ] Reset filters → min age resets to 21 (default unchanged, already was 21)
- [ ] Call `GET /companions?ageMin=18` → backend enforces floor, returns companions aged 21+
- [ ] Admin panel: attempt to set minimumAge=19 → expect 400 "Minimum age cannot be less than 21"