### PR TITLE
fix: landing finalCtaBody maxWidth 460→430

### DIFF
--- a/app/app/landing/index.tsx
+++ b/app/app/landing/index.tsx
@@ -1026,7 +1026,7 @@ const styles = StyleSheet.create({
     color: colors.textMuted,
     textAlign: 'center',
     marginBottom: spacing.lg,
-    maxWidth: 460,
+    maxWidth: 430,
   },
   refundNote: {
     fontSize: 12,


### PR DESCRIPTION
Task #2198 follow-up — fixes remaining finalCtaBody maxWidth: 460 violation missed in commit 6e69fc5. All landing maxWidth values now ≤430.