### PR TITLE
feat: Expo push notifications for booking/message/payout events (#2165)

### DIFF
--- a/backend/daterabbit-api/src/bookings/bookings.controller.ts
+++ b/backend/daterabbit-api/src/bookings/bookings.controller.ts
@@ -3,6 +3,7 @@ import { FileInterceptor } from '@nestjs/platform-express';
 import { BookingsService } from './bookings.service';
 import { PaymentsService } from '../payments/payments.service';
 import { UploadsService } from '../uploads/uploads.service';
+import { UsersService } from '../users/users.service';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { BookingStatus, ActivityType } from './entities/booking.entity';
 import { NotificationsService } from '../notifications/notifications.service';
@@ -17,6 +18,7 @@ export class BookingsController {
     private paymentsService: PaymentsService,
     private notificationsService: NotificationsService,
     private uploadsService: UploadsService,
+    private usersService: UsersService,
     @Inject(forwardRef(() => ReviewsService))
     private reviewsService: ReviewsService,
   ) {}
@@ -76,6 +78,21 @@ export class BookingsController {
       notes: body.notes,
       packageId: body.packageId,
     });
+
+    // Event 1: Notify companion about new booking request (fire-and-forget)
+    this.usersService.findById(body.companionId).then((companion) => {
+      if (!companion) return;
+      this.notificationsService.create({
+        userId: companion.id,
+        type: NotificationType.BOOKING_NEW,
+        title: 'New Booking Request',
+        body: `${req.user.name || 'Someone'} wants to book you for ${body.activity}.`,
+        data: { bookingId: booking.id, seekerId: req.user.id },
+        pushToken: companion.expoPushToken,
+        notificationPreferences: companion.notificationPreferences,
+        notificationsEnabled: companion.notificationsEnabled,
+      }).catch(() => undefined);
+    }).catch(() => undefined);
 
     return booking;
   }
@@ -196,6 +213,22 @@ export class BookingsController {
       );
     }
     const updated = await this.bookingsService.confirm(id);
+
+    // Event 2: Notify seeker that booking was confirmed (fire-and-forget)
+    this.usersService.findById(booking.seekerId).then((seeker) => {
+      if (!seeker) return;
+      this.notificationsService.create({
+        userId: seeker.id,
+        type: NotificationType.BOOKING_CONFIRMED,
+        title: 'Booking Confirmed',
+        body: `${booking.companion?.name || 'Your companion'} confirmed your booking request.`,
+        data: { bookingId: booking.id, companionId: booking.companionId },
+        pushToken: seeker.expoPushToken,
+        notificationPreferences: seeker.notificationPreferences,
+        notificationsEnabled: seeker.notificationsEnabled,
+      }).catch(() => undefined);
+    }).catch(() => undefined);
+
     return this.formatBooking(updated);
   }
 
@@ -259,7 +292,8 @@ export class BookingsController {
     // UC-051: Notify the other party about cancellation
     const isCompanionCancelling = booking.companionId === req.user.id;
     if (isCompanionCancelling) {
-      // Companion declined -> notify seeker
+      // Event 3: Companion declined -> notify seeker (with push)
+      const seeker = await this.usersService.findById(booking.seekerId);
       await this.notificationsService.create({
         userId: booking.seekerId,
         type: NotificationType.BOOKING_DECLINED,
@@ -271,9 +305,13 @@ export class BookingsController {
           companionName: booking.companion?.name,
           reason: body.reason,
         },
+        pushToken: seeker?.expoPushToken,
+        notificationPreferences: seeker?.notificationPreferences,
+        notificationsEnabled: seeker?.notificationsEnabled,
       });
     } else {
-      // Seeker cancelled -> notify companion
+      // Seeker cancelled -> notify companion (with push)
+      const companion = await this.usersService.findById(booking.companionId);
       await this.notificationsService.create({
         userId: booking.companionId,
         type: NotificationType.BOOKING_CANCELLED,
@@ -285,6 +323,9 @@ export class BookingsController {
           seekerName: booking.seeker?.name,
           reason: body.reason,
         },
+        pushToken: companion?.expoPushToken,
+        notificationPreferences: companion?.notificationPreferences,
+        notificationsEnabled: companion?.notificationsEnabled,
       });
     }
 

--- a/backend/daterabbit-api/src/messages/messages.service.ts
+++ b/backend/daterabbit-api/src/messages/messages.service.ts
@@ -3,6 +3,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Message, Conversation } from './entities/message.entity';
 import { BookingsService } from '../bookings/bookings.service';
