### PR TITLE
feat: add EXPIRED booking status and fix expiration cron

### DIFF
--- a/backend/daterabbit-api/src/bookings/bookings.cron.ts
+++ b/backend/daterabbit-api/src/bookings/bookings.cron.ts
@@ -35,17 +35,19 @@ export class BookingsCron {
 
     if (expiredBookings.length === 0) return;
 
-    // Bulk-update status to CANCELLED
-    await this.bookingsRepository.update(
-      {
-        status: BookingStatus.PENDING,
-        createdAt: LessThan(cutoff),
-      },
-      {
-        status: BookingStatus.CANCELLED,
+    // Fix race condition: update only the IDs we just loaded, not a re-run of the where clause.
+    // This prevents marking bookings that were confirmed between the find() and update() calls.
+    const expiredIds = expiredBookings.map((b) => b.id);
+    await this.bookingsRepository
+      .createQueryBuilder()
+      .update()
+      .set({
+        status: BookingStatus.EXPIRED,
         cancellationReason: 'expired: companion did not respond within 24 hours',
-      },
-    );
+      })
+      .whereInIds(expiredIds)
+      .andWhere('status = :status', { status: BookingStatus.PENDING })
+      .execute();
 
     this.logger.log(`[BookingsCron] Expired ${expiredBookings.length} pending bookings`);
 

--- a/backend/daterabbit-api/src/bookings/bookings.service.ts
+++ b/backend/daterabbit-api/src/bookings/bookings.service.ts
@@ -188,16 +188,18 @@ export class BookingsService {
         break;
 
       case 'past':
-        // Completed/cancelled bookings with past dates OR confirmed/paid bookings with past dates
+        // Completed/cancelled/expired bookings OR confirmed/paid bookings with past dates
         seekerWhere = [
           { seekerId: userId, status: BookingStatus.COMPLETED },
           { seekerId: userId, status: BookingStatus.CANCELLED, dateTime: LessThan(now) },
+          { seekerId: userId, status: BookingStatus.EXPIRED },
           { seekerId: userId, dateTime: LessThan(now), status: BookingStatus.CONFIRMED },
           { seekerId: userId, dateTime: LessThan(now), status: BookingStatus.PAID },
         ];
         companionWhere = [
           { companionId: userId, status: BookingStatus.COMPLETED },
           { companionId: userId, status: BookingStatus.CANCELLED, dateTime: LessThan(now) },
+          { companionId: userId, status: BookingStatus.EXPIRED },
           { companionId: userId, dateTime: LessThan(now), status: BookingStatus.CONFIRMED },
           { companionId: userId, dateTime: LessThan(now), status: BookingStatus.PAID },
         ];

--- a/backend/daterabbit-api/src/bookings/entities/booking.entity.ts
+++ b/backend/daterabbit-api/src/bookings/entities/booking.entity.ts
@@ -17,6 +17,7 @@ export enum BookingStatus {
   CANCELLED = 'cancelled',
   COMPLETED = 'completed',
   DISPUTED = 'disputed',
+  EXPIRED = 'expired',
 }
 
 export enum ActivityType {

--- a/backend/daterabbit-api/src/bookings/migrations/add-expired-booking-status.ts
+++ b/backend/daterabbit-api/src/bookings/migrations/add-expired-booking-status.ts
@@ -1,0 +1,15 @@
+import { DataSource } from 'typeorm';
+
+/**
+ * Idempotent bootstrap migration: adds 'expired' value to bookingstatus_enum in Postgres.
+ * Called from main.ts before the app starts listening.
+ *
+ * NOTE: Postgres does not support removing enum values, so there is no automatic rollback.
+ * To roll back manually: you must rename the old enum type, create a new one without 'expired',
+ * alter the column, and drop the old type.
+ */
+export async function runAddExpiredBookingStatusMigration(dataSource: DataSource): Promise<void> {
+  await dataSource.query(`
+    ALTER TYPE bookingstatus_enum ADD VALUE IF NOT EXISTS 'expired'
+  `);
+}

--- a/backend/daterabbit-api/src/main.ts
+++ b/backend/daterabbit-api/src/main.ts
@@ -5,6 +5,7 @@ import { DataSource } from 'typeorm';
 import { AppModule } from './app.module';
 import { runRefreshTokensMigration } from './auth/migrations/create-refresh-tokens';
 import { runNotificationTablesMigration } from './notifications/migrations/create-notification-tables';
+import { runAddExpiredBookingStatusMigration } from './bookings/migrations/add-expired-booking-status';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule, {
@@ -29,6 +30,15 @@ async function bootstrap() {
   } catch (err) {
     console.error('notification_tables migration failed:', err);
     // Non-fatal: app still starts, but notification preferences/logs won't work until fixed
+  }
+
+  try {
+    const dataSource = app.get<DataSource>(getDataSourceToken());
+    await runAddExpiredBookingStatusMigration(dataSource);
+    console.log('add_expired_booking_status migration: OK');
+  } catch (err) {
+    console.error('add_expired_booking_status migration failed:', err);
+    // Non-fatal: app still starts, but expiry cron will fail until fixed
   }
 
   // Enable CORS


### PR DESCRIPTION
## Summary

- Adds `EXPIRED` value to `BookingStatus` enum
- Adds idempotent Postgres migration (`ALTER TYPE IF NOT EXISTS 'expired'`) registered in bootstrap
- Updates expiration cron to use `EXPIRED` instead of `CANCELLED`
- Fixes race condition: uses `id IN (...)` filter instead of re-running the where clause (prevents marking bookings confirmed between `find()` and `update()`)
- Adds `EXPIRED` to past bookings filter in `bookings.service.ts`

Closes #353