### PR TITLE
feat: booking expiry notifications

### DIFF
--- a/backend/daterabbit-api/src/bookings/bookings.cron.ts
+++ b/backend/daterabbit-api/src/bookings/bookings.cron.ts
@@ -23,7 +23,20 @@ export class BookingsCron {
   @Cron(CronExpression.EVERY_HOUR)
   async expirePendingBookings(): Promise<void> {
     const cutoff = new Date(Date.now() - 24 * 60 * 60 * 1000);
-    const result = await this.bookingsRepository.update(
+
+    // Load bookings with seeker/companion so we can send notifications
+    const expiredBookings = await this.bookingsRepository.find({
+      where: {
+        status: BookingStatus.PENDING,
+        createdAt: LessThan(cutoff),
+      },
+      relations: ['seeker', 'companion'],
+    });
+
+    if (expiredBookings.length === 0) return;
+
+    // Bulk-update status to CANCELLED
+    await this.bookingsRepository.update(
       {
         status: BookingStatus.PENDING,
         createdAt: LessThan(cutoff),
@@ -33,10 +46,50 @@ export class BookingsCron {
         cancellationReason: 'expired: companion did not respond within 24 hours',
       },
     );
-    const count = result.affected ?? 0;
-    if (count > 0) {
-      this.logger.log(`[BookingsCron] Expired ${count} pending bookings`);
+
+    this.logger.log(`[BookingsCron] Expired ${expiredBookings.length} pending bookings`);
+
+    // Send push + email notifications for each expired booking
+    for (const booking of expiredBookings) {
+      await this.sendExpiryNotifications(booking).catch((err) => {
+        this.logger.error(`Failed to send expiry notifications for booking ${booking.id}: ${err.message}`);
+      });
     }
+  }
+
+  private async sendExpiryNotifications(booking: Booking): Promise<void> {
+    const companionName = booking.companion?.name || 'your companion';
+    const notifData = { bookingId: booking.id };
+
+    // Notify seeker: request expired, companion did not respond
+    await this.notificationsService.create({
+      userId: booking.seekerId,
+      type: NotificationType.BOOKING_EXPIRED,
+      title: 'Booking request expired',
+      body: `Your request to ${companionName} expired — they didn't respond in time. Try sending a request to another companion.`,
+      data: notifData,
+      pushToken: booking.seeker?.expoPushToken,
+      notificationsEnabled: booking.seeker?.notificationsEnabled,
+      notificationPreferences: booking.seeker?.notificationPreferences as Record<string, boolean> | null,
+      recipientEmail: booking.seeker?.email,
+    }).catch((err) => {
+      this.logger.error(`Failed to notify seeker ${booking.seekerId} for expired booking ${booking.id}: ${err.message}`);
+    });
+
+    // Notify companion: missed a booking request
+    await this.notificationsService.create({
+      userId: booking.companionId,
+      type: NotificationType.BOOKING_EXPIRED,
+      title: 'You missed a booking request',
+      body: `You missed a booking request — it expired before you responded. Check your availability settings to avoid missing future requests.`,
+      data: notifData,
+      pushToken: booking.companion?.expoPushToken,
+      notificationsEnabled: booking.companion?.notificationsEnabled,
+      notificationPreferences: booking.companion?.notificationPreferences as Record<string, boolean> | null,
+      recipientEmail: booking.companion?.email,
+    }).catch((err) => {
+      this.logger.error(`Failed to notify companion ${booking.companionId} for expired booking ${booking.id}: ${err.message}`);
+    });
   }
 
   @Cron(CronExpression.EVERY_5_MINUTES)

--- a/backend/daterabbit-api/src/notifications/entities/notification.entity.ts
+++ b/backend/daterabbit-api/src/notifications/entities/notification.entity.ts
@@ -23,6 +23,7 @@ export enum NotificationType {
   PAYOUT_PROCESSED = 'payout_processed',
   VERIFICATION_APPROVED = 'verification_approved',
   VERIFICATION_REJECTED = 'verification_rejected',
+  BOOKING_EXPIRED = 'booking_expired',
 }
 
 @Entity('notifications')


### PR DESCRIPTION
## Summary

Task #2204 — sends push+email to seeker and companion when a booking request expires after 24h without companion response.

- Added `BOOKING_EXPIRED` to `NotificationType` enum
- `expirePendingBookings()` now loads bookings with `seeker`/`companion` relations before bulk-cancelling
- After update, calls `notificationsService.create()` for both parties with push token, email, and preference fields
- Seeker: "Booking request expired — they didn't respond in time. Try another companion."
- Companion: "You missed a booking request — check your availability settings."

## Test plan

- [ ] Trigger cron manually with a PENDING booking older than 24h → verify booking status becomes CANCELLED
- [ ] Verify seeker receives push notification and email
- [ ] Verify companion receives push notification and email
- [ ] Confirm no notifications sent when there are no expired bookings

🤖 Generated with [Claude Code](https://claude.com/claude-code)