### PR TITLE
fix(security): enforce 21+ age check in Stripe Identity webhook

### DIFF
--- a/backend/daterabbit-api/src/verification/verification.service.ts
+++ b/backend/daterabbit-api/src/verification/verification.service.ts
@@ -259,8 +259,8 @@ export class VerificationService {
     if (session.status === 'verified') {
       verification.status = VerificationStatus.PENDING_REVIEW;
       await this.verificationRepository.save(verification);
-      // Trigger approval — in production this would come via webhook
-      await this.approveVerification(userId);
+      // Trigger approval with age check — in production this would come via webhook
+      await this.approveOrRejectByAge(userId, session);
     } else {
       await this.verificationRepository.save(verification);
     }
@@ -303,7 +303,7 @@ export class VerificationService {
         if (!verification) break;
         verification.stripeVerificationStatus = 'verified';
         await this.verificationRepository.save(verification);
-        await this.approveVerification(verification.userId);
+        await this.approveOrRejectByAge(verification.userId, session);
         break;
       }
       case 'identity.verification_session.requires_input': {
@@ -347,6 +347,49 @@ export class VerificationService {
     }
 
     return { received: true };
+  }
+
+  private async approveOrRejectByAge(
+    userId: string,
+    session: import('stripe').Stripe.Identity.VerificationSession,
+  ): Promise<void> {
+    const dob = session.verified_outputs?.dob;
+    if (!dob || dob.year == null || dob.month == null || dob.day == null) {
+      const verification = await this.verificationRepository.findOne({ where: { userId } });
+      if (!verification) return;
+      verification.status = VerificationStatus.REJECTED;
+      verification.rejectionReason = 'Age could not be verified';
+      await this.verificationRepository.save(verification);
+      await this.usersService.update(userId, {
+        isVerified: false,
+        verificationStatus: UserVerificationStatus.REJECTED,
+      });
+      return;
+    }
+
+    // Stripe month is 1-indexed; JS Date month is 0-indexed
+    const birthDate = new Date(dob.year, dob.month - 1, dob.day);
+    const now = new Date();
+    let age = now.getFullYear() - birthDate.getFullYear();
+    const monthDiff = now.getMonth() - birthDate.getMonth();
+    if (monthDiff < 0 || (monthDiff === 0 && now.getDate() < birthDate.getDate())) {
+      age--;
+    }
+
+    if (age < 21) {
+      const verification = await this.verificationRepository.findOne({ where: { userId } });
+      if (!verification) return;
+      verification.status = VerificationStatus.REJECTED;
+      verification.rejectionReason = 'Under 21: age verification failed';
+      await this.verificationRepository.save(verification);
+      await this.usersService.update(userId, {
+        isVerified: false,
+        verificationStatus: UserVerificationStatus.REJECTED,
+      });
+      return;
+    }
+
+    await this.approveVerification(userId);
   }
 
   private async approveVerification(userId: string): Promise<void> {


### PR DESCRIPTION
## Summary

Task #2200: Legal requirement — DateRabbit is a 21+ platform. Age was not being checked after Stripe Identity verification, creating legal exposure.

- Added `approveOrRejectByAge()` private helper that reads `verified_outputs.dob` from the Stripe session
- Null DOB → REJECT ("Age could not be verified") — safe default
- Age < 21 → REJECT ("Under 21: age verification failed")
- Age >= 21 → calls existing `approveVerification()`
- JS 0-indexed month correctly handled (Stripe sends 1-indexed)
- Both paths covered: `handleStripeIdentityWebhook()` + `checkIdentityStatus()` polling path
- Dev-mode stubs unchanged (no real DOB in dev mode)

## Test plan
- [ ] Stripe webhook with verified session containing DOB age 20 → user rejected
- [ ] Stripe webhook with verified session containing DOB age 21+ → user approved
- [ ] Stripe webhook with verified session containing null DOB → user rejected
- [ ] `checkIdentityStatus()` poll with verified Stripe session → same age logic applies

🤖 Generated with [Claude Code](https://claude.com/claude-code)