### PR TITLE
fix: multer fileSize limit override + profileVideoUrl type

### DIFF
--- a/app/src/services/api.ts
+++ b/app/src/services/api.ts
@@ -1063,6 +1063,7 @@ export interface User {
   isVerified?: boolean;
   verificationStatus?: import('../types').VerificationStatus;
   photos?: { id: string; url: string; order: number; isPrimary: boolean }[];
+  profileVideoUrl?: string;
   stripeOnboardingComplete?: boolean;
   isPublicProfile?: boolean;
   expoPushToken?: string;

--- a/app/src/store/authStore.ts
+++ b/app/src/store/authStore.ts
@@ -100,6 +100,7 @@ function mapApiUserToUser(apiUser: ApiUser): User {
     location: apiUser.location,
     bio: apiUser.bio,
     photos: apiUser.photos,
+    profileVideoUrl: apiUser.profileVideoUrl,
     hourlyRate: apiUser.hourlyRate,
     rating: apiUser.rating,
     reviewCount: apiUser.reviewCount,

--- a/backend/daterabbit-api/src/users/users.controller.ts
+++ b/backend/daterabbit-api/src/users/users.controller.ts
@@ -96,7 +96,7 @@ export class UsersController {
 
   @UseGuards(JwtAuthGuard)
   @Post('me/photos/upload')
-  @UseInterceptors(FileInterceptor('file'))
+  @UseInterceptors(FileInterceptor('file', { limits: { fileSize: 10 * 1024 * 1024 } }))
   async uploadProfilePhoto(
     @Request() req,
     @UploadedFile() file: Express.Multer.File,

--- a/backend/daterabbit-api/src/users/users.module.ts
+++ b/backend/daterabbit-api/src/users/users.module.ts
@@ -16,7 +16,6 @@ import { NotificationsModule } from '../notifications/notifications.module';
   imports: [
     TypeOrmModule.forFeature([User, BlockedUser, UserReport, Favorite, OnlineWatcher]),
     MulterModule.register({
-      limits: { fileSize: 10 * 1024 * 1024 }, // 10MB max
       storage: multer.memoryStorage(),
       fileFilter: (_req, file, cb) => {
         const allowed = ['image/jpeg', 'image/png', 'image/webp'];


### PR DESCRIPTION
## Summary
- Remove module-level `limits: { fileSize: 10MB }` from `MulterModule.register()` in `users.module.ts` — the module-level limit was overriding the per-interceptor 50MB limit set on the video upload endpoint
- Add `limits: { fileSize: 10MB }` inline to the photo upload `FileInterceptor` (previously relied on now-removed module-level limit)
- Add `profileVideoUrl?: string` to `User` interface in `api.ts`
- Add `profileVideoUrl: apiUser.profileVideoUrl` mapping in `mapApiUserToUser` in `authStore.ts`

## Test plan
- [ ] Upload video > 10MB — should succeed (was blocked before)
- [ ] Upload video > 50MB — should fail with correct error
- [ ] Upload photo — should still be limited to 10MB
- [ ] After video upload, `user.profileVideoUrl` is populated in app state

Fixes #349

🤖 Generated with [Claude Code](https://claude.com/claude-code)