### PR TITLE
fix: SpaceGrotesk-Bold → SpaceGrotesk_700Bold in reviews screen (#344)

### DIFF
--- a/app/app/reviews/[id].tsx
+++ b/app/app/reviews/[id].tsx
@@ -360,7 +360,7 @@ const styles = StyleSheet.create({
   },
   replyLabel: {
     fontSize: 13,
-    fontFamily: 'SpaceGrotesk-Bold',
+    fontFamily: 'SpaceGrotesk_700Bold',
     fontWeight: '700',
     color: colors.primary,
     marginBottom: 2,
@@ -386,7 +386,7 @@ const styles = StyleSheet.create({
   },
   replyButtonText: {
     fontSize: 14,
-    fontFamily: 'SpaceGrotesk-Bold',
+    fontFamily: 'SpaceGrotesk_700Bold',
     fontWeight: '700',
     color: '#000',
   },


### PR DESCRIPTION
## Summary
- Replaces wrong font name `SpaceGrotesk-Bold` with correct Expo font variant `SpaceGrotesk_700Bold`
- 2 occurrences in `app/app/reviews/[id].tsx` (lines 363, 389): `replyLabel` and `replyButtonText` styles
- No other occurrences found in the project

Fixes #344