### PR TITLE
fix: admin panel basePath /admin for nginx routing

### DIFF
--- a/admin/next.config.ts
+++ b/admin/next.config.ts
@@ -1,7 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  basePath: '/admin',
 };
 
 export default nextConfig;

--- a/admin/src/lib/auth.ts
+++ b/admin/src/lib/auth.ts
@@ -45,7 +45,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     api.removeToken();
     setUser(null);
     if (typeof window !== 'undefined') {
-      window.location.href = '/login';
+      window.location.href = '/admin/login';
     }
   };
 


### PR DESCRIPTION
## Summary

- Adds `basePath: '/admin'` to `admin/next.config.ts` — nginx proxies `/admin/*` to port 3005 without path rewrite, so Next.js must know it lives at `/admin`
- Fixes `window.location.href = '/login'` → `/admin/login` in `auth.ts` — raw `window.location.href` does not respect Next.js `basePath`, so logout would redirect to the wrong URL without this fix

## Fixes

Closes task #2150. Unblocks task #2139 (admin disputes page).

## Verification

After deploy + rebuild on server:
\`\`\`bash
curl -s -o /dev/null -w "%{http_code}" https://daterabbit.smartlaunchhub.com/admin
# expect 200 or 307
curl -s -o /dev/null -w "%{http_code}" https://daterabbit.smartlaunchhub.com/admin/users
# expect 200 or 307
\`\`\`

## Test plan
- [ ] `https://daterabbit.smartlaunchhub.com/admin` returns 200/307 (not 404)
- [ ] `https://daterabbit.smartlaunchhub.com/admin/users` returns 200/307 (not 404)
- [ ] Logout redirects to `/admin/login` (not bare `/login`)
- [ ] Internal sidebar navigation still works (useRouter respects basePath)