### PR TITLE
fix: Stripe dispute webhook handler (#2138)

### DIFF
--- a/backend/daterabbit-api/src/bookings/entities/booking.entity.ts
+++ b/backend/daterabbit-api/src/bookings/entities/booking.entity.ts
@@ -16,6 +16,7 @@ export enum BookingStatus {
   ACTIVE = 'active',
   CANCELLED = 'cancelled',
   COMPLETED = 'completed',
+  DISPUTED = 'disputed',
 }
 
 export enum ActivityType {

--- a/backend/daterabbit-api/src/payments/payments.service.ts
+++ b/backend/daterabbit-api/src/payments/payments.service.ts
@@ -624,6 +624,32 @@ export class PaymentsService {
         }
         break;
       }
+      case 'charge.dispute.created': {
+        const dispute = event.data.object as Stripe.Dispute;
+        // dispute.payment_intent can be a string ID or an expanded PaymentIntent object
+        const paymentIntentId =
+          typeof dispute.payment_intent === 'string'
+            ? dispute.payment_intent
+            : dispute.payment_intent?.id ?? null;
+
+        if (paymentIntentId) {
+          const booking = await this.bookingsRepo.findOne({
+            where: { paymentIntentId },
+          });
+          // IDOR guard: only update if booking owns this payment intent
+          if (booking && booking.paymentIntentId === paymentIntentId) {
+            await this.bookingsRepo.update(booking.id, {
+              status: BookingStatus.DISPUTED,
+            });
+            console.warn(
+              `[DISPUTE] Stripe dispute opened — bookingId=${booking.id} disputeId=${dispute.id} ` +
+              `amount=${dispute.amount} currency=${dispute.currency} reason=${dispute.reason ?? 'unknown'} ` +
+              `seekerId=${booking.seekerId} companionId=${booking.companionId}`,
+            );
+          }
+        }
+        break;
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

- Add `DISPUTED = 'disputed'` to `BookingStatus` enum in `booking.entity.ts`
- Handle `charge.dispute.created` webhook event in `payments.service.ts`
- Lookup booking by `paymentIntentId`, update `status` to `BookingStatus.DISPUTED`
- IDOR guard: only update if `booking.paymentIntentId === dispute.payment_intent`
- `dispute.payment_intent` handled safely as both string ID and expanded object
- Admin notification via `console.warn` with bookingId, disputeId, amount, currency, reason

## DB migration note

`synchronize` is `true` only when `NODE_ENV !== 'production'` (see `app.module.ts`). Staging will auto-migrate the new enum value. **Production requires a manual migration:** `ALTER TYPE booking_status_enum ADD VALUE 'disputed';`

## Test plan

- [ ] Send mock `charge.dispute.created` webhook with a `payment_intent` matching a booking's `paymentIntentId`
- [ ] Confirm booking status changes to `disputed`
- [ ] Confirm `[DISPUTE]` log line appears in server output
- [ ] Confirm bookings with non-matching `paymentIntentId` are NOT updated

Closes #2138

🤖 Generated with [Claude Code](https://claude.com/claude-code)