### PR TITLE
feat: companion profile video upload (50MB mp4/mov)

### DIFF
--- a/app/app/settings/edit-profile.tsx
+++ b/app/app/settings/edit-profile.tsx
@@ -8,7 +8,9 @@ import {
   TouchableOpacity,
   KeyboardAvoidingView,
   Platform,
+  ActivityIndicator,
 } from 'react-native';
+import * as ImagePicker from 'expo-image-picker';
 import { router } from 'expo-router';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Button } from '../../src/components/Button';
@@ -40,6 +42,8 @@ export default function EditProfileScreen() {
     hourlyRate: user?.hourlyRate?.toString() || '',
   });
   const [loading, setLoading] = useState(false);
+  const [videoLoading, setVideoLoading] = useState(false);
+  const [profileVideoUrl, setProfileVideoUrl] = useState<string | null>(user?.profileVideoUrl || null);
 
   // Initialize images from user profile
   useEffect(() => {
@@ -48,6 +52,31 @@ export default function EditProfileScreen() {
       setImages(user.photos.map(p => p.url));
     }
   }, []);
+
+  const handleVideoUpload = async () => {
+    const permission = await ImagePicker.requestMediaLibraryPermissionsAsync();
+    if (!permission.granted) {
+      showAlert('Permission Required', 'Please allow access to your media library to upload a video.');
+      return;
+    }
+    const result = await ImagePicker.launchImageLibraryAsync({
+      mediaTypes: ImagePicker.MediaTypeOptions.Videos,
+      allowsEditing: false,
+      quality: 1,
+    });
+    if (result.canceled || !result.assets?.[0]) return;
+    const asset = result.assets[0];
+    setVideoLoading(true);
+    try {
+      const { url } = await usersApi.uploadProfileVideo(asset.uri);
+      setProfileVideoUrl(url);
+      showAlert('Success', 'Profile video uploaded successfully.');
+    } catch {
+      showAlert('Error', 'Failed to upload video. Make sure it is MP4 or MOV and under 50MB.');
+    } finally {
+      setVideoLoading(false);
+    }
+  };
 
   const handleSave = async () => {
     if (!formData.name.trim()) {
@@ -199,6 +228,43 @@ export default function EditProfileScreen() {
           )}
         </View>
 
+        {/* Profile Video — companions only, mobile only */}
+        {isFemale && Platform.OS !== 'web' && (
+          <View style={[styles.section, { backgroundColor: colors.white }]}>
+            <Text style={[styles.sectionTitle, { color: colors.text }]}>Profile Video</Text>
+            <Text style={[styles.hint, { color: colors.textSecondary, marginBottom: spacing.md }]}>
+              Upload a short intro video (MP4 or MOV, max 50MB) to help seekers get to know you.
+            </Text>
+            {profileVideoUrl ? (
+              <View style={styles.videoStatus}>
+                <Icon name="check-circle" size={20} color="#4CAF50" />
+                <Text style={[styles.videoStatusText, { color: colors.text }]}>Video uploaded</Text>
+              </View>
+            ) : (
+              <View style={styles.videoStatus}>
+                <Icon name="video" size={20} color={colors.textSecondary} />
+                <Text style={[styles.videoStatusText, { color: colors.textSecondary }]}>No video uploaded</Text>
+              </View>
+            )}
+            <TouchableOpacity
+              style={[styles.videoButton, { borderColor: colors.primary, opacity: videoLoading ? 0.6 : 1 }]}
+              onPress={handleVideoUpload}
+              disabled={videoLoading}
+              accessibilityLabel="Upload profile video"
+              accessibilityRole="button"
+            >
+              {videoLoading ? (
+                <ActivityIndicator size="small" color={colors.primary} />
+              ) : (
+                <Icon name="upload" size={18} color={colors.primary} />
+              )}
+              <Text style={[styles.videoButtonText, { color: colors.primary }]}>
+                {videoLoading ? 'Uploading...' : profileVideoUrl ? 'Replace Video' : 'Upload Video'}
+              </Text>
+            </TouchableOpacity>
+          </View>
+        )}
+
         {/* Account Info (Read-only) */}
         <View style={[styles.section, { backgroundColor: colors.white }]}>
           <Text style={[styles.sectionTitle, { color: colors.text }]}>Account Info</Text>
@@ -320,5 +386,32 @@ const styles = StyleSheet.create({
     fontFamily: typography.fonts.bodyMedium,
     fontSize: typography.sizes.sm,
     fontWeight: '500',
+  },
+  videoStatus: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: spacing.md,
+    gap: spacing.xs,
+  },
+  videoStatusText: {
+    fontSize: typography.sizes.sm,
+    marginLeft: spacing.xs,
+  },
+  videoButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderWidth: 1.5,
+    borderRadius: borderRadius.lg,
+    paddingVertical: spacing.md,
+    paddingHorizontal: spacing.lg,
+    gap: spacing.xs,
+    minHeight: 48,
+  },
+  videoButtonText: {
+    fontFamily: typography.fonts.bodySemiBold,
+    fontSize: typography.sizes.sm,
+    fontWeight: '600',
+    marginLeft: spacing.xs,
   },
 });

