### PR TITLE
fix: route seeker from consent to Stripe Identity screen (UC-019)

### DIFF
--- a/app/app/(seeker-verify)/_layout.tsx
+++ b/app/app/(seeker-verify)/_layout.tsx
@@ -12,6 +12,10 @@ export default function SeekerVerifyLayout() {
       }}
     >
       <Stack.Screen name="intro" />
+      <Stack.Screen name="ssn" />
+      <Stack.Screen name="photo-id" />
+      <Stack.Screen name="selfie" />
+      <Stack.Screen name="consent" />
       <Stack.Screen name="pending" />
       <Stack.Screen name="approved" />
     </Stack>

--- a/app/app/(seeker-verify)/consent.tsx
+++ b/app/app/(seeker-verify)/consent.tsx
@@ -33,7 +33,8 @@ export default function SeekerConsentScreen() {
       Alert.alert('Submission Failed', apiError || 'Failed to submit for review. Please try again.');
       return;
     }
-    router.push('/(seeker-verify)/pending');
+    // After consent, send seeker to Stripe Identity verification (intro.tsx handles the session)
+    router.push('/(seeker-verify)/intro');
   };
 
   return (


### PR DESCRIPTION
## Summary

- After seeker submits consent, redirect to `/(seeker-verify)/intro` (Stripe Identity screen) instead of directly to `/(seeker-verify)/pending` — this was the broken link in UC-019
- Added missing `ssn`, `photo-id`, `selfie`, `consent` screen declarations to the `(seeker-verify)` Stack layout
- `submitForReview()` is kept in `consent.tsx` (it sets the DB `PENDING_REVIEW` flag required before Stripe session creation); `checkIdentityStatus()` in `intro.tsx` also sets this flag when Stripe confirms, so it's idempotent
- `(comp-onboard)/verify.tsx` confirmed correct — already uses `identity-session` endpoint, no changes needed

## Test plan

- [ ] Seeker flow: complete SSN → photo-id → selfie → consent → app navigates to intro screen (Stripe Identity), not pending
- [ ] On intro screen: tapping "Start Identity Verification" calls `POST /verification/identity-session`, opens WebBrowser
- [ ] After returning from browser: `checkIdentityStatus` is called → routes to pending or approved depending on result
- [ ] Dev mode (`DEV_AUTH=true`): identity session auto-approves after 2s, should end at approved screen

Fixes Task #2160