### PR TITLE
feat: companion onboarding completion gate — block publish until profile complete

### DIFF
--- a/app/app/(comp-onboard)/approved.tsx
+++ b/app/app/(comp-onboard)/approved.tsx
@@ -75,7 +75,7 @@ export default function CompanionApprovedScreen() {
         <Animated.View style={[styles.textContainer, textStyle]}>
           <Text style={styles.title}>You're Approved!</Text>
           <Text style={styles.description}>
-            Your companion profile has been verified. You're now ready to receive bookings.
+            Your companion profile has been approved. Complete your profile to start receiving bookings.
           </Text>
 
           <View style={styles.featuresRow}>

--- a/app/app/(tabs)/female/index.tsx
+++ b/app/app/(tabs)/female/index.tsx
@@ -98,6 +98,28 @@ export default function FemaleDashboard() {
         />
       </View>
 
+      {/* Profile incomplete gate — shown when profile is not yet published */}
+      {!user?.isPublicProfile && (
+        <TouchableOpacity
+          style={styles.incompleteGate}
+          onPress={() => router.push('/settings')}
+          activeOpacity={0.85}
+          accessibilityLabel="Complete your profile to start receiving bookings"
+          accessibilityRole="button"
+        >
+          <View style={styles.incompleteGateLeft}>
+            <Icon name="alert-circle" size={20} color={colors.warning} />
+            <View style={styles.incompleteGateText}>
+              <Text style={styles.incompleteGateTitle}>Profile Incomplete</Text>
+              <Text style={styles.incompleteGateDesc}>
+                Add a photo, set your rate and bio to go live
+              </Text>
+            </View>
+          </View>
+          <Icon name="chevron-right" size={18} color={colors.warning} />
+        </TouchableOpacity>
+      )}
+
       {/* Verification reminder */}
       <VerificationBanner />
 
@@ -468,5 +490,37 @@ const styles = StyleSheet.create({
     fontFamily: typography.fonts.body,
     fontSize: typography.sizes.sm,
     color: colors.textMuted,
+  },
+  incompleteGate: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    backgroundColor: colors.warningLight,
+    borderWidth: 1.5,
+    borderColor: colors.warning,
+    borderRadius: borderRadius.md,
+    paddingVertical: spacing.md,
+    paddingHorizontal: spacing.md,
+    marginBottom: spacing.lg,
+  },
+  incompleteGateLeft: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+    flex: 1,
+  },
+  incompleteGateText: {
+    flex: 1,
+  },
+  incompleteGateTitle: {
+    fontFamily: typography.fonts.bodySemiBold,
+    fontSize: typography.sizes.sm,
+    color: colors.text,
+    marginBottom: 2,
+  },
+  incompleteGateDesc: {
+    fontFamily: typography.fonts.body,
+    fontSize: typography.sizes.xs,
+    color: colors.textSecondary,
   },
 });

--- a/backend/daterabbit-api/src/auth/auth.service.ts
+++ b/backend/daterabbit-api/src/auth/auth.service.ts
@@ -272,8 +272,12 @@ export class AuthService {
       }
       user = updated;
     } else {
-      // Create new user
-      user = await this.usersService.create(sanitizedData);
+      // Create new user — companions start with profile hidden until they complete onboarding
+      const createData =
+        sanitizedData.role === UserRole.COMPANION
+          ? { ...sanitizedData, isPublicProfile: false }
+          : sanitizedData;
+      user = await this.usersService.create(createData);
     }
 
     const accessToken = this.jwtService.sign({ id: user.id, email: user.email });

--- a/backend/daterabbit-api/src/users/entities/user.entity.ts
+++ b/backend/daterabbit-api/src/users/entities/user.entity.ts
@@ -80,7 +80,7 @@ export class User {
   @Column({ default: false })
   isAdmin: boolean;
 
-  @Column({ default: true })
+  @Column({ default: false })
   isPublicProfile: boolean;
 
   @Column({ nullable: true })


### PR DESCRIPTION
## Summary
- Fix `isPublicProfile` default from `true` to `false` in `user.entity.ts` — new companions are now hidden until they complete their profile
- Explicitly set `isPublicProfile: false` for new companions in `auth.service.ts register()` as belt-and-suspenders guard
- Add "Profile Incomplete" warning banner to companion dashboard (`female/index.tsx`) — shows when `!user.isPublicProfile`, taps to `/settings`
- Fix misleading text in `approved.tsx`: "You're now ready to receive bookings" → "Complete your profile to start receiving bookings"

## Migration
Not needed — `synchronize: true` for non-production (app.module.ts line 54). Entity change alone updates the column default.

Existing companions are NOT affected (no `UPDATE users SET isPublicProfile=false` — only the column default changes).

## Test plan
- [ ] Register new companion → `isPublicProfile` is `false` in DB
- [ ] Companion dashboard shows "Profile Incomplete" banner
- [ ] Tapping banner navigates to `/settings`
- [ ] Existing companions with `isPublicProfile=true` remain unaffected
- [ ] After companion fills profile and admin sets `isPublicProfile=true`, banner disappears

🤖 Generated with [Claude Code](https://claude.com/claude-code)