### PR TITLE
fix: brand color violations — replace hardcoded hex with theme tokens

### DIFF
--- a/app/app/date/extend/[bookingId].tsx
+++ b/app/app/date/extend/[bookingId].tsx
@@ -91,7 +91,7 @@ export default function ExtendDateScreen() {
             <Text style={styles.sentSubtext}>Your date has been extended by {formatHoursDuration(selected)}.</Text>
           </View>
         ) : responseStatus === 'rejected' ? (
-          <View style={[styles.sentCard, { backgroundColor: '#FF5A85' }]}>
+          <View style={[styles.sentCard, { backgroundColor: colors.primaryLight }]}>
             <Text style={styles.sentText}>Request Declined</Text>
             <Text style={styles.sentSubtext}>The companion declined the extension request.</Text>
           </View>
@@ -140,7 +140,7 @@ const styles = StyleSheet.create({
   button: { backgroundColor: colors.primary, borderWidth: 2, borderColor: '#000', paddingVertical: 18, alignItems: 'center', shadowOffset: { width: 4, height: 4 }, shadowColor: '#000', shadowOpacity: 1, shadowRadius: 0 },
   buttonDisabled: { opacity: 0.6 },
   buttonText: { fontSize: 20, fontFamily: typography.fonts.heading, fontWeight: '700', color: colors.white },
-  sentCard: { backgroundColor: '#FF5A85', borderWidth: 2, borderColor: '#000', padding: 24, alignItems: 'center', shadowOffset: { width: 3, height: 3 }, shadowColor: '#000', shadowOpacity: 1, shadowRadius: 0 },
+  sentCard: { backgroundColor: colors.primaryLight, borderWidth: 2, borderColor: '#000', padding: 24, alignItems: 'center', shadowOffset: { width: 3, height: 3 }, shadowColor: '#000', shadowOpacity: 1, shadowRadius: 0 },
   sentText: { fontSize: 22, fontFamily: typography.fonts.heading, fontWeight: '700', color: '#000' },
   sentSubtext: { fontSize: 14, color: '#000', marginTop: 8, textAlign: 'center' },
   backBtn: { marginTop: 24, alignItems: 'center', padding: 12 },

--- a/app/app/reviews/[id].tsx
+++ b/app/app/reviews/[id].tsx
@@ -355,7 +355,7 @@ const styles = StyleSheet.create({
     paddingLeft: 12,
     borderLeftWidth: 3,
     borderLeftColor: colors.primary,
-    backgroundColor: '#F9F6F1',
+    backgroundColor: colors.backgroundWarm,
     padding: 12,
   },
   replyLabel: {
@@ -367,7 +367,7 @@ const styles = StyleSheet.create({
   },
   replyDate: {
     fontSize: 12,
-    color: '#888',
+    color: colors.textLight,
     marginBottom: 6,
   },
   replyText: {

--- a/app/src/components/CustomTabBar.tsx
+++ b/app/src/components/CustomTabBar.tsx
@@ -175,7 +175,7 @@ const styles = StyleSheet.create({
     minWidth: 16,
     height: 16,
     borderRadius: 8,
-    backgroundColor: '#FF3B30',
+    backgroundColor: colors.error,
     alignItems: 'center',
     justifyContent: 'center',
     paddingHorizontal: 3,

--- a/app/src/components/OfflineBanner.tsx
+++ b/app/src/components/OfflineBanner.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import { View, Text, StyleSheet, Animated, Platform } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useNetworkStore } from '../store/networkStore';
+import { colors } from '../constants/theme';
 
 const BANNER_HEIGHT = 40;
 const BACK_ONLINE_DURATION = 2000;
@@ -79,7 +80,7 @@ export function OfflineBanner() {
       pointerEvents="none"
     >
       <View style={styles.content}>
-        <View style={[styles.dot, { backgroundColor: showBackOnline && !isOffline ? '#6EE7A0' : '#FF6B6B' }]} />
+        <View style={[styles.dot, { backgroundColor: showBackOnline && !isOffline ? '#6EE7A0' : colors.error }]} />
         <Text style={styles.text}>{message}</Text>
       </View>
     </Animated.View>


### PR DESCRIPTION
## Summary
- Task #2195 — fixes 6 hardcoded color violations in extend, reviews, OfflineBanner, CustomTabBar

## Changes
- `extend/[bookingId].tsx:94` — `'#FF5A85'` inline → `colors.primaryLight`
- `extend/[bookingId].tsx:143` — `sentCard` backgroundColor `'#FF5A85'` → `colors.primaryLight`
- `reviews/[id].tsx:358` — `replyBlock` backgroundColor `'#F9F6F1'` → `colors.backgroundWarm`
- `reviews/[id].tsx:370` — `replyDate` color `'#888'` → `colors.textLight`
- `OfflineBanner.tsx:82` — offline dot `'#FF6B6B'` → `colors.error` (added colors import)
- `CustomTabBar.tsx:178` — badge backgroundColor `'#FF3B30'` → `colors.error`

## Test plan
- [ ] tsc --noEmit passes (0 new errors)
- [ ] Extend screen shows pink card on rejected response
- [ ] Reviews screen reply block uses warm background
- [ ] OfflineBanner offline dot uses error color
- [ ] CustomTabBar unread badge uses error color