### PR TITLE
fix: remove dangling ssn Stack.Screen (#2179)

### DIFF
--- a/app/app/(seeker-verify)/_layout.tsx
+++ b/app/app/(seeker-verify)/_layout.tsx
@@ -12,8 +12,7 @@ export default function SeekerVerifyLayout() {
       }}
     >
       <Stack.Screen name="intro" />
-      <Stack.Screen name="ssn" />
-      <Stack.Screen name="photo-id" />
+<Stack.Screen name="photo-id" />
       <Stack.Screen name="selfie" />
       <Stack.Screen name="consent" />
       <Stack.Screen name="pending" />


### PR DESCRIPTION
Removes orphaned Stack.Screen for ssn route that was deleted in #2161.

- Deleted `<Stack.Screen name="ssn" />` from `app/(seeker-verify)/_layout.tsx` line 15
- No new TypeScript errors introduced