### PR TITLE
fix: Stripe Connect deep link return_url on native

### DIFF
--- a/app/src/services/api.ts
+++ b/app/src/services/api.ts
@@ -686,9 +686,10 @@ export const messagesApi = {
 // Payments API
 export const paymentsApi = {
   createConnectAccount: () =>
-    apiRequest<{ url: string }>('/payments/connect/onboard', {
-      method: 'POST',
-    }),
+    apiRequest<{ url: string }>(
+      `/payments/connect/onboard${Platform.OS !== 'web' ? '?platform=native' : ''}`,
+      { method: 'POST' },
+    ),
 
   getConnectStatus: () =>
     apiRequest<{ complete: boolean; payoutsEnabled: boolean }>('/payments/connect/status'),

--- a/backend/daterabbit-api/src/payments/payments.controller.ts
+++ b/backend/daterabbit-api/src/payments/payments.controller.ts
@@ -27,8 +27,11 @@ export class PaymentsController {
 
   @Post('connect/onboard')
   @UseGuards(JwtAuthGuard)
-  async createConnectAccount(@Request() req) {
-    return this.paymentsService.createConnectAccount(req.user.id);
+  async createConnectAccount(
+    @Request() req,
+    @Query('platform') platform?: string,
+  ) {
+    return this.paymentsService.createConnectAccount(req.user.id, platform);
   }
 
   @Get('connect/status')

--- a/backend/daterabbit-api/src/payments/payments.service.ts
+++ b/backend/daterabbit-api/src/payments/payments.service.ts
@@ -47,7 +47,7 @@ export class PaymentsService {
 
   // --- Connect (Companion onboarding) ---
 
-  async createConnectAccount(userId: string): Promise<{ url: string }> {
+  async createConnectAccount(userId: string, platform?: string): Promise<{ url: string }> {
     this.ensureStripe();
     const user = await this.usersRepo.findOne({ where: { id: userId } });
     if (!user) throw new HttpException('User not found', HttpStatus.NOT_FOUND);
@@ -64,10 +64,15 @@ export class PaymentsService {
       await this.usersRepo.update(userId, { stripeAccountId: accountId });
     }
 
+    const isNative = platform === 'native';
+    const webBase = this.configService.get('APP_URL', 'https://daterabbit.smartlaunchhub.com');
+    const refreshUrl = isNative ? 'daterabbit://stripe/refresh' : `${webBase}/stripe/refresh`;
+    const returnUrl = isNative ? 'daterabbit://stripe/return' : `${webBase}/stripe/return`;
+
     const accountLink = await this.stripe.accountLinks.create({
       account: accountId,
-      refresh_url: `${this.configService.get('APP_URL', 'https://daterabbit.smartlaunchhub.com')}/stripe/refresh`,
-      return_url: `${this.configService.get('APP_URL', 'https://daterabbit.smartlaunchhub.com')}/stripe/return`,
+      refresh_url: refreshUrl,
+      return_url: returnUrl,
       type: 'account_onboarding',
     });
 


### PR DESCRIPTION
## Summary

- Task #2178: When `platform=native` query param is passed, backend returns `daterabbit://` deep link URLs for Stripe Connect onboarding callbacks instead of web URLs
- Frontend (`app/src/services/api.ts`) automatically appends `?platform=native` when `Platform.OS !== 'web'`

## Changes

- `payments.service.ts`: `createConnectAccount(userId, platform?)` uses `daterabbit://stripe/return` and `daterabbit://stripe/refresh` when `platform === 'native'`
- `payments.controller.ts`: `@Query('platform')` added and forwarded to service
- `app/src/services/api.ts`: appends `?platform=native` when `Platform.OS !== 'web'`

## How to verify

`POST /payments/connect/onboard?platform=native` → returned Stripe account link URL contains `daterabbit://` in `return_url` / `refresh_url` params

🤖 Generated with [Claude Code](https://claude.com/claude-code)