### PR TITLE
fix: companion history screen import paths

### DIFF
--- a/app/app/(tabs)/female/history.tsx
+++ b/app/app/(tabs)/female/history.tsx
@@ -10,11 +10,11 @@ import {
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useRouter } from 'expo-router';
-import { Card } from '../../../../src/components/Card';
-import { UserImage } from '../../../../src/components/UserImage';
-import { Icon } from '../../../../src/components/Icon';
-import { useTheme, spacing, typography, borderRadius } from '../../../../src/constants/theme';
-import { bookingsApi, Booking } from '../../../../src/services/api';
+import { Card } from '../../../src/components/Card';
+import { UserImage } from '../../../src/components/UserImage';
+import { Icon } from '../../../src/components/Icon';
+import { useTheme, spacing, typography, borderRadius } from '../../../src/constants/theme';
+import { bookingsApi, Booking } from '../../../src/services/api';
 
 export default function CompanionHistoryScreen() {
   const insets = useSafeAreaInsets();


### PR DESCRIPTION
Task #2203 fix — history.tsx used ../../../../src/ (4 levels) instead of ../../../src/ (3 levels). Fixes 5 TS2307 errors.