### PR TITLE
fix: payout amount validation (task #2164)

### DIFF
--- a/backend/daterabbit-api/src/payments/payments.service.ts
+++ b/backend/daterabbit-api/src/payments/payments.service.ts
@@ -137,6 +137,12 @@ export class PaymentsService {
     }
 
     const amount = Math.round(Number(booking.totalPrice) * 100); // cents
+    if (amount <= 0) {
+      throw new HttpException(
+        'Booking total price must be greater than zero',
+        HttpStatus.UNPROCESSABLE_ENTITY,
+      );
+    }
     const commissionRate = await this.getCommissionRate();
     const platformFee = Math.round(amount * commissionRate); // dynamic platform fee from PlatformSettings
 
@@ -458,10 +464,16 @@ export class PaymentsService {
     const payoutCents = amount ? Math.round(amount * 100) : availableCents;
 
     if (payoutCents <= 0) {
-      return { success: false, message: 'No available balance to pay out' };
+      throw new HttpException(
+        'Payout amount must be greater than zero',
+        HttpStatus.UNPROCESSABLE_ENTITY,
+      );
     }
     if (payoutCents > availableCents) {
-      return { success: false, message: 'Insufficient available balance' };
+      throw new HttpException(
+        'Payout amount exceeds available balance',
+        HttpStatus.UNPROCESSABLE_ENTITY,
+      );
     }
 
     const payout = await this.stripe.payouts.create(


### PR DESCRIPTION
## Summary

- `createPayout`: replaced silent `{ success: false }` returns with `HttpException(422)` for zero/negative amount and over-balance amount
- `createPaymentIntent`: added guard throwing `HttpException(422)` if booking `totalPrice` converts to <= 0 cents before hitting Stripe

## Test plan

- POST /payments/payouts/create with `amount: -10` → expect 422
- POST /payments/payouts/create with `amount: 0` → expect 422
- POST /payments/payouts/create with `amount: 99999` (exceeds balance) → expect 422
- POST /payments/bookings/:id/pay on booking with totalPrice=0 → expect 422
- Normal payout with valid amount → expect 200 success

Fixes task #2164