### PR TITLE
fix: add error states to 4 critical screens

### DIFF
--- a/app/app/(comp-onboard)/pending.tsx
+++ b/app/app/(comp-onboard)/pending.tsx
@@ -4,6 +4,7 @@ import {
   Text,
   StyleSheet,
   ActivityIndicator,
+  TouchableOpacity,
 } from 'react-native';
 import { router } from 'expo-router';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -16,7 +17,7 @@ const POLL_INTERVAL_MS = 10_000;
 
 export default function CompPendingScreen() {
   const insets = useSafeAreaInsets();
-  const { fetchStatus, status } = useVerificationStore();
+  const { fetchStatus, status, error: fetchError } = useVerificationStore();
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   useEffect(() => {
@@ -44,6 +45,27 @@ export default function CompPendingScreen() {
   }, [status]);
 
   const isRejected = status === 'rejected';
+
+  if (fetchError && !status) {
+    return (
+      <View style={[styles.container, styles.errorContainer, { paddingTop: insets.top + spacing.lg, paddingBottom: insets.bottom + spacing.xl }]}>
+        <ProgressBar currentStep={6} totalSteps={7} />
+        <View style={styles.errorContent}>
+          <View style={[styles.errorIconCircle, { backgroundColor: colors.errorLight }]}>
+            <Icon name="alert" size={36} color={colors.error} />
+          </View>
+          <Text style={[styles.errorTitle, { color: colors.text }]}>Could Not Load Status</Text>
+          <Text style={[styles.errorMessage, { color: colors.textMuted }]}>{fetchError}</Text>
+          <TouchableOpacity
+            style={[styles.retryButton, { borderColor: colors.border }]}
+            onPress={fetchStatus}
+          >
+            <Text style={styles.retryButtonText}>Try Again</Text>
+          </TouchableOpacity>
+        </View>
+      </View>
+    );
+  }
 
   return (
     <View
@@ -203,5 +225,45 @@ const styles = StyleSheet.create({
     fontSize: typography.sizes.sm,
     color: colors.textMuted,
     lineHeight: 20,
+  },
+  errorContainer: {
+    // same base as container
+  },
+  errorContent: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: spacing.xl,
+  },
+  errorIconCircle: {
+    width: 80,
+    height: 80,
+    borderRadius: 40,
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginBottom: spacing.lg,
+  },
+  errorTitle: {
+    fontFamily: typography.fonts.heading,
+    fontSize: typography.sizes.xl,
+    textAlign: 'center',
+    marginBottom: spacing.sm,
+  },
+  errorMessage: {
+    fontFamily: typography.fonts.body,
+    fontSize: typography.sizes.md,
+    textAlign: 'center',
+    marginBottom: spacing.lg,
+  },
+  retryButton: {
+    borderWidth: 2,
+    borderRadius: borderRadius.md,
+    paddingVertical: spacing.sm,
+    paddingHorizontal: spacing.xl,
+  },
+  retryButtonText: {
+    fontFamily: typography.fonts.bodySemiBold,
+    fontSize: typography.sizes.md,
+    color: colors.text,
   },
 });

--- a/app/app/(seeker-verify)/pending.tsx
+++ b/app/app/(seeker-verify)/pending.tsx
@@ -3,6 +3,7 @@ import {
   View,
   Text,
   StyleSheet,
+  TouchableOpacity,
 } from 'react-native';
 import { router } from 'expo-router';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -24,7 +25,7 @@ const POLL_INTERVAL_MS = 10_000;
 
 export default function SeekerVerifyPendingScreen() {
   const insets = useSafeAreaInsets();
-  const { fetchStatus, status } = useVerificationStore();
+  const { fetchStatus, status, error: fetchError } = useVerificationStore();
   const pollingRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   const rotation = useSharedValue(0);
@@ -78,6 +79,24 @@ export default function SeekerVerifyPendingScreen() {
   const pulseStyle = useAnimatedStyle(() => ({
     transform: [{ scale: pulse.value }],
   }));
+
+  if (fetchError && !status) {
+    return (
+      <View style={[styles.container, styles.centered, { paddingTop: insets.top, paddingBottom: insets.bottom }]}>
+        <View style={[styles.errorIcon, { backgroundColor: colors.error + '20' }]}>
+          <Icon name="alert" size={40} color={colors.error} />
+        </View>
+        <Text style={[styles.errorTitle, { color: colors.text }]}>Could Not Load Status</Text>
+        <Text style={[styles.errorMessage, { color: colors.textSecondary }]}>{fetchError}</Text>
+        <TouchableOpacity
+          style={[styles.retryButton, { borderColor: colors.border }]}
+          onPress={fetchStatus}
+        >
+          <Text style={[styles.retryButtonText, { color: colors.text }]}>Try Again</Text>
+        </TouchableOpacity>
+      </View>
+    );
+  }
 
   return (
     <View style={[styles.container, { paddingTop: insets.top, paddingBottom: insets.bottom }]}>
@@ -259,5 +278,41 @@ const styles = StyleSheet.create({
     color: colors.textMuted,
     textAlign: 'center',
     marginTop: spacing.sm,
+  },
+  centered: {
+    justifyContent: 'center',
+    alignItems: 'center',
+    paddingHorizontal: spacing.xl,
+  },
+  errorIcon: {
+    width: 80,
+    height: 80,
+    borderRadius: 40,
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginBottom: spacing.lg,
+  },
+  errorTitle: {
+    fontFamily: typography.fonts.heading,
+    fontSize: typography.sizes.xl,
+    textAlign: 'center',
+    marginBottom: spacing.sm,
+  },
+  errorMessage: {
+    fontFamily: typography.fonts.body,
+    fontSize: typography.sizes.md,
+    textAlign: 'center',
+    marginBottom: spacing.lg,
+  },
+  retryButton: {
+    borderWidth: 1,
+    borderRadius: borderRadius.md,
+    paddingVertical: spacing.sm,
+    paddingHorizontal: spacing.xl,
+  },
+  retryButtonText: {
+    fontFamily: typography.fonts.bodySemiBold,
+    fontSize: typography.sizes.md,
+    color: colors.text,
   },
 });

--- a/app/app/(tabs)/male/messages.tsx
+++ b/app/app/(tabs)/male/messages.tsx
@@ -1,17 +1,17 @@
 import React, { useCallback } from 'react';
-import { View, Text, StyleSheet, ScrollView, TouchableOpacity, ActivityIndicator } from 'react-native';
+import { View, Text, StyleSheet, ScrollView, TouchableOpacity, ActivityIndicator, Pressable } from 'react-native';
 import { router, useFocusEffect } from 'expo-router';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { UserImage } from '../../../src/components/UserImage';
 import { EmptyState } from '../../../src/components/EmptyState';
 import { useMessagesStore, POLL_INTERVAL } from '../../../src/store/messagesStore';
-import { useTheme, spacing, typography } from '../../../src/constants/theme';
+import { useTheme, spacing, typography, borderRadius } from '../../../src/constants/theme';
 import type { Chat } from '../../../src/types';
 
 export default function MessagesScreen() {
   const insets = useSafeAreaInsets();
   const { colors } = useTheme();
-  const { chats, isLoading, fetchChats } = useMessagesStore();
+  const { chats, isLoading, error, clearError, fetchChats } = useMessagesStore();
 
   // Poll conversations every 10 seconds while screen is focused
   useFocusEffect(
@@ -50,6 +50,26 @@ export default function MessagesScreen() {
     return (
       <View style={[styles.container, styles.centered, { backgroundColor: colors.background }]}>
         <ActivityIndicator size="large" color={colors.primary} />
+      </View>
+    );
+  }
+
+  if (error && chats.length === 0) {
+    return (
+      <View style={[styles.container, styles.centered, { backgroundColor: colors.background }]}>
+        <View style={[styles.errorIcon, { backgroundColor: colors.error + '20' }]}>
+          <Text style={[styles.errorIconText, { color: colors.error }]}>!</Text>
+        </View>
+        <Text style={[styles.errorTitle, { color: colors.text }]}>Could Not Load Messages</Text>
+        <Text style={[styles.errorMessage, { color: colors.textSecondary }]}>
+          {error}
+        </Text>
+        <Pressable
+          style={[styles.retryButton, { borderColor: colors.border }]}
+          onPress={() => { clearError(); fetchChats(); }}
+        >
+          <Text style={[styles.retryButtonText, { color: colors.text }]}>Try Again</Text>
+        </Pressable>
       </View>
     );
   }
@@ -189,5 +209,40 @@ const styles = StyleSheet.create({
   unreadCount: {
     fontFamily: typography.fonts.bodySemiBold,
     fontSize: typography.sizes.xs,
+  },
+  errorIcon: {
+    width: 72,
+    height: 72,
+    borderRadius: 36,
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginBottom: spacing.lg,
+  },
+  errorIconText: {
+    fontFamily: typography.fonts.heading,
+    fontSize: 36,
+  },
+  errorTitle: {
+    fontFamily: typography.fonts.heading,
+    fontSize: typography.sizes.xl,
+    marginBottom: spacing.sm,
+    textAlign: 'center',
+  },
+  errorMessage: {
+    fontFamily: typography.fonts.body,
+    fontSize: typography.sizes.md,
+    textAlign: 'center',
+    marginBottom: spacing.lg,
+    paddingHorizontal: spacing.lg,
+  },
+  retryButton: {
+    borderWidth: 1,
+    borderRadius: borderRadius.md,
+    paddingVertical: spacing.sm,
+    paddingHorizontal: spacing.xl,
+  },
+  retryButtonText: {
+    fontFamily: typography.fonts.bodySemiBold,
+    fontSize: typography.sizes.md,
   },
 });

--- a/app/app/booking/request-sent/[bookingId].tsx
+++ b/app/app/booking/request-sent/[bookingId].tsx
@@ -24,6 +24,7 @@ export default function RequestSentScreen() {
 
   const [booking, setBooking] = useState<Booking | null>(null);
   const [loading, setLoading] = useState(true);
+  const [fetchError, setFetchError] = useState<string | null>(null);
   const [cancelling, setCancelling] = useState(false);
   const [elapsedMinutes, setElapsedMinutes] = useState(0);
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
@@ -32,7 +33,12 @@ export default function RequestSentScreen() {
   const fetchBooking = useCallback(async () => {
     if (!bookingId) return;
     const b = await getBookingById(bookingId);
-    if (!b) return;
+    if (!b) {
+      setFetchError('Failed to load booking. Please try again.');
+      setLoading(false);
+      return;
+    }
+    setFetchError(null);
     setBooking(b);
     setLoading(false);
 
@@ -92,6 +98,24 @@ export default function RequestSentScreen() {
     return (
       <View style={[styles.container, styles.centered, { backgroundColor: colors.background }]}>
         <ActivityIndicator size="large" color={colors.primary} />
+      </View>
+    );
+  }
+
+  if (fetchError) {
+    return (
+      <View style={[styles.container, styles.centered, { backgroundColor: colors.background }]}>
+        <View style={[styles.errorIcon, { backgroundColor: colors.error + '20' }]}>
+          <Icon name="alert" size={48} color={colors.error} />
+        </View>
+        <Text style={[styles.errorTitle, { color: colors.text }]}>Could Not Load Booking</Text>
+        <Text style={[styles.errorMessage, { color: colors.textSecondary }]}>{fetchError}</Text>
+        <Button
+          title="Try Again"
+          onPress={fetchBooking}
+          variant="outline"
+          style={{ marginTop: spacing.lg }}
+        />
       </View>
     );
   }
@@ -249,5 +273,23 @@ const styles = StyleSheet.create({
   },
   bottomBar: {
     padding: spacing.lg,
+  },
+  errorIcon: {
+    width: 96,
+    height: 96,
+    borderRadius: 48,
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginBottom: spacing.lg,
+  },
+  errorTitle: {
+    fontFamily: typography.fonts.heading,
+    fontSize: typography.sizes.xl,
+    marginBottom: spacing.sm,
+  },
+  errorMessage: {
+    fontFamily: typography.fonts.body,
+    fontSize: typography.sizes.md,
+    textAlign: 'center',
   },
 });


### PR DESCRIPTION
## Summary

- `booking/request-sent/[bookingId].tsx` — fetchBooking returns null on API failure; added `fetchError` state that triggers centered error UI with retry
- `(tabs)/male/messages.tsx` — store already had `error` field but screen never read it; now shows error UI when `error` is set and chats list is empty
- `(seeker-verify)/pending.tsx` — verificationStore `error` aliased as `fetchError`; error UI shown when status is not yet loaded
- `(comp-onboard)/pending.tsx` — same pattern as seeker pending

## Pattern

Centered: icon (alert) + title + message + "Try Again" button that calls the fetch function. Matches existing pattern in `payment/[bookingId].tsx`.

## Test plan
- [ ] tsc: 0 new errors (verified)
- [ ] Each screen on API failure shows error UI instead of blank screen
- [ ] Retry button re-triggers the fetch

Task #2197