### PR TITLE
feat: refresh token system (access 15m + refresh 30d PostgreSQL)

### DIFF
--- a/app/src/services/api.ts
+++ b/app/src/services/api.ts
@@ -7,13 +7,35 @@ import { useNetworkStore } from '../store/networkStore';
 const API_BASE_URL = 'http://localhost:3004/api'; // audit mode — local backend with DEV_AUTH=true
 const API_TIMEOUT_MS = 10_000; // 10 seconds
 
-// Token management — stored in SecureStore (iOS Keychain / Android Keystore)
-// On web, falls back to localStorage since SecureStore is not available
+// Token storage keys
 const TOKEN_KEY = 'authToken';
+const REFRESH_TOKEN_KEY = 'refreshToken';
+
+// In-memory cache for tokens (avoids repeated SecureStore reads)
 let authToken: string | null = null;
+let refreshTokenCache: string | null = null;
+
+// ─── Refresh-cycle state ───────────────────────────────────────────────────
+// isRefreshing prevents concurrent 401 responses from triggering parallel refresh calls.
+// pendingQueue holds resolve/reject callbacks of requests that arrived during a refresh.
+let isRefreshing = false;
+type QueueEntry = { resolve: (token: string) => void; reject: (err: unknown) => void };
+let pendingQueue: QueueEntry[] = [];
+
+function drainQueue(token: string) {
+  pendingQueue.forEach((entry) => entry.resolve(token));
+  pendingQueue = [];
+}
+
+function rejectQueue(err: unknown) {
+  pendingQueue.forEach((entry) => entry.reject(err));
+  pendingQueue = [];
+}
 
 // Debounce timer for offline detection — prevents false banner on cold start / slow API
 let offlineTimer: ReturnType<typeof setTimeout> | null = null;
+
+// ─── Access token helpers ──────────────────────────────────────────────────
 
 export async function getToken(): Promise<string | null> {
   if (authToken) return authToken;
@@ -42,11 +64,103 @@ export async function setToken(token: string | null): Promise<void> {
   }
 }
 
