### PR TITLE
feat: admin disputes list and detail pages

### DIFF
--- a/admin/src/app/(dashboard)/disputes/[id]/page.tsx
+++ b/admin/src/app/(dashboard)/disputes/[id]/page.tsx
@@ -1,0 +1,319 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import { ArrowLeft, CheckCircle, XCircle } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Separator } from '@/components/ui/separator';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Textarea } from '@/components/ui/textarea';
+import { Label } from '@/components/ui/label';
+import { StatusBadge } from '@/components/admin/status-badge';
+import { UserAvatar } from '@/components/admin/user-avatar';
+import { PageHeader } from '@/components/admin/page-header';
+import { api } from '@/lib/api';
+import { Dispute } from '@/types';
+import { formatDateTime, formatCurrency } from '@/lib/utils';
+
+export default function DisputeDetailPage() {
+  const params = useParams();
+  const router = useRouter();
+  const disputeId = params.id as string;
+
+  const [dispute, setDispute] = useState<Dispute | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  const [resolveDialogOpen, setResolveDialogOpen] = useState(false);
+  const [resolveAction, setResolveAction] = useState<'resolved' | 'closed'>('resolved');
+  const [adminNote, setAdminNote] = useState('');
+  const [isActioning, setIsActioning] = useState(false);
+
+  useEffect(() => {
+    api.getDisputeById(disputeId)
+      .then(setDispute)
+      .catch(() => setError('Failed to load dispute'))
+      .finally(() => setIsLoading(false));
+  }, [disputeId]);
+
+  const openResolveDialog = (action: 'resolved' | 'closed') => {
+    setResolveAction(action);
+    setAdminNote('');
+    setResolveDialogOpen(true);
+  };
+
+  const handleResolve = async () => {
+    if (!dispute) return;
+    setIsActioning(true);
+    try {
+      const updated = await api.resolveDispute(dispute.id, {
+        status: resolveAction,
+        adminNote: adminNote.trim() || undefined,
+      });
+      setDispute(updated);
+      setResolveDialogOpen(false);
+    } catch (err: any) {
+      setError(err.response?.data?.message || 'Failed to update dispute');
+    } finally {
+      setIsActioning(false);
+    }
+  };
+
+  if (isLoading) {
+    return <div className="h-64 bg-muted animate-pulse rounded-lg" />;
+  }
+
+  if (!dispute) {
+    return (
+      <div className="space-y-4">
+        <Button variant="ghost" onClick={() => router.back()}>
+          <ArrowLeft className="mr-2 h-4 w-4" /> Back
+        </Button>
+        <p className="text-muted-foreground">Dispute not found.</p>
+      </div>
+    );
+  }
+
+  const isActionable = dispute.status === 'open' || dispute.status === 'under_review';
+
+  return (
+    <div className="space-y-6">
+      <PageHeader title={`Dispute #${dispute.id.slice(0, 8)}`}>
+        <Button variant="outline" onClick={() => router.back()}>
+          <ArrowLeft className="mr-2 h-4 w-4" />
+          Back
+        </Button>
+        {isActionable && (
+          <>
+            <Button
+              variant="outline"
+              size="sm"
+              className="text-emerald-600 border-emerald-300 hover:bg-emerald-50"
+              onClick={() => openResolveDialog('resolved')}
+            >
+              <CheckCircle className="mr-1 h-4 w-4" />
+              Resolve
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              className="text-slate-600 border-slate-300 hover:bg-slate-50"
+              onClick={() => openResolveDialog('closed')}
+            >
+              <XCircle className="mr-1 h-4 w-4" />
+              Close
+            </Button>
+          </>
+        )}
+      </PageHeader>
+
+      {error && (
+        <div className="rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-700">
+          {error}
+        </div>
+      )}
+
+      <div className="grid gap-4 md:grid-cols-2">
+        {/* Dispute details */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Dispute Details</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            <div className="flex justify-between items-center">
+              <span className="text-sm text-muted-foreground">Status</span>
+              <StatusBadge status={dispute.status} />
+            </div>
+            <Separator />
+            <div>
+              <p className="text-sm text-muted-foreground mb-1">Reason</p>
+              <p className="text-sm">{dispute.reason}</p>
+            </div>
+            {dispute.adminNote && (
+              <>
+                <Separator />
+                <div>
+                  <p className="text-sm text-muted-foreground mb-1">Admin Note</p>
+                  <p className="text-sm">{dispute.adminNote}</p>
+                </div>
+              </>
+            )}
+            <Separator />
+            <div className="flex justify-between">
+              <span className="text-sm text-muted-foreground">Opened</span>
+              <span className="text-sm">{formatDateTime(dispute.createdAt)}</span>
+            </div>
+            {dispute.resolvedAt && (
+              <div className="flex justify-between">
+                <span className="text-sm text-muted-foreground">Resolved</span>
+                <span className="text-sm">{formatDateTime(dispute.resolvedAt)}</span>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+
+        {/* Related booking */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Related Booking</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            {dispute.booking ? (
+              <>
+                <div className="flex justify-between">
+                  <span className="text-sm text-muted-foreground">Activity</span>
+                  <span className="text-sm font-medium">{dispute.booking.activity}</span>
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-sm text-muted-foreground">Scheduled</span>
+                  <span className="text-sm">{formatDateTime(dispute.booking.scheduledAt)}</span>
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-sm text-muted-foreground">Total Price</span>
+                  <span className="text-sm font-bold">{formatCurrency(dispute.booking.totalPrice)}</span>
+                </div>
+                <Separator />
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="w-full text-xs"
+                  onClick={() => router.push(`/bookings/${dispute.bookingId}`)}
+                >
+                  View Full Booking
+                </Button>
+              </>
+            ) : (
+              <p className="text-sm text-muted-foreground">Booking data unavailable.</p>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Participants */}
+      <div className="grid gap-4 md:grid-cols-3">
+        {/* Opened by */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Opened By</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div
+              className="flex items-center gap-3 cursor-pointer hover:bg-muted/50 rounded-lg p-2 -m-2 transition-colors"
+              onClick={() => router.push(`/users/${dispute.openedByUserId}`)}
+            >
+              <UserAvatar
+                name={dispute.openedByUser?.name || null}
+                avatarUrl={dispute.openedByUser?.avatarUrl || null}
+                size="md"
+              />
+              <div>
+                <p className="font-medium text-sm">{dispute.openedByUser?.name || 'Unknown'}</p>
+                <p className="text-xs text-muted-foreground">{dispute.openedByUser?.email}</p>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* Seeker */}
+        {dispute.booking?.seeker && (
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base">Seeker</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div
+                className="flex items-center gap-3 cursor-pointer hover:bg-muted/50 rounded-lg p-2 -m-2 transition-colors"
+                onClick={() => router.push(`/users/${dispute.booking.seekerId}`)}
+              >
+                <UserAvatar
+                  name={dispute.booking.seeker?.name || null}
+                  avatarUrl={dispute.booking.seeker?.avatarUrl || null}
+                  size="md"
+                />
+                <div>
+                  <p className="font-medium text-sm">{dispute.booking.seeker?.name || 'Unknown'}</p>
+                  <p className="text-xs text-muted-foreground">{dispute.booking.seeker?.email}</p>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        )}
+
+        {/* Companion */}
+        {dispute.booking?.companion && (
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base">Companion</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div
+                className="flex items-center gap-3 cursor-pointer hover:bg-muted/50 rounded-lg p-2 -m-2 transition-colors"
+                onClick={() => router.push(`/users/${dispute.booking.companionId}`)}
+              >
+                <UserAvatar
+                  name={dispute.booking.companion?.name || null}
+                  avatarUrl={dispute.booking.companion?.avatarUrl || null}
+                  size="md"
+                />
+                <div>
+                  <p className="font-medium text-sm">{dispute.booking.companion?.name || 'Unknown'}</p>
+                  <p className="text-xs text-muted-foreground">{dispute.booking.companion?.email}</p>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        )}
+      </div>
+
+      {/* Resolve/Close dialog */}
+      <Dialog open={resolveDialogOpen} onOpenChange={setResolveDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>
+              {resolveAction === 'resolved' ? 'Resolve Dispute' : 'Close Dispute'}
+            </DialogTitle>
+            <DialogDescription>
+              {resolveAction === 'resolved'
+                ? 'Mark this dispute as resolved. Optionally add an admin note visible to the team.'
+                : 'Close this dispute without a formal resolution. Optionally add an admin note.'}
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-2">
+            <Label htmlFor="admin-note">Admin Note (optional)</Label>
+            <Textarea
+              id="admin-note"
+              placeholder="Describe the outcome or reason for this decision..."
+              value={adminNote}
+              onChange={(e) => setAdminNote(e.target.value)}
+              rows={3}
+            />
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setResolveDialogOpen(false)}>
+              Cancel
+            </Button>
+            <Button
+              variant={resolveAction === 'resolved' ? 'default' : 'secondary'}
+              onClick={handleResolve}
+              disabled={isActioning}
+            >
+              {isActioning
+                ? 'Saving...'
+                : resolveAction === 'resolved'
+                ? 'Mark as Resolved'
+                : 'Close Dispute'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/admin/src/app/(dashboard)/disputes/page.tsx
+++ b/admin/src/app/(dashboard)/disputes/page.tsx
@@ -1,0 +1,146 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { useRouter } from 'next/navigation';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { PageHeader } from '@/components/admin/page-header';
+import { DataTable, Column } from '@/components/admin/data-table';
+import { StatusBadge } from '@/components/admin/status-badge';
+import { UserAvatar } from '@/components/admin/user-avatar';
+import { api } from '@/lib/api';
+import { Dispute, DisputeStatus } from '@/types';
+import { formatDateTime, truncate } from '@/lib/utils';
+
+const DISPUTE_STATUSES: Array<{ value: DisputeStatus | 'ALL'; label: string }> = [
+  { value: 'ALL', label: 'All statuses' },
+  { value: 'open', label: 'Open' },
+  { value: 'under_review', label: 'Under Review' },
+  { value: 'resolved', label: 'Resolved' },
+  { value: 'closed', label: 'Closed' },
+];
+
+const columns: Column<Dispute>[] = [
+  {
+    key: 'id',
+    header: 'ID',
+    cell: (d) => (
+      <span className="text-xs font-mono text-muted-foreground">{d.id.slice(0, 8)}</span>
+    ),
+  },
+  {
+    key: 'openedBy',
+    header: 'Opened By',
+    cell: (d) => (
+      <div className="flex items-center gap-2">
+        <UserAvatar
+          name={d.openedByUser?.name || null}
+          avatarUrl={d.openedByUser?.avatarUrl || null}
+          size="sm"
+        />
+        <div>
+          <p className="text-sm font-medium">{d.openedByUser?.name || 'Unknown'}</p>
+          <p className="text-xs text-muted-foreground">{d.openedByUser?.email}</p>
+        </div>
+      </div>
+    ),
+  },
+  {
+    key: 'booking',
+    header: 'Booking',
+    cell: (d) => (
+      <span className="text-sm font-medium">
+        {d.booking?.activity || <span className="text-muted-foreground italic">N/A</span>}
+      </span>
+    ),
+  },
+  {
+    key: 'reason',
+    header: 'Reason',
+    cell: (d) => (
+      <span className="text-sm text-muted-foreground">{truncate(d.reason, 60)}</span>
+    ),
+  },
+  {
+    key: 'status',
+    header: 'Status',
+    cell: (d) => <StatusBadge status={d.status} />,
+  },
+  {
+    key: 'createdAt',
+    header: 'Opened',
+    cell: (d) => (
+      <span className="text-sm text-muted-foreground">{formatDateTime(d.createdAt)}</span>
+    ),
+  },
+];
+
+export default function DisputesPage() {
+  const router = useRouter();
+  const [disputes, setDisputes] = useState<Dispute[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [status, setStatus] = useState<DisputeStatus | 'ALL'>('ALL');
+  const [page, setPage] = useState(1);
+  const [totalPages, setTotalPages] = useState(1);
+  const [total, setTotal] = useState(0);
+
+  const fetchDisputes = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      const result = await api.getDisputes({ page, limit: 20, status });
+      setDisputes(result.data);
+      setTotalPages(result.totalPages);
+      setTotal(result.total);
+    } catch (err) {
+      console.error('Failed to fetch disputes:', err);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [page, status]);
+
+  useEffect(() => {
+    fetchDisputes();
+  }, [fetchDisputes]);
+
+  useEffect(() => {
+    setPage(1);
+  }, [status]);
+
+  return (
+    <div className="space-y-6">
+      <PageHeader title="Disputes" description={`${total} total disputes`} />
+
+      <div className="flex gap-3">
+        <Select
+          value={status}
+          onValueChange={(v) => setStatus(v as DisputeStatus | 'ALL')}
+        >
+          <SelectTrigger className="w-52">
+            <SelectValue placeholder="Status" />
+          </SelectTrigger>
+          <SelectContent>
+            {DISPUTE_STATUSES.map((s) => (
+              <SelectItem key={s.value} value={s.value}>
+                {s.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <DataTable
+        columns={columns}
+        data={disputes}
+        isLoading={isLoading}
+        emptyMessage="No disputes found."
+        onRowClick={(d) => router.push(`/disputes/${d.id}`)}
+        pagination={{ page, totalPages, onPageChange: setPage }}
+      />
+    </div>
+  );
+}

--- a/admin/src/components/admin/sidebar-nav.tsx
+++ b/admin/src/components/admin/sidebar-nav.tsx
@@ -9,6 +9,7 @@ import {
   CreditCard,
   ShieldCheck,
   Star,
+  AlertTriangle,
   Settings,
   Rabbit,
 } from 'lucide-react';
@@ -21,6 +22,7 @@ const navItems = [
   { href: '/payments', label: 'Payments', icon: CreditCard },
   { href: '/verifications', label: 'Verifications', icon: ShieldCheck },
   { href: '/reviews', label: 'Reviews', icon: Star },
+  { href: '/disputes', label: 'Disputes', icon: AlertTriangle },
   { href: '/settings', label: 'Settings', icon: Settings },
 ];
 

--- a/admin/src/components/admin/status-badge.tsx
+++ b/admin/src/components/admin/status-badge.tsx
@@ -28,6 +28,12 @@ const statusConfig: Record<string, { label: string; variant: 'default' | 'second
 
   // Transaction statuses
   FAILED: { label: 'Failed', variant: 'destructive' },
+
+  // Dispute statuses (lowercase from backend)
+  open: { label: 'Open', variant: 'secondary' },
+  under_review: { label: 'Under Review', variant: 'outline' },
+  resolved: { label: 'Resolved', variant: 'default' },
+  closed: { label: 'Closed', variant: 'secondary' },
 };
 
 export function StatusBadge({ status }: StatusBadgeProps) {

--- a/admin/src/lib/api.ts
+++ b/admin/src/lib/api.ts
@@ -6,6 +6,8 @@ import {
   Transaction,
   VerificationSubmission,
   Review,
+  Dispute,
+  DisputeStatus,
   PlatformSettings,
   PaginatedResponse,
   DashboardStats,
@@ -202,6 +204,34 @@ class ApiClient {
 
   async deleteReview(id: string): Promise<void> {
     await this.client.delete(`/admin/reviews/${id}`);
+  }
+
+  // Disputes
+  async getDisputes(params: {
+    page?: number;
+    limit?: number;
+    status?: DisputeStatus | 'ALL';
+  }): Promise<PaginatedResponse<Dispute>> {
+    const { status, ...rest } = params;
+    const res = await this.client.get<{ items: Dispute[]; total: number; page: number; limit: number }>(
+      '/admin/disputes',
+      { params: { ...rest, status: status && status !== 'ALL' ? status : undefined } },
+    );
+    const { items, total, page, limit } = res.data;
+    return { data: items, total, page, limit, totalPages: Math.ceil(total / (limit || 20)) };
+  }
+
+  async getDisputeById(id: string): Promise<Dispute> {
+    const res = await this.client.get<Dispute>(`/admin/disputes/${id}`);
+    return res.data;
+  }
+
+  async resolveDispute(
+    id: string,
+    body: { status: 'resolved' | 'closed'; adminNote?: string },
+  ): Promise<Dispute> {
+    const res = await this.client.patch<Dispute>(`/admin/disputes/${id}/resolve`, body);
+    return res.data;
   }
 
   // Settings

--- a/admin/src/types/index.ts
+++ b/admin/src/types/index.ts
@@ -106,6 +106,32 @@ export interface Review {
   createdAt: string;
 }
 
+// Dispute types
+export type DisputeStatus = 'open' | 'under_review' | 'resolved' | 'closed';
+
+export interface Dispute {
+  id: string;
+  bookingId: string;
+  booking: {
+    id: string;
+    activity: string;
+    scheduledAt: string;
+    totalPrice: number;
+    seekerId: string;
+    companionId: string;
+    seeker: Pick<User, 'id' | 'name' | 'email' | 'avatarUrl'>;
+    companion: Pick<User, 'id' | 'name' | 'email' | 'avatarUrl'>;
+  };
+  openedByUserId: string;
+  openedByUser: Pick<User, 'id' | 'name' | 'email' | 'avatarUrl'>;
+  reason: string;
+  status: DisputeStatus;
+  adminNote: string | null;
+  resolvedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
 // Settings types
 export interface PlatformSettings {
   platformFeePercent: number;


### PR DESCRIPTION
## Summary
- Add `Dispute` type + `DisputeStatus` to `types/index.ts`
- Add `getDisputes`, `getDisputeById`, `resolveDispute` (PATCH) to `lib/api.ts` with correct backend `items`→`data` normalization
- Add lowercase dispute status entries to `StatusBadge` statusConfig
- Add Disputes nav item to sidebar
- Disputes list page: `/disputes` — status filter, pagination, click-through to detail
- Dispute detail page: `/disputes/[id]` — booking info, seeker/companion/opener cards, Resolve/Close dialog with optional admin note

## Test plan
- [ ] Navigate to `/disputes` — see list with status filter
- [ ] Filter by "Open" — only open disputes shown
- [ ] Click row — opens `/disputes/:id` detail page
- [ ] Detail shows booking info, participants
- [ ] Click "Resolve" — dialog opens, submit → status changes to resolved
- [ ] Click "Close" — dialog opens, submit → status changes to closed
- [ ] Resolved/closed disputes show grayed-out action buttons (hidden)
- [ ] Click booking link → navigates to `/bookings/:id`

Closes #2139