### PR TITLE
feat: checkout fee breakdown with Stripe processing fee

### DIFF
--- a/app/app/payment/[bookingId].tsx
+++ b/app/app/payment/[bookingId].tsx
@@ -23,6 +23,12 @@ export default function PaymentScreen() {
 
   const [booking, setBooking] = useState<Booking | null>(null);
   const [clientSecret, setClientSecret] = useState<string | null>(null);
+  const [feeBreakdown, setFeeBreakdown] = useState<{
+    subtotal: number;
+    platformFee: number;
+    stripeFee: number;
+    totalCharged: number;
+  } | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -43,6 +49,9 @@ export default function PaymentScreen() {
       const result = await createPaymentIntent(bookingId);
       if (result.success && result.clientSecret) {
         setClientSecret(result.clientSecret);
+        if (result.feeBreakdown) {
+          setFeeBreakdown(result.feeBreakdown);
+        }
       } else {
         setError(result.error || 'Failed to initialize payment');
       }
@@ -138,20 +147,28 @@ export default function PaymentScreen() {
               ${booking.hourlyRate}/hr &times; {booking.duration || 1}h
             </Text>
             <Text style={[styles.priceValue, { color: colors.text }]}>
-              ${booking.subtotal.toFixed(2)}
+              ${(feeBreakdown?.subtotal ?? booking.subtotal).toFixed(2)}
             </Text>
           </View>
           <View style={styles.priceRow}>
             <Text style={[styles.priceLabel, { color: colors.textSecondary }]}>Platform fee</Text>
             <Text style={[styles.priceValue, { color: colors.text }]}>
-              ${booking.platformFee.toFixed(2)}
+              ${(feeBreakdown?.platformFee ?? booking.platformFee).toFixed(2)}
+            </Text>
+          </View>
+          <View style={styles.priceRow}>
+            <Text style={[styles.priceLabel, { color: colors.textSecondary }]}>
+              Stripe processing fee (2.9% + $0.30)
+            </Text>
+            <Text style={[styles.priceValue, { color: colors.text }]}>
+              ${(feeBreakdown?.stripeFee ?? 0).toFixed(2)}
             </Text>
           </View>
           <View style={[styles.divider, { borderBottomColor: colors.border + '30' }]} />
           <View style={styles.priceRow}>
-            <Text style={[styles.totalLabel, { color: colors.text }]}>Total</Text>
+            <Text style={[styles.totalLabel, { color: colors.text }]}>Total charged</Text>
             <Text style={[styles.totalValue, { color: colors.primary }]}>
-              ${booking.total.toFixed(2)}
+              ${(feeBreakdown?.totalCharged ?? booking.total).toFixed(2)}
             </Text>
           </View>
         </Card>
@@ -163,7 +180,7 @@ export default function PaymentScreen() {
         {clientSecret && booking && (
           <StripePaymentForm
             clientSecret={clientSecret}
-            amount={booking.total}
+            amount={feeBreakdown?.totalCharged ?? booking.total}
             onSuccess={handlePaymentSuccess}
           />
         )}

--- a/app/src/services/api.ts
+++ b/app/src/services/api.ts
@@ -695,7 +695,15 @@ export const paymentsApi = {
     apiRequest<{ complete: boolean; payoutsEnabled: boolean }>('/payments/connect/status'),
 
   createPaymentIntent: (bookingId: string) =>
-    apiRequest<{ clientSecret: string }>(`/payments/bookings/${bookingId}/pay`, {
+    apiRequest<{
+      clientSecret: string;
+      feeBreakdown?: {
+        subtotal: number;
+        platformFee: number;
+        stripeFee: number;
+        totalCharged: number;
+      };
+    }>(`/payments/bookings/${bookingId}/pay`, {
       method: 'POST',
     }),
 

--- a/app/src/store/earningsStore.ts
+++ b/app/src/store/earningsStore.ts
@@ -22,7 +22,12 @@ interface EarningsState {
   fetchEarnings: () => Promise<void>;
   fetchConnectStatus: () => Promise<void>;
   startStripeOnboarding: () => Promise<{ success: boolean; url?: string; error?: string }>;
-  createPaymentIntent: (bookingId: string) => Promise<{ success: boolean; clientSecret?: string; error?: string }>;
+  createPaymentIntent: (bookingId: string) => Promise<{
+    success: boolean;
+    clientSecret?: string;
+    feeBreakdown?: { subtotal: number; platformFee: number; stripeFee: number; totalCharged: number };
+    error?: string;
+  }>;
 
   // Utility
   clearError: () => void;
@@ -82,7 +87,7 @@ export const useEarningsStore = create<EarningsState>((set) => ({
     try {
       const result = await paymentsApi.createPaymentIntent(bookingId);
       set({ isLoading: false });
-      return { success: true, clientSecret: result.clientSecret };
+      return { success: true, clientSecret: result.clientSecret, feeBreakdown: result.feeBreakdown };
     } catch (err) {
       const message = err instanceof ApiError ? err.message : 'Failed to create payment';
       set({ error: message, isLoading: false });

--- a/backend/daterabbit-api/src/payments/payments.service.ts
+++ b/backend/daterabbit-api/src/payments/payments.service.ts
@@ -105,7 +105,15 @@ export class PaymentsService {
   async createPaymentIntent(
     userId: string,
     bookingId: string,
-  ): Promise<{ clientSecret: string }> {
+  ): Promise<{
+    clientSecret: string;
+    feeBreakdown: {
+      subtotal: number;
+      platformFee: number;
+      stripeFee: number;
+      totalCharged: number;
+    };
+  }> {
     this.ensureStripe();
 
     const booking = await this.bookingsRepo.findOne({
@@ -120,6 +128,19 @@ export class PaymentsService {
     if (booking.status !== BookingStatus.CONFIRMED)
       throw new HttpException('Booking must be confirmed first', HttpStatus.BAD_REQUEST);
 
+    const subtotal = Math.round(Number(booking.totalPrice) * 100) / 100; // dollars, 2dp
+    const commissionRate = await this.getCommissionRate();
+    const platformFeeAmount = Math.round(subtotal * commissionRate * 100) / 100;
+    const stripeFee = Math.round(((subtotal + platformFeeAmount) * 0.029 + 0.30) * 100) / 100;
+    const totalCharged = Math.round((subtotal + platformFeeAmount + stripeFee) * 100) / 100;
+
+    const feeBreakdown = {
+      subtotal,
+      platformFee: platformFeeAmount,
+      stripeFee,
+      totalCharged,
+    };
+
     // Idempotency: return existing payment intent if one already exists and is still active
     if (booking.paymentIntentId) {
       const existingIntent = await this.stripe.paymentIntents.retrieve(booking.paymentIntentId);
@@ -128,7 +149,7 @@ export class PaymentsService {
         existingIntent.status === 'requires_confirmation' ||
         existingIntent.status === 'requires_action'
       ) {
-        return { clientSecret: existingIntent.client_secret! };
+        return { clientSecret: existingIntent.client_secret!, feeBreakdown };
       }
       // Intent is cancelled/failed — clear it and create a new one
       await this.bookingsRepo.update(bookingId, { paymentIntentId: null as any });
@@ -144,21 +165,21 @@ export class PaymentsService {
       );
     }
 
-    const amount = Math.round(Number(booking.totalPrice) * 100); // cents
-    if (amount <= 0) {
+    const totalChargedCents = Math.round(totalCharged * 100);
+    if (totalChargedCents <= 0) {
       throw new HttpException(
         'Booking total price must be greater than zero',
         HttpStatus.UNPROCESSABLE_ENTITY,
       );
     }
-    const commissionRate = await this.getCommissionRate();
-    const platformFee = Math.round(amount * commissionRate); // dynamic platform fee from PlatformSettings
+    // Platform fee applied on the subtotal only (companion gets subtotal minus platform fee)
+    const platformFeeCents = Math.round(platformFeeAmount * 100);
 
     const paymentIntent = await this.stripe.paymentIntents.create({
-      amount,
+      amount: totalChargedCents,
       currency: 'usd',
       capture_method: 'manual',
-      application_fee_amount: platformFee,
+      application_fee_amount: platformFeeCents,
       transfer_data: {
         destination: companion.stripeAccountId,
       },
@@ -173,7 +194,7 @@ export class PaymentsService {
       paymentIntentId: paymentIntent.id,
     });
 
-    return { clientSecret: paymentIntent.client_secret! };
+    return { clientSecret: paymentIntent.client_secret!, feeBreakdown };
   }
 
   // --- Capture / Cancel (escrow) ---


### PR DESCRIPTION
## Summary
- Seeker now sees full 3-line breakdown before paying: date cost + platform service fee + Stripe processing fee (2.9%+$0.30) = total charged
- Backend computes and returns feeBreakdown in payment intent response
- PaymentIntent amount is now totalCharged (includes Stripe fee), not just subtotal+platformFee

## Test plan
- [ ] Book a date, confirm it, go to payment screen
- [ ] Verify 3 lines shown: Date cost, Platform fee, Stripe processing fee
- [ ] Verify math: e.g. $100 date → platform fee ~$20 (20%) → Stripe fee = ($120 × 0.029) + $0.30 = $3.78 → Total = $123.78
- [ ] Verify Stripe charges totalCharged amount (not just subtotal)
- [ ] Verify fallback if feeBreakdown not present (shows booking.total)

🤖 Generated with [Claude Code](https://claude.com/claude-code)