### PR TITLE
fix: CustomTabBar LucideIcon TS error (#2174)

### DIFF
--- a/app/src/components/CustomTabBar.tsx
+++ b/app/src/components/CustomTabBar.tsx
@@ -4,13 +4,13 @@ import { usePathname, useRouter } from 'expo-router';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { LinearGradient } from 'expo-linear-gradient';
 import { colors, spacing, typography, borderRadius, shadows } from '../constants/theme';
-import { Home, Search, Calendar, MessageCircle, User, Grid, Mail, Wallet } from 'lucide-react-native';
+import { Home, Search, Calendar, MessageCircle, User, Grid, Mail, Wallet, type LucideIcon } from 'lucide-react-native';
 import { useMessagesStore } from '../store/messagesStore';
 
 interface TabItem {
   name: string;
   path: string;
-  icon: React.ComponentType<{ size: number; color: string; strokeWidth?: number }>;
+  icon: LucideIcon;
   label: string;
 }
 


### PR DESCRIPTION
## Summary
- Replaces custom `ComponentType<{ size: number; ... }>` with the proper `LucideIcon` type imported from `lucide-react-native`
- Eliminates 10 TypeScript errors in `CustomTabBar.tsx` caused by `size: number` being narrower than `LucideProps.size` (`string | number | null | undefined`)
- No runtime behavior change — purely a type-level fix

## Test plan
- [ ] `npx tsc --noEmit` passes with no CustomTabBar errors
- [ ] Tab bar renders correctly with icons at runtime

Trinity: #2174