### PR TITLE
feat: identity webhook auto-approval (#2180)

### DIFF
--- a/backend/daterabbit-api/src/verification/verification.controller.ts
+++ b/backend/daterabbit-api/src/verification/verification.controller.ts
@@ -101,6 +101,13 @@ export class VerificationWebhookController {
     private readonly configService: ConfigService,
   ) {}
 
+  @Post('stripe-identity-webhook')
+  handleStripeIdentityWebhook(@Req() req: any) {
+    const rawBody: Buffer = req.rawBody;
+    const signature = req.headers['stripe-signature'] as string;
+    return this.verificationService.handleStripeIdentityWebhook(rawBody, signature);
+  }
+
   @Post('webhook')
   handleWebhook(
     @Body() payload: any,

--- a/backend/daterabbit-api/src/verification/verification.service.ts
+++ b/backend/daterabbit-api/src/verification/verification.service.ts
@@ -271,6 +271,56 @@ export class VerificationService {
     };
   }
 
+  async handleStripeIdentityWebhook(
+    rawBody: Buffer,
+    signature: string,
+  ): Promise<{ received: boolean }> {
+    if (!this.stripe) {
+      return { received: true };
+    }
+
+    const webhookSecret = this.configService.get<string>(
+      'STRIPE_IDENTITY_WEBHOOK_SECRET',
+    );
+
+    let event: import('stripe').Stripe.Event;
+    try {
+      event = this.stripe.webhooks.constructEvent(
+        rawBody,
+        signature,
+        webhookSecret ?? '',
+      );
+    } catch {
+      throw new BadRequestException('Invalid Stripe webhook signature');
+    }
+
+    switch (event.type) {
+      case 'identity.verification_session.verified': {
+        const session = event.data.object as import('stripe').Stripe.Identity.VerificationSession;
+        const verification = await this.verificationRepository.findOne({
+          where: { stripeVerificationSessionId: session.id },
+        });
+        if (!verification) break;
+        verification.stripeVerificationStatus = 'verified';
+        await this.verificationRepository.save(verification);
+        await this.approveVerification(verification.userId);
+        break;
+      }
+      case 'identity.verification_session.requires_input': {
+        const session = event.data.object as import('stripe').Stripe.Identity.VerificationSession;
+        const verification = await this.verificationRepository.findOne({
+          where: { stripeVerificationSessionId: session.id },
+        });
+        if (!verification) break;
+        verification.stripeVerificationStatus = 'requires_input';
+        await this.verificationRepository.save(verification);
+        break;
+      }
+    }
+
+    return { received: true };
+  }
+
   async handleWebhook(payload: any): Promise<{ received: boolean }> {
     // Mock webhook endpoint for future Checkr integration
     // In production, this would process Checkr background check results


### PR DESCRIPTION
## Summary
- Adds `handleStripeIdentityWebhook` method to `VerificationService` that handles `identity.verification_session.verified` and `identity.verification_session.requires_input` Stripe events
- Adds `POST /verification/stripe-identity-webhook` endpoint in `VerificationWebhookController` (no JWT guard, uses raw body + stripe-signature header)
- On `verified` event: finds verification by `stripeVerificationSessionId`, updates status, saves, then calls `approveVerification(userId)` for seeker auto-approval

## Test plan
- [ ] Deploy to staging
- [ ] Use Stripe CLI: `stripe trigger identity.verification_session.verified` with forwarding to `/api/verification/stripe-identity-webhook`
- [ ] Confirm seeker user gets `isVerified: true` and `verificationStatus: approved`