### PR TITLE
fix: sync favorites from server on pull-to-refresh

### DIFF
--- a/app/app/favorites/index.tsx
+++ b/app/app/favorites/index.tsx
@@ -15,7 +15,7 @@ import * as Haptics from 'expo-haptics';
 export default function FavoritesScreen() {
   const insets = useSafeAreaInsets();
   const { colors } = useTheme();
-  const { favorites, toggleFavorite } = useFavoritesStore();
+  const { favorites, toggleFavorite, syncFromServer } = useFavoritesStore();
   
   const [favoriteCompanions, setFavoriteCompanions] = useState<CompanionDetail[]>([]);
   const [isLoading, setIsLoading] = useState(true);
@@ -46,9 +46,10 @@ export default function FavoritesScreen() {
 
   const onRefresh = useCallback(async () => {
     setRefreshing(true);
+    await syncFromServer();
     await fetchFavorites();
     setRefreshing(false);
-  }, [fetchFavorites]);
+  }, [fetchFavorites, syncFromServer]);
 
   const handleToggleFavorite = (id: string) => {
     if (Platform.OS !== 'web') {


### PR DESCRIPTION
## Summary
- Add `syncFromServer()` to destructure in `favorites/index.tsx`
- Call `await syncFromServer()` inside `onRefresh` before `fetchFavorites()`
- Add `syncFromServer` to `useCallback` deps array

Pull-to-refresh on the favorites screen now fetches the latest favorites
from the backend before reloading companion details, so changes made on
another device or via web are reflected immediately.

Closes task #2163

🤖 Generated with [Claude Code](https://claude.com/claude-code)