+// ─── Refresh token helpers ─────────────────────────────────────────────────
+
+export async function getRefreshToken(): Promise<string | null> {
+  if (refreshTokenCache) return refreshTokenCache;
+  if (Platform.OS === 'web') {
+    refreshTokenCache = localStorage.getItem(REFRESH_TOKEN_KEY);
+  } else {
+    refreshTokenCache = await SecureStore.getItemAsync(REFRESH_TOKEN_KEY);
+  }
+  return refreshTokenCache;
+}
+
+export async function setRefreshToken(token: string | null): Promise<void> {
+  refreshTokenCache = token;
+  if (Platform.OS === 'web') {
+    if (token) {
+      localStorage.setItem(REFRESH_TOKEN_KEY, token);
+    } else {
+      localStorage.removeItem(REFRESH_TOKEN_KEY);
+    }
+  } else {
+    if (token) {
+      await SecureStore.setItemAsync(REFRESH_TOKEN_KEY, token);
+    } else {
+      await SecureStore.deleteItemAsync(REFRESH_TOKEN_KEY);
+    }
+  }
+}
+
+// ─── Internal refresh execution (called by interceptor and proactive refresh) ─
+
+/**
+ * Performs a single token rotation call against POST /auth/refresh.
+ * Updates both tokens in storage on success.
+ * Returns new access token, or throws on failure.
+ * NOT exported — callers should use attemptTokenRefresh().
+ */
+async function executeRefresh(): Promise<string> {
+  const stored = await getRefreshToken();
+  if (!stored) {
+    throw new ApiError('No refresh token available', 401);
+  }
+
+  // Direct fetch — bypasses apiRequest to avoid recursive 401 interception
+  const response = await fetch(`${API_BASE_URL}/auth/refresh`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ refreshToken: stored }),
+  });
+
+  if (!response.ok) {
+    const data = await response.json().catch(() => ({}));
+    throw new ApiError(data.message || 'Token refresh failed', response.status);
+  }
+
+  const data = await response.json();
+  const newAccessToken: string = data.accessToken || data.token;
+  const newRefreshToken: string = data.refreshToken;
+
+  await setToken(newAccessToken);
+  await setRefreshToken(newRefreshToken);
+
+  return newAccessToken;
+}
+
+/**
+ * Thread-safe token refresh: if a refresh is already in progress, queues the
+ * caller and resolves when the first refresh completes. Only one /auth/refresh
+ * request will be sent regardless of how many concurrent 401s triggered this.
+ */
+export async function attemptTokenRefresh(): Promise<string> {
+  if (isRefreshing) {
+    // Wait for the in-progress refresh to finish
+    return new Promise<string>((resolve, reject) => {
+      pendingQueue.push({ resolve, reject });
+    });
+  }
+
+  isRefreshing = true;
+  try {
+    const newToken = await executeRefresh();
+    drainQueue(newToken);
+    return newToken;
+  } catch (err) {
+    rejectQueue(err);
+    throw err;
+  } finally {
+    isRefreshing = false;
+  }
+}
+
 // API request helper
 interface RequestOptions {
   method?: 'GET' | 'POST' | 'PATCH' | 'PUT' | 'DELETE';
   body?: unknown;
   auth?: boolean;
+  _isRetry?: boolean; // internal flag — prevents recursive 401 retry
 }
 
 export class ApiError extends Error {
@@ -63,7 +177,7 @@ export async function apiRequest<T>(
   endpoint: string,
   options: RequestOptions = {}
 ): Promise<T> {
-  const { method = 'GET', body, auth = true } = options;
+  const { method = 'GET', body, auth = true, _isRetry = false } = options;
 
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',
@@ -111,6 +225,30 @@ export async function apiRequest<T>(
   }
   useNetworkStore.getState().setOnline();
 
+  // ── Reactive 401 interceptor ──────────────────────────────────────────────
+  // On 401: attempt token refresh once, then retry the original request.
+  // Guards:
+  //   - _isRetry=true  → already retried, don't loop again
+  //   - endpoint contains /auth/refresh → never retry refresh itself (circular)
+  //   - auth=false → no-auth endpoints can't benefit from a refresh
+  if (
+    response.status === 401 &&
+    auth &&
+    !_isRetry &&
+    !endpoint.includes('/auth/refresh')
+  ) {
+    try {
+      await attemptTokenRefresh();
+      // Retry original request with the new access token (already saved in storage)
+      return apiRequest<T>(endpoint, { ...options, _isRetry: true, auth: true });
+    } catch {
+      // Refresh failed — clear tokens and propagate 401 so logout can happen
+      await setToken(null);
+      await setRefreshToken(null);
+      throw new ApiError('Session expired. Please log in again.', 401);
+    }
+  }
+
   const data = await response.json().catch(() => ({}));
 
   if (!response.ok) {
@@ -124,6 +262,15 @@ export async function apiRequest<T>(
 }
 
 // Auth API
+// Shape returned by verify/register — includes both tokens plus backward-compat `token` alias
+export interface AuthTokenResponse {
+  success: boolean;
+  accessToken: string;
+  token: string;         // backward compat — same value as accessToken
+  refreshToken: string;
+  user: User;
+}
+
 export const authApi = {
   requestOtp: (email: string) =>
     apiRequest<{ success: boolean; isNewUser: boolean }>('/auth/start', {
@@ -133,7 +280,7 @@ export const authApi = {
     }),
 
   verifyOtp: (email: string, code: string) =>
-    apiRequest<{ success: boolean; token: string; user: User }>('/auth/verify', {
+    apiRequest<AuthTokenResponse>('/auth/verify', {
       method: 'POST',
       body: { email, code },
       auth: false,
@@ -148,9 +295,21 @@ export const authApi = {
     location?: string;
     hourlyRate?: number;
   }) =>
-    apiRequest<{ success: boolean; token: string; user: User }>('/auth/register', {
+    apiRequest<AuthTokenResponse>('/auth/register', {
       method: 'POST',
       body: data,
+    }),
+
+  refresh: (refreshToken: string) =>
+    apiRequest<AuthTokenResponse>('/auth/refresh', {
+      method: 'POST',
+      body: { refreshToken },
+      auth: false,
+    }),
+
+  logout: () =>
+    apiRequest<{ success: boolean }>('/auth/logout', {
+      method: 'POST',
     }),
 };
 

--- a/app/src/store/authStore.ts
+++ b/app/src/store/authStore.ts
@@ -2,8 +2,21 @@ import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import type { User, UserRole, VerificationStatus } from '../types';
-import { authApi, usersApi, setToken, getToken, ApiError, User as ApiUser } from '../services/api';
+import {
+  authApi,
+  usersApi,
+  setToken,
+  getToken,
+  setRefreshToken,
+  getRefreshToken,
+  attemptTokenRefresh,
+  ApiError,
+  User as ApiUser,
+} from '../services/api';
 import { useFavoritesStore } from './favoritesStore';
+
+// Proactive refresh: renew access token 20 minutes after last successful auth/refresh
+const PROACTIVE_REFRESH_INTERVAL_MS = 20 * 60 * 1000;
 
 type AuthStep = 'idle' | 'email' | 'otp' | 'onboarding' | 'authenticated';
 
@@ -101,6 +114,9 @@ function mapApiUserToUser(apiUser: ApiUser): User {
   };
 }
 
+// Module-level timer — survives re-renders, cleared on logout
+let proactiveRefreshTimer: ReturnType<typeof setInterval> | null = null;
+
 export const useAuthStore = create<AuthState>()(
   persist(
     (set, get) => ({
@@ -115,29 +131,72 @@ export const useAuthStore = create<AuthState>()(
       pendingEmail: null,
       error: null,
 
-      // Initialize - check if we have a saved token and fetch user
+      // Initialize - check if we have a saved token and fetch user.
+      // Level 3 refresh: attempt proactive token refresh on app start so the
+      // access token is always fresh (avoids first-request 401 after 15m).
       initialize: async () => {
-        const token = await getToken();
-        if (token) {
+        const [accessToken, storedRefreshToken] = await Promise.all([
+          getToken(),
+          getRefreshToken(),
+        ]);
+
+        if (!accessToken && !storedRefreshToken) {
+          // No session at all
+          return;
+        }
+
+        // If we have a refresh token, eagerly rotate it on start so the
+        // access token won't expire mid-session.
+        if (storedRefreshToken) {
           try {
-            const apiUser = await usersApi.getMe();
-            set({
-              user: mapApiUserToUser(apiUser),
-              isAuthenticated: true,
-              hasCompletedOnboarding: true,
-              authStep: 'authenticated',
-            });
-            // Sync favorites from server after successful auth
-            useFavoritesStore.getState().syncFromServer();
+            await attemptTokenRefresh();
           } catch {
-            // Token invalid, clear it
+            // Refresh token expired/invalid — clear session
             await setToken(null);
-            set({
-              user: null,
-              isAuthenticated: false,
-              authStep: 'idle',
-            });
+            await setRefreshToken(null);
+            set({ user: null, isAuthenticated: false, authStep: 'idle' });
+            return;
           }
+        }
+
+        try {
+          const apiUser = await usersApi.getMe();
+          set({
+            user: mapApiUserToUser(apiUser),
+            isAuthenticated: true,
+            hasCompletedOnboarding: true,
+            authStep: 'authenticated',
+          });
+          // Sync favorites from server after successful auth
+          useFavoritesStore.getState().syncFromServer();
+
+          // Level 2 refresh: proactive 20-minute interval keeps access token alive
+          // without waiting for a 401. Timer is module-scoped so it survives re-renders.
+          if (!proactiveRefreshTimer) {
+            proactiveRefreshTimer = setInterval(async () => {
+              const rt = await getRefreshToken();
+              if (!rt) return;
+              try {
+                await attemptTokenRefresh();
+              } catch {
+                // Proactive refresh failed — clear session, user will see 401 on next request
+                clearInterval(proactiveRefreshTimer!);
+                proactiveRefreshTimer = null;
+                await setToken(null);
+                await setRefreshToken(null);
+                useAuthStore.getState().setUser(null);
+              }
+            }, PROACTIVE_REFRESH_INTERVAL_MS);
+          }
+        } catch {
+          // Access token invalid and refresh already attempted — clear session
+          await setToken(null);
+          await setRefreshToken(null);
+          set({
+            user: null,
+            isAuthenticated: false,
+            authStep: 'idle',
+          });
         }
       },
 
@@ -175,8 +234,9 @@ export const useAuthStore = create<AuthState>()(
         try {
           const result = await authApi.verifyOtp(pendingEmail, code);
 
-          // Save the token
-          await setToken(result.token);
+          // Save both tokens (accessToken + refreshToken)
+          await setToken(result.accessToken || result.token);
+          await setRefreshToken(result.refreshToken);
 
           // Fetch user profile to determine if onboarding is needed
           try {
@@ -253,8 +313,9 @@ export const useAuthStore = create<AuthState>()(
             hourlyRate: data.role === 'companion' ? data.hourlyRate : undefined,
           });
 
-          // Save the new token
-          await setToken(result.token);
+          // Save both tokens
+          await setToken(result.accessToken || result.token);
+          await setRefreshToken(result.refreshToken);
 
           set({
             user: mapApiUserToUser(result.user),
@@ -324,7 +385,17 @@ export const useAuthStore = create<AuthState>()(
       }),
 
       logout: async () => {
+        // Stop proactive refresh interval
+        if (proactiveRefreshTimer) {
+          clearInterval(proactiveRefreshTimer);
+          proactiveRefreshTimer = null;
+        }
+
+        // Revoke refresh tokens server-side (best-effort, non-blocking)
+        authApi.logout().catch(() => {});
+
         await setToken(null);
+        await setRefreshToken(null);
         useFavoritesStore.getState().clearFavorites();
         set({
           user: null,

--- a/backend/daterabbit-api/src/auth/auth.controller.ts
+++ b/backend/daterabbit-api/src/auth/auth.controller.ts
@@ -3,7 +3,7 @@ import { Throttle } from '@nestjs/throttler';
 import { AuthService } from './auth.service';
 import { JwtAuthGuard } from './guards/jwt-auth.guard';
 import { UserRole } from '../users/entities/user.entity';
-import { SendOtpDto, VerifyOtpDto } from './dto/auth.dto';
+import { SendOtpDto, VerifyOtpDto, RefreshTokenDto } from './dto/auth.dto';
 
 @Controller('auth')
 export class AuthController {
@@ -40,6 +40,28 @@ export class AuthController {
     }
 
     return result;
+  }
+
+  /**
+   * POST /auth/refresh
+   * Accepts a valid refresh token, revokes it, and returns a new access+refresh pair.
+   * Rate limited to 30 calls per 10 minutes to prevent brute-force.
+   */
+  @Post('refresh')
+  @Throttle({ default: { limit: 30, ttl: 600000 } })
+  async refresh(@Body() body: RefreshTokenDto) {
+    return this.authService.rotateRefreshToken(body.refreshToken);
+  }
+
+  /**
+   * POST /auth/logout
+   * Revokes all refresh tokens for the authenticated user.
+   */
+  @Post('logout')
+  @UseGuards(JwtAuthGuard)
+  async logout(@Request() req) {
+    await this.authService.revokeAllUserTokens(req.user.id);
+    return { success: true };
   }
 
   @Post('register')

--- a/backend/daterabbit-api/src/auth/auth.module.ts
+++ b/backend/daterabbit-api/src/auth/auth.module.ts
@@ -1,24 +1,35 @@
 import { Module } from '@nestjs/common';
 import { JwtModule } from '@nestjs/jwt';
 import { PassportModule } from '@nestjs/passport';
+import { TypeOrmModule } from '@nestjs/typeorm';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { AuthService } from './auth.service';
 import { AuthController } from './auth.controller';
 import { JwtStrategy } from './strategies/jwt.strategy';
 import { UsersModule } from '../users/users.module';
 import { EmailModule } from '../email/email.module';
+import { RefreshToken } from './entities/refresh-token.entity';
 
 @Module({
   imports: [
     UsersModule,
     PassportModule,
     EmailModule,
+    TypeOrmModule.forFeature([RefreshToken]),
     JwtModule.registerAsync({
       imports: [ConfigModule],
       inject: [ConfigService],
       useFactory: (configService: ConfigService) => ({
         secret: configService.get('JWT_SECRET'),
-        signOptions: { expiresIn: configService.get('JWT_EXPIRATION', '7d') },
+        // JWT_ACCESS_EXPIRATION = 15m (new var). Falls back to JWT_EXPIRATION for
+        // backward compat, then to '7d' so existing deployments without the new
+        // env var don't instantly expire every token on deploy.
+        signOptions: {
+          expiresIn: configService.get(
+            'JWT_ACCESS_EXPIRATION',
+            configService.get('JWT_EXPIRATION', '15m'),
+          ),
+        },
       }),
     }),
   ],

--- a/backend/daterabbit-api/src/auth/auth.service.ts
+++ b/backend/daterabbit-api/src/auth/auth.service.ts
@@ -1,11 +1,17 @@
 import { Injectable, HttpException, HttpStatus } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { ConfigService } from '@nestjs/config';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
 import * as crypto from 'crypto';
 import { UsersService } from '../users/users.service';
 import { User, UserRole } from '../users/entities/user.entity';
 import { EmailService } from '../email/email.service';
 import { sanitizeText } from '../common/sanitize';
+import { RefreshToken } from './entities/refresh-token.entity';
+
+// Refresh token TTL: 30 days sliding window
+const REFRESH_TOKEN_TTL_DAYS = 30;
 
 @Injectable()
 export class AuthService {
@@ -18,6 +24,8 @@ export class AuthService {
     private jwtService: JwtService,
     private configService: ConfigService,
     private emailService: EmailService,
+    @InjectRepository(RefreshToken)
+    private refreshTokensRepository: Repository<RefreshToken>,
   ) {}
 
   generateOtp(): string {
@@ -27,6 +35,102 @@ export class AuthService {
     }
     return crypto.randomInt(100000, 1000000).toString();
   }
+
+  // ─── Refresh token helpers ─────────────────────────────────────────────────
+
+  private hashToken(plainToken: string): string {
+    return crypto.createHash('sha256').update(plainToken).digest('hex');
+  }
+
+  /**
+   * Creates a new refresh token in DB for the given userId.
+   * Returns the PLAIN token (stored only once, never persisted in plain form).
+   */
+  async createRefreshToken(userId: string): Promise<string> {
+    const plainToken = crypto.randomBytes(64).toString('hex');
+    const tokenHash = this.hashToken(plainToken);
+
+    const expiresAt = new Date(
+      Date.now() + REFRESH_TOKEN_TTL_DAYS * 24 * 60 * 60 * 1000,
+    );
+
+    const entity = this.refreshTokensRepository.create({
+      userId,
+      tokenHash,
+      expiresAt,
+      isRevoked: false,
+    });
+    await this.refreshTokensRepository.save(entity);
+
+    return plainToken;
+  }
+
+  /**
+   * Validates the incoming plain refresh token, revokes it, and issues a new pair.
+   * Implements token rotation: each refresh token can only be used once.
+   */
+  async rotateRefreshToken(plainToken: string): Promise<{
+    accessToken: string;
+    token: string; // backward compat alias
+    refreshToken: string;
+    user: Partial<User>;
+  }> {
+    const tokenHash = this.hashToken(plainToken);
+
+    const stored = await this.refreshTokensRepository.findOne({
+      where: { tokenHash },
+    });
+
+    if (!stored) {
+      throw new HttpException('Invalid refresh token', HttpStatus.UNAUTHORIZED);
+    }
+
+    if (stored.isRevoked) {
+      // Token reuse detected — revoke all tokens for this user (security measure)
+      await this.revokeAllUserTokens(stored.userId);
+      throw new HttpException(
+        'Refresh token already used. Please log in again.',
+        HttpStatus.UNAUTHORIZED,
+      );
+    }
+
+    if (stored.expiresAt < new Date()) {
+      throw new HttpException('Refresh token expired', HttpStatus.UNAUTHORIZED);
+    }
+
+    // Revoke the used token (rotation — each token usable exactly once)
+    await this.refreshTokensRepository.update(stored.id, { isRevoked: true });
+
+    const user = await this.usersService.findById(stored.userId);
+    if (!user || !user.isActive || user.deletedAt) {
+      throw new HttpException('Account is deactivated', HttpStatus.UNAUTHORIZED);
+    }
+
+    // Issue new pair
+    const accessToken = this.jwtService.sign({ id: user.id, email: user.email });
+    const newRefreshToken = await this.createRefreshToken(user.id);
+
+    const { otpCode, otpExpiresAt, otpAttempts, otpLockedUntil, ...safeUser } = user;
+
+    return {
+      accessToken,
+      token: accessToken, // backward compat
+      refreshToken: newRefreshToken,
+      user: safeUser,
+    };
+  }
+
+  /**
+   * Revokes all refresh tokens for a user (used on logout and on token reuse detection).
+   */
+  async revokeAllUserTokens(userId: string): Promise<void> {
+    await this.refreshTokensRepository.update(
+      { userId, isRevoked: false },
+      { isRevoked: true },
+    );
+  }
+
+  // ─── OTP Auth ──────────────────────────────────────────────────────────────
 
   async startAuth(email: string): Promise<{ success: boolean; isNewUser: boolean }> {
     let user = await this.usersService.findByEmail(email);
@@ -63,7 +167,17 @@ export class AuthService {
     return { success: true, isNewUser };
   }
 
-  async verifyOtp(email: string, code: string): Promise<{ success: boolean; token?: string; user?: User; error?: string }> {
+  async verifyOtp(
+    email: string,
+    code: string,
+  ): Promise<{
+    success: boolean;
+    accessToken?: string;
+    token?: string; // backward compat alias — old mobile clients read result.token
+    refreshToken?: string;
+    user?: User;
+    error?: string;
+  }> {
     const user = await this.usersService.findByEmail(email);
 
     if (!user) {
@@ -87,8 +201,10 @@ export class AuthService {
       return { success: false, error: 'OTP expired' };
     }
 
-    const isValid = user.otpCode.length === code.length &&
+    const isValid =
+      user.otpCode.length === code.length &&
       crypto.timingSafeEqual(Buffer.from(user.otpCode), Buffer.from(code));
+
     if (!isValid) {
       // Increment attempt counter in DB — visible to all PM2 cluster instances
       const newCount = await this.usersService.incrementOtpAttempts(
@@ -108,11 +224,18 @@ export class AuthService {
     await this.usersService.resetOtpAttempts(user.id);
     await this.usersService.clearOtp(user.id);
 
-    // Generate JWT
-    const token = this.jwtService.sign({ id: user.id, email: user.email });
+    // Generate access + refresh token pair
+    const accessToken = this.jwtService.sign({ id: user.id, email: user.email });
+    const refreshToken = await this.createRefreshToken(user.id);
 
     const { otpCode, otpExpiresAt, otpAttempts, otpLockedUntil, ...safeUser } = user;
-    return { success: true, token, user: safeUser as User };
+    return {
+      success: true,
+      accessToken,
+      token: accessToken, // backward compat — old clients read result.token
+      refreshToken,
+      user: safeUser as User,
+    };
   }
 
   async register(data: {
@@ -123,7 +246,14 @@ export class AuthService {
     location?: string;
     bio?: string;
     hourlyRate?: number;
-  }): Promise<{ success: boolean; token?: string; user?: User; error?: string }> {
+  }): Promise<{
+    success: boolean;
+    accessToken?: string;
+    token?: string; // backward compat alias
+    refreshToken?: string;
+    user?: User;
+    error?: string;
+  }> {
     // Sanitize user-facing text fields
     const sanitizedData = {
       ...data,
@@ -146,10 +276,18 @@ export class AuthService {
       user = await this.usersService.create(sanitizedData);
     }
 
-    const token = this.jwtService.sign({ id: user.id, email: user.email });
+    const accessToken = this.jwtService.sign({ id: user.id, email: user.email });
+    const refreshToken = await this.createRefreshToken(user.id);
+
     const { otpCode, otpExpiresAt, otpAttempts, otpLockedUntil, ...safeUser } = user;
 
-    return { success: true, token, user: safeUser as User };
+    return {
+      success: true,
+      accessToken,
+      token: accessToken, // backward compat — old clients read result.token
+      refreshToken,
+      user: safeUser as User,
+    };
   }
 
   validateToken(token: string): { id: string; email: string } | null {

--- a/backend/daterabbit-api/src/auth/dto/auth.dto.ts
+++ b/backend/daterabbit-api/src/auth/dto/auth.dto.ts
@@ -1,6 +1,12 @@
 import { IsEmail, IsNotEmpty, IsString, MaxLength } from 'class-validator';
 import { Transform } from 'class-transformer';
 
+export class RefreshTokenDto {
+  @IsString()
+  @IsNotEmpty()
+  refreshToken: string;
+}
+
 export class SendOtpDto {
   @IsEmail({}, { message: 'Invalid email format' })
   @MaxLength(254)

--- a/backend/daterabbit-api/src/auth/entities/refresh-token.entity.ts
+++ b/backend/daterabbit-api/src/auth/entities/refresh-token.entity.ts
@@ -1,0 +1,31 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  Index,
+} from 'typeorm';
+
+@Entity('refresh_tokens')
+export class RefreshToken {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Index()
+  @Column({ type: 'uuid' })
+  userId: string;
+
+  // Stored as SHA-256 hash — plain token returned to client once, never stored
+  @Index({ unique: true })
+  @Column({ type: 'varchar', length: 64 })
+  tokenHash: string;
+
+  @Column({ type: 'timestamp' })
+  expiresAt: Date;
+
+  @Column({ default: false })
+  isRevoked: boolean;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}

--- a/backend/daterabbit-api/src/auth/migrations/create-refresh-tokens.ts
+++ b/backend/daterabbit-api/src/auth/migrations/create-refresh-tokens.ts
@@ -1,0 +1,21 @@
+import { DataSource } from 'typeorm';
+
+/**
+ * Idempotent bootstrap migration: creates refresh_tokens table if it doesn't exist.
+ * Called from main.ts before the app starts listening.
+ * Needed because synchronize=false in production (TypeORM auto-sync disabled).
+ */
+export async function runRefreshTokensMigration(dataSource: DataSource): Promise<void> {
+  await dataSource.query(`
+    CREATE TABLE IF NOT EXISTS refresh_tokens (
+      id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+      "userId" UUID NOT NULL,
+      "tokenHash" VARCHAR(64) NOT NULL,
+      "expiresAt" TIMESTAMP NOT NULL,
+      "isRevoked" BOOLEAN NOT NULL DEFAULT FALSE,
+      "createdAt" TIMESTAMP NOT NULL DEFAULT NOW(),
+      CONSTRAINT "UQ_refresh_tokens_tokenHash" UNIQUE ("tokenHash")
+    );
+    CREATE INDEX IF NOT EXISTS "IDX_refresh_tokens_userId" ON refresh_tokens ("userId");
+  `);
+}

--- a/backend/daterabbit-api/src/main.ts
+++ b/backend/daterabbit-api/src/main.ts
@@ -1,11 +1,25 @@
 import { NestFactory } from '@nestjs/core';
 import { ValidationPipe } from '@nestjs/common';
+import { getDataSourceToken } from '@nestjs/typeorm';
+import { DataSource } from 'typeorm';
 import { AppModule } from './app.module';
+import { runRefreshTokensMigration } from './auth/migrations/create-refresh-tokens';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule, {
     rawBody: true,
   });
+
+  // Run idempotent bootstrap migration for refresh_tokens table
+  // Required because synchronize=false in production
+  try {
+    const dataSource = app.get<DataSource>(getDataSourceToken());
+    await runRefreshTokensMigration(dataSource);
+    console.log('refresh_tokens migration: OK');
+  } catch (err) {
+    console.error('refresh_tokens migration failed:', err);
+    // Non-fatal: app still starts, but refresh tokens won't work until fixed
+  }
 
   // Enable CORS
   const corsOrigins = ['https://daterabbit.smartlaunchhub.com'];
@@ -28,6 +42,6 @@ async function bootstrap() {
 
   const port = process.env.PORT || 3000;
   await app.listen(port);
-  console.log(`🚀 DateRabbit API running on port ${port}`);
+  console.log(`DateRabbit API running on port ${port}`);
 }
 bootstrap();


### PR DESCRIPTION
## Summary

- **refresh_tokens table**: TypeORM entity + idempotent SQL bootstrap migration (runs at startup, works in production where `synchronize=false`)
- **POST /auth/refresh**: token rotation — each refresh token is single-use; reuse triggers full revocation for the user
- **POST /auth/logout**: server-side revocation of all user refresh tokens
- **JWT_ACCESS_EXPIRATION=15m**: new env var, backward-compatible with JWT_EXPIRATION fallback
- **Client 3-level refresh**: reactive (401 interceptor + concurrent request queue), proactive (20-min interval), on app start
- **Backward compat**: `result.token` alias preserved alongside `accessToken` in all responses so existing mobile clients keep working during rolling deploy
- **Security**: refresh tokens stored as SHA-256 hashes, never plain text

## Files changed

**Backend:**
- `src/auth/entities/refresh-token.entity.ts` — new entity
- `src/auth/migrations/create-refresh-tokens.ts` — idempotent SQL migration
- `src/auth/auth.service.ts` — createRefreshToken, rotateRefreshToken, revokeAllUserTokens
- `src/auth/auth.controller.ts` — POST /auth/refresh, POST /auth/logout
- `src/auth/auth.module.ts` — TypeOrmModule.forFeature([RefreshToken]), JWT_ACCESS_EXPIRATION
- `src/auth/dto/auth.dto.ts` — RefreshTokenDto
- `src/main.ts` — run bootstrap migration before app starts

**Frontend:**
- `src/services/api.ts` — refresh token storage, attemptTokenRefresh(), 401 interceptor with isRefreshing guard + pending queue
- `src/store/authStore.ts` — save both tokens, proactive 20-min interval, on-start refresh, logout revocation

## Test plan

- `POST /api/auth/start + verify` → response includes `accessToken` + `refreshToken`
- `POST /api/auth/refresh { refreshToken }` → new pair returned, old token rejected on reuse
- Restart API → `POST /api/auth/refresh` still works (PostgreSQL-persisted)
- Wait 15m → next API call triggers 401 → interceptor refreshes → request succeeds transparently

Closes #2133