--- a/app/src/services/api.ts
+++ b/app/src/services/api.ts
@@ -414,6 +414,32 @@ export const usersApi = {
     }
     return data;
   },
+
+  uploadProfileVideo: async (uri: string): Promise<{ url: string }> => {
+    const token = await getToken();
+    const formData = new FormData();
+    const extension = uri.split('.').pop()?.split('?')[0]?.toLowerCase() || 'mp4';
+    // Normalize mov extension to correct MIME type
+    const mimeType = extension === 'mov' ? 'video/quicktime' : `video/${extension}`;
+    formData.append('video', {
+      uri,
+      type: mimeType,
+      name: `profile-video.${extension}`,
+    } as unknown as Blob);
+    const response = await fetch(`${API_BASE_URL}/users/me/video/upload`, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${token}`,
+        'Content-Type': 'multipart/form-data',
+      },
+      body: formData,
+    });
+    const data = await response.json();
+    if (!response.ok) {
+      throw new ApiError(data.message || 'Video upload failed', response.status);
+    }
+    return data;
+  },
 };
 
 // Companions API

--- a/app/src/types/index.ts
+++ b/app/src/types/index.ts
@@ -66,6 +66,7 @@ export interface User {
   longitude?: number;
   emergencyContactName?: string;
   emergencyContactEmail?: string;
+  profileVideoUrl?: string;
   createdAt: string;
 }
 

--- a/backend/daterabbit-api/src/main.ts
+++ b/backend/daterabbit-api/src/main.ts
@@ -6,6 +6,7 @@ import { AppModule } from './app.module';
 import { runRefreshTokensMigration } from './auth/migrations/create-refresh-tokens';
 import { runNotificationTablesMigration } from './notifications/migrations/create-notification-tables';
 import { runAddExpiredBookingStatusMigration } from './bookings/migrations/add-expired-booking-status';
+import { runAddProfileVideoUrlMigration } from './users/migrations/add-profile-video-url';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule, {
@@ -39,6 +40,15 @@ async function bootstrap() {
   } catch (err) {
     console.error('add_expired_booking_status migration failed:', err);
     // Non-fatal: app still starts, but expiry cron will fail until fixed
+  }
+
+  try {
+    const dataSource = app.get<DataSource>(getDataSourceToken());
+    await runAddProfileVideoUrlMigration(dataSource);
+    console.log('add_profile_video_url migration: OK');
+  } catch (err) {
+    console.error('add_profile_video_url migration failed:', err);
+    // Non-fatal: app still starts
   }
 
   // Enable CORS

--- a/backend/daterabbit-api/src/users/entities/user.entity.ts
+++ b/backend/daterabbit-api/src/users/entities/user.entity.ts
@@ -106,6 +106,9 @@ export class User {
     payments: boolean;
   };
 
+  @Column({ type: 'varchar', nullable: true })
+  profileVideoUrl: string;
+
   @Column({ type: 'timestamp', nullable: true })
   lastSeen: Date;
 

--- a/backend/daterabbit-api/src/users/migrations/add-profile-video-url.ts
+++ b/backend/daterabbit-api/src/users/migrations/add-profile-video-url.ts
@@ -1,0 +1,11 @@
+import { DataSource } from 'typeorm';
+
+/**
+ * Idempotent migration: adds profileVideoUrl column to users table.
+ * Called from main.ts before the app starts listening.
+ */
+export async function runAddProfileVideoUrlMigration(dataSource: DataSource): Promise<void> {
+  await dataSource.query(`
+    ALTER TABLE "users" ADD COLUMN IF NOT EXISTS "profileVideoUrl" VARCHAR;
+  `);
+}

--- a/backend/daterabbit-api/src/users/users.controller.ts
+++ b/backend/daterabbit-api/src/users/users.controller.ts
@@ -1,5 +1,6 @@
-import { Controller, Get, Post, Put, Patch, Delete, Body, UseGuards, Request, Param, BadRequestException, ParseUUIDPipe, UseInterceptors, UploadedFile } from '@nestjs/common';
+import { Controller, Get, Post, Put, Patch, Delete, Body, UseGuards, Request, Param, BadRequestException, ForbiddenException, ParseUUIDPipe, UseInterceptors, UploadedFile } from '@nestjs/common';
 import { FileInterceptor } from '@nestjs/platform-express';
+import * as multer from 'multer';
 import { UsersService } from './users.service';
 import { UploadsService } from '../uploads/uploads.service';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
@@ -105,6 +106,40 @@ export class UsersController {
     }
     this.uploadsService.validateImageFile(file);
     const url = await this.uploadsService.uploadFile(file, 'profile-photos');
+    return { url };
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Post('me/video/upload')
+  @UseInterceptors(FileInterceptor('video', {
+    limits: { fileSize: 50 * 1024 * 1024 }, // 50MB — overrides module-level 10MB limit
+    storage: multer.memoryStorage(),
+    fileFilter: (_req, file, cb) => {
+      // Override module-level fileFilter which only allows images
+      const allowed = ['video/mp4', 'video/quicktime', 'video/mov'];
+      if (allowed.includes(file.mimetype)) {
+        cb(null, true);
+      } else {
+        cb(new BadRequestException('Only MP4 and MOV videos are allowed'), false);
+      }
+    },
+  }))
+  async uploadProfileVideo(
+    @Request() req,
+    @UploadedFile() file: Express.Multer.File,
+  ) {
+    if (!file) {
+      throw new BadRequestException('No video file provided');
+    }
+    // Only companions can upload a profile video
+    const user = await this.usersService.findById(req.user.id);
+    if (!user || user.role !== UserRole.COMPANION) {
+      throw new ForbiddenException('Only companions can upload a profile video');
+    }
+    this.uploadsService.validateVideoFile(file);
+    const url = await this.uploadsService.uploadFile(file, 'videos');
+    // Persist URL in user profile
+    await this.usersService.update(req.user.id, { profileVideoUrl: url } as any);
     return { url };
   }
 


### PR DESCRIPTION
Closes #349

## Changes

**Backend:**
- `POST /api/users/me/video/upload` — new endpoint with `FileInterceptor` using inline multer config that overrides the module-level image-only `fileFilter`. Allows `video/mp4`, `video/quicktime`, `video/mov`, 50MB max.
- Idempotent migration: `ALTER TABLE "users" ADD COLUMN IF NOT EXISTS "profileVideoUrl" VARCHAR`
- `profileVideoUrl` column added to `User` entity
- Companion-only guard: returns 403 for non-companions

**Frontend:**
- Video upload section in `edit-profile.tsx` — shows only for companions (`user.role === 'companion'`) and only on mobile (`Platform.OS !== 'web'`)
- Shows current status: "Video uploaded" (check icon) or "No video uploaded"
- Upload/Replace Video button with loading indicator during upload
- `uploadProfileVideo()` method added to `usersApi`
- `profileVideoUrl?: string` added to `User` interface in types