### PR TITLE
fix: favorites toggleFavorite rollback + loading state until synced

### DIFF
--- a/app/app/favorites/index.tsx
+++ b/app/app/favorites/index.tsx
@@ -15,8 +15,8 @@ import * as Haptics from 'expo-haptics';
 export default function FavoritesScreen() {
   const insets = useSafeAreaInsets();
   const { colors } = useTheme();
-  const { favorites, toggleFavorite, syncFromServer } = useFavoritesStore();
-  
+  const { favorites, synced, toggleFavorite, syncFromServer } = useFavoritesStore();
+
   const [favoriteCompanions, setFavoriteCompanions] = useState<CompanionDetail[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
@@ -43,9 +43,20 @@ export default function FavoritesScreen() {
     }
   }, [favorites]);
 
+  // Kick off server sync on mount if not yet synced
   useEffect(() => {
-    fetchFavorites();
-  }, [fetchFavorites]);
+    if (!synced) {
+      syncFromServer();
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Fetch companion details once synced, and whenever favorites list changes
+  useEffect(() => {
+    if (synced) {
+      fetchFavorites();
+    }
+  }, [favorites, synced, fetchFavorites]);
 
   const onRefresh = useCallback(async () => {
     setRefreshing(true);
@@ -55,12 +66,15 @@ export default function FavoritesScreen() {
     setRefreshing(false);
   }, [fetchFavorites, syncFromServer]);
 
-  const handleToggleFavorite = (id: string) => {
+  const handleToggleFavorite = async (id: string) => {
     if (Platform.OS !== 'web') {
       Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
     }
-    toggleFavorite(id);
+    // Optimistic UI: remove from list immediately
     setFavoriteCompanions(prev => prev.filter(c => c.id !== id));
+    await toggleFavorite(id);
+    // If toggle failed (rollback happened in store), re-fetch to restore the item
+    // favorites selector change will trigger the useEffect above
   };
 
   return (

--- a/app/src/store/favoritesStore.ts
+++ b/app/src/store/favoritesStore.ts
@@ -6,7 +6,8 @@ import { usersApi } from '../services/api';
 interface FavoritesState {
   favorites: string[];
   synced: boolean;
-  toggleFavorite: (profileId: string) => void;
+  isToggling: boolean;
+  toggleFavorite: (profileId: string) => Promise<void>;
   isFavorite: (profileId: string) => boolean;
   clearFavorites: () => void;
   syncFromServer: () => Promise<void>;
@@ -17,18 +18,33 @@ export const useFavoritesStore = create<FavoritesState>()(
     (set, get) => ({
       favorites: [],
       synced: false,
+      isToggling: false,
 
-      toggleFavorite: (profileId: string) => {
+      toggleFavorite: async (profileId: string) => {
         const { favorites } = get();
-        if (favorites.includes(profileId)) {
-          set({ favorites: favorites.filter((id) => id !== profileId) });
-          // Sync removal to server (fire-and-forget)
-          usersApi.removeFavorite(profileId).catch(() => {});
-        } else {
-          set({ favorites: [...favorites, profileId] });
-          // Sync addition to server (fire-and-forget)
-          usersApi.addFavorite(profileId).catch(() => {});
+        const wasIncluded = favorites.includes(profileId);
+
+        // Optimistic update
+        set({
+          favorites: wasIncluded
+            ? favorites.filter((id) => id !== profileId)
+            : [...favorites, profileId],
+          isToggling: true,
+        });
+
+        try {
+          if (wasIncluded) {
+            await usersApi.removeFavorite(profileId);
+          } else {
+            await usersApi.addFavorite(profileId);
+          }
+        } catch {
+          // Rollback on failure
+          set({ favorites, isToggling: false });
+          return;
         }
+
+        set({ isToggling: false });
       },
 
       isFavorite: (profileId: string) => {
@@ -40,8 +56,15 @@ export const useFavoritesStore = create<FavoritesState>()(
       },
 
       syncFromServer: async () => {
+        // Skip sync while a toggle is in flight to avoid overwriting optimistic state
+        if (get().isToggling) return;
+
         try {
           const { favorites: serverFavorites } = await usersApi.getFavorites();
+
+          // Re-check after await — toggle may have started
+          if (get().isToggling) return;
+
           const { favorites: localFavorites } = get();
 
           // Merge: server is source of truth, but add any local-only items


### PR DESCRIPTION
## Summary
- `toggleFavorite` is now async: applies optimistic update, awaits the API call, and **rolls back** `favorites` to the previous state on catch
- Added `isToggling` flag to prevent `syncFromServer` from overwriting optimistic state during an in-flight API call (checked before request and after await)
- `favorites/index.tsx` now shows a loading spinner until `synced === true`; mount effect triggers `syncFromServer()` if not yet synced, a second effect fetches companion details once `synced` flips true and re-fetches whenever favorites change (covers rollback restore automatically)

## Test plan
- [ ] Toggle a favorite with network offline → heart un-fills then re-fills (rollback)
- [ ] Toggle a favorite with network online → optimistic remove, API call succeeds, item stays removed
- [ ] Open favorites screen for the first time (synced=false) → spinner shown until server sync completes
- [ ] Open favorites screen when already synced → list renders immediately (no extra spinner)
- [ ] Pull-to-refresh → calls syncFromServer + re-fetches companion details

🤖 Generated with [Claude Code](https://claude.com/claude-code)