+import { UsersService } from '../users/users.service';
 import { NotificationsService } from '../notifications/notifications.service';
 import { NotificationType } from '../notifications/entities/notification.entity';
 import { sanitizeText } from '../common/sanitize';
@@ -18,6 +19,7 @@ export class MessagesService {
     @InjectRepository(Conversation)
     private conversationsRepository: Repository<Conversation>,
     private bookingsService: BookingsService,
+    private usersService: UsersService,
     private notificationsService: NotificationsService,
   ) {}
 
@@ -59,14 +61,18 @@ export class MessagesService {
       lastMessageAt: saved.createdAt,
     });
 
-    // Create notification for receiver (non-blocking)
+    // Event 4: Create notification for receiver with Expo push (non-blocking)
     try {
+      const receiver = await this.usersService.findById(receiverId);
       await this.notificationsService.create({
         userId: receiverId,
         type: NotificationType.NEW_MESSAGE,
         title: 'New Message',
         body: content.length > 100 ? content.slice(0, 100) + '...' : content,
         data: { senderId, conversationId: conversation.id },
+        pushToken: receiver?.expoPushToken,
+        notificationPreferences: receiver?.notificationPreferences,
+        notificationsEnabled: receiver?.notificationsEnabled,
       });
     } catch {
       // Notification failure must NOT break message delivery

--- a/backend/daterabbit-api/src/notifications/entities/notification.entity.ts
+++ b/backend/daterabbit-api/src/notifications/entities/notification.entity.ts
@@ -9,6 +9,7 @@ import {
 import { User } from '../../users/entities/user.entity';
 
 export enum NotificationType {
+  BOOKING_NEW = 'booking_new',
   BOOKING_CONFIRMED = 'booking_confirmed',
   BOOKING_DECLINED = 'booking_declined',
   BOOKING_CANCELLED = 'booking_cancelled',
@@ -19,6 +20,7 @@ export enum NotificationType {
   SAFETY_ALERT = 'safety_alert',
   REPORT_ISSUE = 'report_issue',
   COMPANION_ONLINE = 'companion_online',
+  PAYOUT_PROCESSED = 'payout_processed',
 }
 
 @Entity('notifications')

--- a/backend/daterabbit-api/src/notifications/notifications.service.ts
+++ b/backend/daterabbit-api/src/notifications/notifications.service.ts
@@ -10,15 +10,69 @@ export class NotificationsService {
     private notificationsRepository: Repository<Notification>,
   ) {}
 
+  /**
+   * Fire-and-forget Expo push. Silently skips if token is missing.
+   * Never throws — push failures must not affect DB notification saving.
+   */
+  async sendPush(
+    token: string | null | undefined,
+    title: string,
+    body: string,
+    data?: Record<string, any>,
+  ): Promise<void> {
+    if (!token) return;
+    try {
+      await fetch('https://exp.host/--/api/v2/push/send', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ to: token, title, body, data }),
+      });
+    } catch {
+      // push failure is non-critical
+    }
+  }
+
   async create(data: {
     userId: string;
     type: NotificationType;
     title: string;
     body: string;
     data?: Record<string, any>;
+    /** Optional: Expo push token of the recipient. If provided and notificationsEnabled, push is sent. */
+    pushToken?: string | null;
+    /** Optional: notificationPreferences JSON from user entity. Used to check per-category opt-in. */
+    notificationPreferences?: Record<string, boolean> | null;
+    /** Optional: whether user has globally enabled notifications. Defaults to true if not provided. */
+    notificationsEnabled?: boolean;
   }): Promise<Notification> {
-    const notification = this.notificationsRepository.create(data);
-    return this.notificationsRepository.save(notification);
+    const { pushToken, notificationPreferences, notificationsEnabled, ...notifData } = data;
+    const notification = this.notificationsRepository.create(notifData);
+    const saved = await this.notificationsRepository.save(notification);
+
+    // Determine per-category key for preference check
+    const prefKey = this.prefKeyForType(data.type);
+    const globalEnabled = notificationsEnabled !== false; // true if undefined
+    const categoryEnabled =
+      !notificationPreferences || // no prefs object means all enabled
+      notificationPreferences[prefKey] !== false;
+
+    if (pushToken && globalEnabled && categoryEnabled) {
+      // Fire-and-forget — don't await so DB save isn't delayed
+      this.sendPush(pushToken, data.title, data.body, data.data).catch(() => undefined);
+    }
+
+    return saved;
+  }
+
+  private prefKeyForType(type: NotificationType): string {
+    switch (type) {
+      case NotificationType.NEW_MESSAGE:
+        return 'messages';
+      case NotificationType.PAYOUT_PROCESSED:
+        return 'payments';
+      default:
+        return 'bookings';
+    }
   }
 
   async getByUser(userId: string, limit = 20, offset = 0): Promise<Notification[]> {

--- a/backend/daterabbit-api/src/payments/payments.module.ts
+++ b/backend/daterabbit-api/src/payments/payments.module.ts
@@ -3,11 +3,12 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { User } from '../users/entities/user.entity';
 import { Booking } from '../bookings/entities/booking.entity';
 import { PlatformSettings } from '../admin/entities/platform-settings.entity';
+import { NotificationsModule } from '../notifications/notifications.module';
 import { PaymentsService } from './payments.service';
 import { PaymentsController, WebhooksController } from './payments.controller';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([User, Booking, PlatformSettings])],
