### PR TITLE
feat: companion approval/rejection notifications

### DIFF
--- a/backend/daterabbit-api/src/admin/admin.module.ts
+++ b/backend/daterabbit-api/src/admin/admin.module.ts
@@ -13,6 +13,7 @@ import { PlatformSettings } from './entities/platform-settings.entity';
 import { Dispute } from '../disputes/entities/dispute.entity';
 import { UsersModule } from '../users/users.module';
 import { CitiesModule } from '../cities/cities.module';
+import { NotificationsModule } from '../notifications/notifications.module';
 
 @Module({
   imports: [
@@ -27,6 +28,7 @@ import { CitiesModule } from '../cities/cities.module';
     }),
     UsersModule,
     CitiesModule,
+    NotificationsModule,
   ],
   controllers: [AdminController],
   providers: [AdminService, AdminGuard],

--- a/backend/daterabbit-api/src/admin/admin.service.ts
+++ b/backend/daterabbit-api/src/admin/admin.service.ts
@@ -10,6 +10,8 @@ import { CitiesService } from '../cities/cities.service';
 import { CreateCityDto } from '../cities/dto/create-city.dto';
 import { UpdateCityDto } from '../cities/dto/update-city.dto';
 import { Dispute, DisputeStatus } from '../disputes/entities/dispute.entity';
+import { NotificationsService } from '../notifications/notifications.service';
+import { NotificationType } from '../notifications/entities/notification.entity';
 
 @Injectable()
 export class AdminService {
@@ -27,6 +29,7 @@ export class AdminService {
     @InjectRepository(Dispute)
     private disputesRepo: Repository<Dispute>,
     private readonly citiesService: CitiesService,
+    private readonly notificationsService: NotificationsService,
   ) {}
 
   async getStats() {
@@ -314,6 +317,20 @@ export class AdminService {
       verificationStatus: 'approved' as any,
     });
 
+    const user = await this.usersRepo.findOne({ where: { id: verification.userId } });
+    if (user) {
+      this.notificationsService.create({
+        userId: user.id,
+        type: NotificationType.VERIFICATION_APPROVED,
+        title: 'Verification Approved',
+        body: 'Congratulations! Your profile is now live on DateRabbit.',
+        recipientEmail: user.email,
+        pushToken: user.expoPushToken,
+        notificationPreferences: user.notificationPreferences,
+        notificationsEnabled: user.notificationsEnabled,
+      }).catch(() => undefined);
+    }
+
     return { success: true };
   }
 
@@ -331,6 +348,20 @@ export class AdminService {
       isVerified: false,
       verificationStatus: 'rejected' as any,
     });
+
+    const user = await this.usersRepo.findOne({ where: { id: verification.userId } });
+    if (user) {
+      this.notificationsService.create({
+        userId: user.id,
+        type: NotificationType.VERIFICATION_REJECTED,
+        title: 'Verification Not Approved',
+        body: 'Your verification was not approved. Please re-submit with clearer photos.',
+        recipientEmail: user.email,
+        pushToken: user.expoPushToken,
+        notificationPreferences: user.notificationPreferences,
+        notificationsEnabled: user.notificationsEnabled,
+      }).catch(() => undefined);
+    }
 
     return { success: true };
   }

--- a/backend/daterabbit-api/src/notifications/entities/notification.entity.ts
+++ b/backend/daterabbit-api/src/notifications/entities/notification.entity.ts
@@ -21,6 +21,8 @@ export enum NotificationType {
   REPORT_ISSUE = 'report_issue',
   COMPANION_ONLINE = 'companion_online',
   PAYOUT_PROCESSED = 'payout_processed',
+  VERIFICATION_APPROVED = 'verification_approved',
+  VERIFICATION_REJECTED = 'verification_rejected',
 }
 
 @Entity('notifications')

--- a/backend/daterabbit-api/src/verification/verification.module.ts
+++ b/backend/daterabbit-api/src/verification/verification.module.ts
@@ -7,6 +7,7 @@ import { VerificationService } from './verification.service';
 import { VerificationController, VerificationWebhookController } from './verification.controller';
 import { UsersModule } from '../users/users.module';
 import { UploadsModule } from '../uploads/uploads.module';
+import { NotificationsModule } from '../notifications/notifications.module';
 
 @Module({
   imports: [
@@ -25,6 +26,7 @@ import { UploadsModule } from '../uploads/uploads.module';
     }),
     UsersModule,
     UploadsModule,
+    NotificationsModule,
   ],
   providers: [VerificationService],
   controllers: [VerificationController, VerificationWebhookController],

--- a/backend/daterabbit-api/src/verification/verification.service.ts
+++ b/backend/daterabbit-api/src/verification/verification.service.ts
@@ -19,6 +19,8 @@ import { SubmitSsnDto } from './dto/submit-ssn.dto';
 import { SubmitReferencesDto } from './dto/submit-references.dto';
 import { SubmitConsentDto } from './dto/submit-consent.dto';
 import { UserRole, UserVerificationStatus } from '../users/entities/user.entity';
+import { NotificationsService } from '../notifications/notifications.service';
+import { NotificationType } from '../notifications/entities/notification.entity';
 
 @Injectable()
 export class VerificationService {
@@ -30,6 +32,7 @@ export class VerificationService {
     private usersService: UsersService,
     private uploadsService: UploadsService,
     private configService: ConfigService,
+    private readonly notificationsService: NotificationsService,
   ) {
     const secretKey = this.configService.get<string>('STRIPE_SECRET_KEY');
     if (secretKey) {
@@ -404,6 +407,20 @@ export class VerificationService {
       isVerified: true,
       verificationStatus: UserVerificationStatus.APPROVED,
     });
+
+    const user = await this.usersService.findById(userId);
+    if (user) {
+      this.notificationsService.create({
+        userId: user.id,
+        type: NotificationType.VERIFICATION_APPROVED,
+        title: 'Verification Approved',
+        body: 'Congratulations! Your profile is now live on DateRabbit.',
+        recipientEmail: user.email,
+        pushToken: user.expoPushToken,
+        notificationPreferences: user.notificationPreferences,
+        notificationsEnabled: user.notificationsEnabled,
+      }).catch(() => undefined);
+    }
   }
 
   private async getOrFail(userId: string): Promise<Verification> {


### PR DESCRIPTION
## Summary

- Add `VERIFICATION_APPROVED` and `VERIFICATION_REJECTED` to `NotificationType` enum
- Import `NotificationsModule` in `AdminModule` and `VerificationModule`
- Inject `NotificationsService` in `AdminService` → fire push+email in `approveVerification()` and `rejectVerification()`
- Inject `NotificationsService` in `VerificationService` → fire push+email in private `approveVerification()` (Stripe/dev auto-approval path)

Closes task #2202

## Test plan
- [ ] Admin approves companion → user receives push + email
- [ ] Admin rejects companion → user receives push + email
- [ ] Dev auto-approval (DEV_AUTH=true, 3s delay) → user receives push + email
- [ ] Stripe webhook approval path → user receives push + email
- [ ] Notification call failure does not break approval flow (fire-and-forget)

🤖 Generated with [Claude Code](https://claude.com/claude-code)