### PR TITLE
fix: show error feedback on fetch failure in favorites and bookings (#2167)

### DIFF
--- a/app/app/bookings-history.tsx
+++ b/app/app/bookings-history.tsx
@@ -27,8 +27,10 @@ export default function BookingsHistoryScreen() {
   const [page, setPage] = useState(1);
   const [totalPages, setTotalPages] = useState(1);
   const [loadingMore, setLoadingMore] = useState(false);
+  const [fetchError, setFetchError] = useState<string | null>(null);
 
   const fetchBookings = useCallback(async (pageNum: number, isRefresh = false) => {
+    setFetchError(null);
     try {
       if (isRefresh) {
         setRefreshing(true);
@@ -51,6 +53,7 @@ export default function BookingsHistoryScreen() {
       setPage(pageNum);
     } catch (error) {
       console.error('Failed to fetch past bookings:', error);
+      setFetchError('Failed to load history. Please try again.');
     } finally {
       setLoading(false);
       setRefreshing(false);
@@ -183,6 +186,20 @@ export default function BookingsHistoryScreen() {
         <View style={styles.loadingContainer}>
           <ActivityIndicator size="large" color={colors.primary} />
         </View>
+      ) : fetchError ? (
+        <View style={styles.errorContainer}>
+          <Icon name="alert-circle" size={64} color={colors.error} />
+          <Text style={[styles.errorTitle, { color: colors.text }]}>Something went wrong</Text>
+          <Text style={[styles.errorText, { color: colors.textSecondary }]}>{fetchError}</Text>
+          <TouchableOpacity
+            style={[styles.retryButton, { backgroundColor: colors.primary }]}
+            onPress={() => fetchBookings(1)}
+            accessibilityRole="button"
+            accessibilityLabel="Try again"
+          >
+            <Text style={[styles.retryButtonText, { color: colors.white }]}>Try Again</Text>
+          </TouchableOpacity>
+        </View>
       ) : (
         <FlatList
           data={bookings}
@@ -298,5 +315,33 @@ const styles = StyleSheet.create({
     fontFamily: typography.fonts.body,
     fontSize: typography.sizes.md,
     textAlign: 'center',
+  },
+  errorContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    paddingHorizontal: spacing.lg,
+  },
+  errorTitle: {
+    fontFamily: typography.fonts.heading,
+    fontSize: typography.sizes.lg,
+    marginTop: spacing.lg,
+    marginBottom: spacing.sm,
+  },
+  errorText: {
+    fontFamily: typography.fonts.body,
+    fontSize: typography.sizes.md,
+    textAlign: 'center',
+    marginBottom: spacing.lg,
+  },
+  retryButton: {
+    paddingHorizontal: spacing.xl,
+    paddingVertical: spacing.sm,
+    borderRadius: borderRadius.md,
+  },
+  retryButtonText: {
+    fontFamily: typography.fonts.bodySemiBold,
+    fontSize: typography.sizes.md,
+    fontWeight: '600',
   },
 });

--- a/app/app/favorites/index.tsx
+++ b/app/app/favorites/index.tsx
@@ -20,6 +20,7 @@ export default function FavoritesScreen() {
   const [favoriteCompanions, setFavoriteCompanions] = useState<CompanionDetail[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   const fetchFavorites = useCallback(async () => {
     if (favorites.length === 0) {
@@ -29,12 +30,14 @@ export default function FavoritesScreen() {
     }
 
     setIsLoading(true);
+    setError(null);
     try {
       const companionPromises = favorites.map(id => companionsApi.getById(id));
       const companions = await Promise.all(companionPromises);
       setFavoriteCompanions(companions);
     } catch (err) {
       console.error('Failed to fetch favorites:', err);
+      setError('Failed to load favorites. Please try again.');
     } finally {
       setIsLoading(false);
     }
@@ -46,6 +49,7 @@ export default function FavoritesScreen() {
 
   const onRefresh = useCallback(async () => {
     setRefreshing(true);
+    setError(null);
     await syncFromServer();
     await fetchFavorites();
     setRefreshing(false);
@@ -72,14 +76,27 @@ export default function FavoritesScreen() {
         <View style={{ width: 44 }} />
       </View>
 
-      <ScrollView 
-        style={styles.scrollView} 
+      <ScrollView
+        style={styles.scrollView}
         contentContainerStyle={styles.content}
         refreshControl={
           <RefreshControl refreshing={refreshing} onRefresh={onRefresh} />
         }
       >
-        {isLoading ? (
+        {error ? (
+          <View style={styles.errorContainer}>
+            <Icon name="alert-circle" size={48} color={colors.error} />
+            <Text style={[styles.errorText, { color: colors.text }]}>{error}</Text>
+            <TouchableOpacity
+              style={[styles.retryButton, { backgroundColor: colors.primary }]}
+              onPress={() => fetchFavorites()}
+              accessibilityRole="button"
+              accessibilityLabel="Retry loading favorites"
+            >
+              <Text style={[styles.retryButtonText, { color: colors.white }]}>Retry</Text>
+            </TouchableOpacity>
+          </View>
+        ) : isLoading ? (
           <View style={styles.loadingContainer}>
             <ActivityIndicator size="large" color={colors.primary} />
             <Text style={[styles.loadingText, { color: colors.textSecondary, marginTop: spacing.md }]}>Loading favorites...</Text>
@@ -288,5 +305,26 @@ const styles = StyleSheet.create({
   actions: {
     flexDirection: 'row',
     gap: spacing.md,
+  },
+  errorContainer: {
+    alignItems: 'center',
+    paddingTop: 60,
+    paddingHorizontal: spacing.lg,
+  },
+  errorText: {
+    fontSize: typography.sizes.md,
+    textAlign: 'center',
+    marginTop: spacing.md,
+    marginBottom: spacing.lg,
+  },
+  retryButton: {
+    paddingHorizontal: spacing.xl,
+    paddingVertical: spacing.sm,
+    borderRadius: borderRadius.md,
+  },
+  retryButtonText: {
+    fontFamily: typography.fonts.bodySemiBold,
+    fontSize: typography.sizes.md,
+    fontWeight: '600',
   },
 });


### PR DESCRIPTION
## Summary
- Replace silent catch blocks with proper error states and retry UI
- `favorites/index.tsx`: adds `error` state, shows banner with icon + message + Retry button
- `bookings-history.tsx`: adds `fetchError` state, shows full-screen error view with Try Again button

## Test plan
- [ ] Simulate network failure on Favorites screen → should see error banner with Retry button instead of blank screen
- [ ] Tap Retry → should attempt reload
- [ ] Simulate network failure on Booking History screen → should see full-screen error view
- [ ] Pull-to-refresh on Favorites → clears error state and retries
- [ ] TypeScript: no new errors introduced (baseline test-file errors remain unchanged)