### PR TITLE
feat: date history screens (#2140)

### DIFF
--- a/app/app/(tabs)/male/bookings.tsx
+++ b/app/app/(tabs)/male/bookings.tsx
@@ -99,14 +99,33 @@ export default function BookingsScreen() {
     switch (activeTab) {
       case 'upcoming': return 'Your confirmed dates will appear here';
       case 'pending': return 'Waiting for companions to accept your requests';
-      case 'past': return 'Your date history will be shown here';
+      case 'past': return 'Completed and cancelled dates will appear here';
     }
+  };
+
+  const getEmptyAction = (): { label: string; action: () => void } | undefined => {
+    if (activeTab === 'past') {
+      return {
+        label: 'View Full History',
+        action: () => router.push('/bookings-history'),
+      };
+    }
+    return { label: 'Browse Companions', action: () => router.push('/(tabs)/male/browse') };
   };
 
   return (
     <View style={[styles.container, { backgroundColor: colors.background }]}>
       <View style={[styles.header, { paddingTop: insets.top + spacing.md }]}>
         <Text style={[styles.title, { color: colors.text }]}>My Bookings</Text>
+        {activeTab === 'past' && (
+          <TouchableOpacity
+            onPress={() => router.push('/bookings-history')}
+            accessibilityLabel="View full booking history"
+            accessibilityRole="button"
+          >
+            <Text style={[styles.historyLink, { color: colors.primary }]}>History</Text>
+          </TouchableOpacity>
+        )}
       </View>
 
       <View style={styles.tabs}>
@@ -148,8 +167,8 @@ export default function BookingsScreen() {
             icon="calendar"
             title={`No ${activeTab} bookings`}
             description={getEmptyDescription()}
-            actionLabel="Browse Companions"
-            onAction={() => router.push('/(tabs)/male/browse')}
+            actionLabel={getEmptyAction()?.label}
+            onAction={getEmptyAction()?.action}
           />
         ) : (
           bookings.map((booking) => (
@@ -352,10 +371,17 @@ const styles = StyleSheet.create({
   header: {
     paddingHorizontal: spacing.lg,
     paddingBottom: spacing.md,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
   },
   title: {
     fontFamily: typography.fonts.heading,
     fontSize: typography.sizes.xl,
+  },
+  historyLink: {
+    fontFamily: typography.fonts.bodyMedium,
+    fontSize: typography.sizes.sm,
   },
   tabs: {
     flexDirection: 'row',

--- a/app/app/bookings-history.tsx
+++ b/app/app/bookings-history.tsx
@@ -10,13 +10,13 @@ import {
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useRouter } from 'expo-router';
-import { Card } from '../../../../src/components/Card';
-import { UserImage } from '../../../../src/components/UserImage';
-import { Icon } from '../../../../src/components/Icon';
-import { useTheme, spacing, typography, borderRadius } from '../../../../src/constants/theme';
-import { bookingsApi, Booking } from '../../../../src/services/api';
+import { Card } from '../src/components/Card';
+import { UserImage } from '../src/components/UserImage';
+import { Icon } from '../src/components/Icon';
+import { useTheme, spacing, typography, borderRadius } from '../src/constants/theme';
+import { bookingsApi, Booking } from '../src/services/api';
 
-export default function EarningsHistoryScreen() {
+export default function BookingsHistoryScreen() {
   const insets = useSafeAreaInsets();
   const router = useRouter();
   const { colors } = useTheme();
@@ -45,7 +45,7 @@ export default function EarningsHistoryScreen() {
         setBookings((prev) => [...prev, ...fetched]);
       }
 
-      // getMyBookings returns total items — derive pages with page size 20
+      // getMyBookings returns total items — derive pages at page size 20
       const pages = Math.max(1, Math.ceil(response.total / 20));
       setTotalPages(pages);
       setPage(pageNum);
@@ -75,16 +75,18 @@ export default function EarningsHistoryScreen() {
   const formatDate = (dateStr: string) => {
     const date = new Date(dateStr);
     return date.toLocaleDateString(undefined, {
+      weekday: 'short',
       month: 'short',
       day: 'numeric',
       year: 'numeric',
     });
   };
 
-  const getStatusStyle = (status: string) => {
+  const getStatusStyle = (status: string, noShowReason?: string) => {
+    if (noShowReason) return { bg: colors.error + '20', text: colors.error };
     switch (status) {
       case 'completed':
-        return { bg: colors.success + '20', text: colors.success };
+        return { bg: colors.primary + '20', text: colors.primary };
       case 'cancelled':
         return { bg: colors.error + '20', text: colors.error };
       case 'active':
@@ -95,21 +97,28 @@ export default function EarningsHistoryScreen() {
   };
 
   const renderItem = ({ item }: { item: Booking }) => {
-    const seeker = item.seeker ?? { name: 'Unknown', photo: undefined };
-    const statusStyle = getStatusStyle(item.status);
+    const rawCompanion = item.companion;
+    const companion =
+      rawCompanion && rawCompanion.name
+        ? rawCompanion
+        : { name: 'Unknown', photo: null, rating: 0, id: '' };
+    const statusStyle = getStatusStyle(item.status, item.noShowReason);
+    const statusLabel = item.noShowReason ? 'no show' : item.status;
 
     return (
       <TouchableOpacity
         onPress={() => router.push(`/booking/${item.id}`)}
         activeOpacity={0.85}
         accessibilityRole="button"
-        accessibilityLabel={`View date with ${seeker.name}`}
+        accessibilityLabel={`View booking with ${companion.name}`}
       >
         <Card style={styles.card}>
           <View style={styles.cardRow}>
-            <UserImage name={seeker.name} uri={seeker.photo} size={48} />
+            <UserImage name={companion.name} uri={companion.photo} size={52} showVerified />
             <View style={styles.cardInfo}>
-              <Text style={[styles.seekerName, { color: colors.text }]}>{seeker.name}</Text>
+              <Text style={[styles.companionName, { color: colors.text }]}>
+                {companion.name}
+              </Text>
               <Text style={[styles.activity, { color: colors.textSecondary }]}>
                 {item.activity || 'Date'} • {item.duration || 1}h
               </Text>
@@ -118,12 +127,12 @@ export default function EarningsHistoryScreen() {
               </Text>
             </View>
             <View style={styles.cardRight}>
-              <Text style={[styles.earnings, { color: colors.success }]}>
-                +${(item.companionEarnings ?? 0).toFixed(2)}
+              <Text style={[styles.amount, { color: colors.text }]}>
+                ${item.total}
               </Text>
               <View style={[styles.statusBadge, { backgroundColor: statusStyle.bg }]}>
                 <Text style={[styles.statusText, { color: statusStyle.text }]}>
-                  {item.status}
+                  {statusLabel}
                 </Text>
               </View>
             </View>
@@ -147,9 +156,9 @@ export default function EarningsHistoryScreen() {
     return (
       <View style={styles.emptyContainer}>
         <Icon name="calendar" size={64} color={colors.textSecondary} />
-        <Text style={[styles.emptyTitle, { color: colors.text }]}>No past dates yet</Text>
+        <Text style={[styles.emptyTitle, { color: colors.text }]}>No past bookings</Text>
         <Text style={[styles.emptyText, { color: colors.textSecondary }]}>
-          Your completed dates will appear here
+          Your date history will appear here
         </Text>
       </View>
     );
@@ -166,7 +175,7 @@ export default function EarningsHistoryScreen() {
         >
           <Icon name="arrow-left" size={24} color={colors.text} />
         </TouchableOpacity>
-        <Text style={[styles.title, { color: colors.text }]}>Date History</Text>
+        <Text style={[styles.title, { color: colors.text }]}>Booking History</Text>
         <View style={styles.placeholder} />
       </View>
 
@@ -239,7 +248,7 @@ const styles = StyleSheet.create({
     flex: 1,
     marginLeft: spacing.md,
   },
-  seekerName: {
+  companionName: {
     fontFamily: typography.fonts.bodySemiBold,
     fontSize: typography.sizes.md,
   },
@@ -256,7 +265,7 @@ const styles = StyleSheet.create({
   cardRight: {
     alignItems: 'flex-end',
   },
-  earnings: {
+  amount: {
     fontFamily: typography.fonts.heading,
     fontSize: typography.sizes.md,
   },


### PR DESCRIPTION
## Summary
- **Seeker**: new `/bookings-history` screen — past bookings list (companion name, activity, date, amount, status badge); tapping a card opens `/booking/[id]`; accessible via "History" link in bookings tab header and "View Full History" in empty past-tab state
- **Companion**: rewrote `earnings/history.tsx` — replaced payment transactions with past bookings from `bookingsApi.getMyBookings('past')`; shows seeker name, activity, date, companionEarnings, status badge; tap -> `/booking/[id]`
- Direct `bookingsApi` calls (no store) to avoid state clobbering in the shared `bookings[]` slice
- Zero new TypeScript errors

## Files changed
- `app/app/bookings-history.tsx` (new)
- `app/app/(tabs)/female/earnings/history.tsx` (rewritten)
- `app/app/(tabs)/male/bookings.tsx` (added History link + dynamic empty state)

## Test plan
- [ ] Seeker: Bookings tab -> switch to Past -> tap "History" -> see paginated past booking cards -> tap card -> booking detail
- [ ] Seeker: Bookings tab -> Past tab with no bookings -> see "View Full History" empty state action
- [ ] Companion: Earnings tab -> "See All" -> see past dates list with seeker names and earnings amounts -> tap card -> booking detail
- [ ] Pull-to-refresh works on both screens
- [ ] Load-more works when total > 20

🤖 Generated with [Claude Code](https://claude.com/claude-code)