+  imports: [TypeOrmModule.forFeature([User, Booking, PlatformSettings]), NotificationsModule],
   providers: [PaymentsService],
   controllers: [PaymentsController, WebhooksController],
   exports: [PaymentsService],

--- a/backend/daterabbit-api/src/payments/payments.service.ts
+++ b/backend/daterabbit-api/src/payments/payments.service.ts
@@ -6,6 +6,8 @@ import Stripe from 'stripe';
 import { User, UserRole } from '../users/entities/user.entity';
 import { Booking, BookingStatus } from '../bookings/entities/booking.entity';
 import { PlatformSettings } from '../admin/entities/platform-settings.entity';
+import { NotificationsService } from '../notifications/notifications.service';
+import { NotificationType } from '../notifications/entities/notification.entity';
 
 @Injectable()
 export class PaymentsService {
@@ -19,6 +21,7 @@ export class PaymentsService {
     private bookingsRepo: Repository<Booking>,
     @InjectRepository(PlatformSettings)
     private settingsRepo: Repository<PlatformSettings>,
+    private notificationsService: NotificationsService,
   ) {
     const secretKey = this.configService.get('STRIPE_SECRET_KEY');
     if (secretKey) {
@@ -480,6 +483,18 @@ export class PaymentsService {
       { amount: payoutCents, currency: 'usd' },
       { stripeAccount: user.stripeAccountId },
     );
+
+    // Event 5: Notify companion that payout was processed (fire-and-forget)
+    this.notificationsService.create({
+      userId,
+      type: NotificationType.PAYOUT_PROCESSED,
+      title: 'Payout Initiated',
+      body: `Your payout of $${(payoutCents / 100).toFixed(2)} has been initiated and is on its way.`,
+      data: { payoutId: payout.id, amount: payoutCents / 100 },
+      pushToken: user.expoPushToken,
+      notificationPreferences: user.notificationPreferences,
+      notificationsEnabled: user.notificationsEnabled,
+    }).catch(() => undefined);
 
     return {
       success: true,


### PR DESCRIPTION
## Summary

- Adds Expo push delivery to `NotificationsService` via `sendPush()` helper (plain fetch, no new packages)
- Extends `create()` to accept optional `pushToken`/`notificationPreferences`/`notificationsEnabled` — callers pass them in, no circular dep issues
- Fills missing notification calls for events 1, 2, and 5 that were entirely absent before

## Events implemented

| # | Event | Who notified | Where |
|---|-------|-------------|-------|
| 1 | New booking request | Companion | `bookings.controller` `createBooking` |
| 2 | Booking confirmed | Seeker | `bookings.controller` `confirmBooking` |
| 3 | Booking declined | Seeker | `bookings.controller` `cancelBooking` (push added) |
| 4 | New message | Receiver | `messages.service` `sendMessage` (push added) |
| 5 | Payout processed | Companion | `payments.service` `createPayout` |

## Changes

- `notification.entity.ts` — added `BOOKING_NEW` and `PAYOUT_PROCESSED` enum values
- `notifications.service.ts` — added `sendPush()` + extended `create()` DTO
- `bookings.controller.ts` — added `UsersService` injection, events 1/2/3
- `messages.service.ts` — added `UsersService` injection, event 4 push delivery
- `payments.service.ts` — added `NotificationsService` injection, event 5
- `payments.module.ts` — imported `NotificationsModule`

## Test plan

- [ ] `tsc --noEmit` passes (verified: 0 errors)
- [ ] Create booking → companion receives push
- [ ] Confirm booking → seeker receives push
- [ ] Cancel booking (companion cancels) → seeker receives push
- [ ] Send message → receiver receives push
- [ ] Initiate payout → companion receives push