### PR TITLE
fix: KeyboardAvoidingView missing on 5 screens (task #2162)

### DIFF
--- a/app/app/booking/[id].tsx
+++ b/app/app/booking/[id].tsx
@@ -8,6 +8,8 @@ import {
   TextInput,
   ActivityIndicator,
   BackHandler,
+  KeyboardAvoidingView,
+  Platform,
 } from 'react-native';
 import { router, useLocalSearchParams } from 'expo-router';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -214,7 +216,10 @@ export default function BookingScreen() {
   }
 
   return (
-    <View style={[styles.container, { backgroundColor: colors.background }]}>
+    <KeyboardAvoidingView
+      style={[styles.container, { backgroundColor: colors.background }]}
+      behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+    >
       {/* Header */}
       <View style={[styles.header, { paddingTop: insets.top + spacing.sm, backgroundColor: colors.white, borderBottomColor: colors.border }]}>
         <TouchableOpacity style={[styles.backButton, { backgroundColor: colors.surface }]} onPress={handleBack} testID="booking-back-btn"
@@ -540,7 +545,7 @@ export default function BookingScreen() {
           testID="booking-submit-btn"
         />
       </View>
-    </View>
+    </KeyboardAvoidingView>
   );
 }
 

--- a/app/app/reviews/[id].tsx
+++ b/app/app/reviews/[id].tsx
@@ -8,6 +8,8 @@ import {
   ActivityIndicator,
   TextInput,
   Alert,
+  KeyboardAvoidingView,
+  Platform,
 } from 'react-native';
 import { useLocalSearchParams, router } from 'expo-router';
 import { colors, typography, shadows } from '../../src/constants/theme';
@@ -199,7 +201,10 @@ export default function ReviewDetailScreen() {
   );
 
   return (
-    <View style={styles.container}>
+    <KeyboardAvoidingView
+      style={styles.container}
+      behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+    >
       {/* Header */}
       <View style={styles.header}>
         <TouchableOpacity
@@ -244,7 +249,7 @@ export default function ReviewDetailScreen() {
           ItemSeparatorComponent={() => <View style={styles.separator} />}
         />
       )}
-    </View>
+    </KeyboardAvoidingView>
   );
 }
 

--- a/app/app/settings/delete-account.tsx
+++ b/app/app/settings/delete-account.tsx
@@ -6,6 +6,8 @@ import {
   ScrollView,
   TouchableOpacity,
   TextInput,
+  KeyboardAvoidingView,
+  Platform,
 } from 'react-native';
 import { router } from 'expo-router';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -51,7 +53,10 @@ export default function DeleteAccountScreen() {
   };
 
   return (
-    <View style={[styles.container, { backgroundColor: colors.background }]}>
+    <KeyboardAvoidingView
+      style={[styles.container, { backgroundColor: colors.background }]}
+      behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+    >
       <View style={[styles.header, { paddingTop: insets.top + spacing.sm, backgroundColor: colors.white, borderBottomColor: colors.border }]}>
         <TouchableOpacity style={[styles.backButton, { backgroundColor: colors.surface }]} onPress={() => router.back()}
           accessibilityLabel="Go back"
@@ -146,7 +151,7 @@ export default function DeleteAccountScreen() {
           </Text>
         </TouchableOpacity>
       </ScrollView>
-    </View>
+    </KeyboardAvoidingView>
   );
 }
 

--- a/app/app/settings/index.tsx
+++ b/app/app/settings/index.tsx
@@ -8,6 +8,8 @@ import {
   Switch,
   TextInput,
   ActivityIndicator,
+  KeyboardAvoidingView,
+  Platform,
 } from 'react-native';
 import { router } from 'expo-router';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -109,7 +111,10 @@ export default function SettingsScreen() {
   };
 
   return (
-    <View style={[styles.container, { backgroundColor: colors.background }]}>
+    <KeyboardAvoidingView
+      style={[styles.container, { backgroundColor: colors.background }]}
+      behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+    >
       <View style={[styles.header, { paddingTop: insets.top + spacing.sm, backgroundColor: colors.white, borderBottomColor: colors.border }]}>
         <TouchableOpacity style={[styles.backButton, { backgroundColor: colors.surface }]} onPress={() => router.back()}
           accessibilityLabel="Go back"
@@ -298,7 +303,7 @@ export default function SettingsScreen() {
         />
 
       </ScrollView>
-    </View>
+    </KeyboardAvoidingView>
   );
 }
 

--- a/app/app/settings/my-packages.tsx
+++ b/app/app/settings/my-packages.tsx
@@ -8,6 +8,8 @@ import {
   TextInput,
   ActivityIndicator,
   RefreshControl,
+  KeyboardAvoidingView,
+  Platform,
 } from 'react-native';
 import { router } from 'expo-router';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -151,7 +153,10 @@ export default function MyPackagesScreen() {
   }
 
   return (
-    <View style={[styles.container, { backgroundColor: colors.background }]}>
+    <KeyboardAvoidingView
+      style={[styles.container, { backgroundColor: colors.background }]}
+      behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+    >
       <View style={[styles.header, { paddingTop: insets.top + spacing.sm, backgroundColor: colors.white, borderBottomColor: colors.border }]}>
         <TouchableOpacity style={[styles.backButton, { backgroundColor: colors.surface }]} onPress={() => router.back()}>
           <Icon name="arrow-left" size={24} color={colors.text} />
@@ -347,7 +352,7 @@ export default function MyPackagesScreen() {
 
         <View style={{ height: spacing.xxl }} />
       </ScrollView>
-    </View>
+    </KeyboardAvoidingView>
   );
 }
 


### PR DESCRIPTION
## Summary

- Added `KeyboardAvoidingView` + `Platform` to 5 screens where keyboard was covering TextInput fields on iOS
- Pattern: `behavior={Platform.OS === 'ios' ? 'padding' : 'height'}`, wraps outermost container
- No new TS errors introduced (baseline errors are pre-existing in tests/)

## Screens fixed

- `app/app/booking/[id].tsx` — location + notes inputs (absolute bottomBar, no offset needed)
- `app/app/reviews/[id].tsx` — reply TextInput inside FlatList (KAV wraps root)
- `app/app/settings/index.tsx` — emergency contact name/email inputs
- `app/app/settings/delete-account.tsx` — "DELETE" confirmation input
- `app/app/settings/my-packages.tsx` — price + description inputs (create + edit forms)

## Test plan

- [ ] Open booking screen on iOS, scroll to location/notes fields, tap — keyboard should push content up not cover it
- [ ] Open reviews screen, tap Reply, keyboard should not cover the reply input
- [ ] Open Settings, tap emergency contact fields — keyboard avoids
- [ ] Open Delete Account, tap confirmation input — keyboard avoids
- [ ] Open My Packages, tap price/description — keyboard avoids

Fixes #2162