### PR TITLE
feat: UC-048 date completion with actualDuration + confirm-duration + auto-capture cron

### DIFF
--- a/backend/daterabbit-api/src/bookings/bookings.controller.ts
+++ b/backend/daterabbit-api/src/bookings/bookings.controller.ts
@@ -333,13 +333,50 @@ export class BookingsController {
   }
 
   @Put(':id/complete')
-  async completeBooking(@Param('id', ParseUUIDPipe) id: string, @Request() req) {
-    const updated = await this.bookingsService.complete(id, req.user.id);
-    // Capture the Stripe hold (fire-and-forget)
-    this.paymentsService.capturePayment(id).catch(err =>
-      console.error('Stripe capture error for booking', id, err),
-    );
+  async completeBooking(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Request() req,
+    @Body() body: { actualDuration?: number },
+  ) {
+    const updated = await this.bookingsService.complete(id, req.user.id, {
+      actualDuration: body.actualDuration,
+    });
+
+    // If actualDuration provided, defer payment capture to seeker confirmation flow.
+    // Otherwise, capture immediately for backwards compatibility.
+    if (body.actualDuration === undefined) {
+      this.paymentsService.capturePayment(id).catch(err =>
+        console.error('Stripe capture error for booking', id, err),
+      );
+    }
+
     return this.formatBooking(updated);
+  }
+
+  @Post(':id/confirm-duration')
+  async confirmDuration(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Request() req,
+    @Body() body: { confirmed: boolean },
+  ) {
+    if (typeof body.confirmed !== 'boolean') {
+      throw new HttpException('confirmed (boolean) is required', HttpStatus.BAD_REQUEST);
+    }
+
+    const booking = await this.bookingsService.confirmDuration(id, req.user.id, body.confirmed);
+
+    if (body.confirmed) {
+      // Capture proportional payment (fire-and-forget)
+      this.paymentsService.captureProportional(
+        id,
+        Number(booking.actualDurationHours ?? booking.duration),
+      ).catch(err =>
+        console.error('Stripe proportional capture error for booking', id, err),
+      );
+    }
+    // If !confirmed — leave for admin dispute resolution, no capture
+
+    return this.formatBooking(booking);
   }
 
   @Post(':id/checkin')
@@ -558,6 +595,9 @@ export class BookingsController {
       reportIssueText: booking.reportIssueText || undefined,
       packageId: booking.packageId || undefined,
       selfieVerified: booking.selfieVerified || false,
+      completedAt: booking.completedAt || undefined,
+      durationConfirmedBySeeker: booking.durationConfirmedBySeeker !== null && booking.durationConfirmedBySeeker !== undefined ? booking.durationConfirmedBySeeker : undefined,
+      durationConfirmedAt: booking.durationConfirmedAt || undefined,
       seeker: booking.seeker ? {
         id: booking.seeker.id,
         name: booking.seeker.name,

--- a/backend/daterabbit-api/src/bookings/bookings.cron.ts
+++ b/backend/daterabbit-api/src/bookings/bookings.cron.ts
@@ -94,6 +94,43 @@ export class BookingsCron {
     });
   }
 
+  @Cron(CronExpression.EVERY_HOUR)
+  async autoCaptureCompletedBookings(): Promise<void> {
+    const cutoff = new Date(Date.now() - 24 * 60 * 60 * 1000);
+
+    const bookings = await this.bookingsRepository.find({
+      where: {
+        status: BookingStatus.COMPLETED,
+        durationConfirmedBySeeker: IsNull(),
+        completedAt: LessThan(cutoff),
+      },
+    });
+
+    if (bookings.length === 0) return;
+
+    for (const booking of bookings) {
+      try {
+        // Guard: recheck inside iteration to avoid race conditions
+        const fresh = await this.bookingsRepository.findOne({
+          where: { id: booking.id, durationConfirmedBySeeker: IsNull() },
+        });
+        if (!fresh) continue;
+
+        await this.paymentsService.captureProportional(
+          booking.id,
+          Number(fresh.actualDurationHours ?? fresh.duration),
+        );
+        await this.bookingsRepository.update(booking.id, {
+          durationConfirmedBySeeker: true,
+          durationConfirmedAt: new Date(),
+        });
+        this.logger.log(`[AutoCapture] Captured payment for booking ${booking.id} after 24h timeout`);
+      } catch (err: any) {
+        this.logger.error(`[AutoCapture] Failed for booking ${booking.id}: ${err.message}`);
+      }
+    }
+  }
+
   @Cron(CronExpression.EVERY_5_MINUTES)
   async checkNoShows() {
     const fifteenMinutesAgo = new Date(Date.now() - 15 * 60 * 1000);

--- a/backend/daterabbit-api/src/bookings/bookings.service.ts
+++ b/backend/daterabbit-api/src/bookings/bookings.service.ts
@@ -322,7 +322,7 @@ export class BookingsService {
     });
   }
 
-  async complete(id: string, userId: string): Promise<Booking> {
+  async complete(id: string, userId: string, options?: { actualDuration?: number }): Promise<Booking> {
     const booking = await this.findById(id);
 
     if (!booking) {
@@ -335,7 +335,8 @@ export class BookingsService {
 
     if (
       booking.status !== BookingStatus.CONFIRMED &&
-      booking.status !== BookingStatus.PAID
+      booking.status !== BookingStatus.PAID &&
+      booking.status !== BookingStatus.ACTIVE
     ) {
       throw new HttpException(
         `Cannot complete a ${booking.status} booking`,
@@ -353,7 +354,19 @@ export class BookingsService {
       );
     }
 
-    const updated = await this.updateStatus(id, BookingStatus.COMPLETED);
+    const update: Partial<Booking> = {
+      status: BookingStatus.COMPLETED,
+      completedAt: now,
+      activeDateEndedAt: now,
+    };
+
+    if (options?.actualDuration !== undefined) {
+      const actualDurationHours = options.actualDuration / 60;
+      update.actualDurationHours = actualDurationHours;
+    }
+
+    await this.bookingsRepository.update(id, update);
+    const updated = await this.findById(id);
     if (!updated) {
       throw new HttpException('Failed to update booking', HttpStatus.INTERNAL_SERVER_ERROR);
     }
@@ -370,6 +383,31 @@ export class BookingsService {
     }
 
     return updated;
+  }
+
+  async confirmDuration(
+    bookingId: string,
+    seekerId: string,
+    confirmed: boolean,
+  ): Promise<Booking> {
+    const booking = await this.findById(bookingId);
+    if (!booking) {
+      throw new HttpException('Booking not found', HttpStatus.NOT_FOUND);
+    }
+    if (booking.seekerId !== seekerId) {
+      throw new HttpException('Only the seeker can confirm duration', HttpStatus.FORBIDDEN);
+    }
+    if (booking.status !== BookingStatus.COMPLETED) {
+      throw new HttpException('Booking must be completed first', HttpStatus.BAD_REQUEST);
+    }
+
+    const now = new Date();
+    await this.bookingsRepository.update(bookingId, {
+      durationConfirmedBySeeker: confirmed,
+      durationConfirmedAt: now,
+    });
+
+    return (await this.findById(bookingId))!;
   }
 
   async seekerCheckin(bookingId: string, seekerId: string, lat?: number, lon?: number): Promise<Booking> {

--- a/backend/daterabbit-api/src/bookings/entities/booking.entity.ts
+++ b/backend/daterabbit-api/src/bookings/entities/booking.entity.ts
@@ -133,6 +133,15 @@ export class Booking {
   @Column({ type: 'boolean', default: false })
   selfieVerified: boolean;
 
+  @Column({ type: 'timestamp', nullable: true })
+  completedAt: Date;
+
+  @Column({ type: 'boolean', nullable: true })
+  durationConfirmedBySeeker: boolean;
+
+  @Column({ type: 'timestamp', nullable: true })
+  durationConfirmedAt: Date;
+
   // Who initiated the cancellation (seekerId or companionId) — used for tiered refund policy
   @Column({ nullable: true })
   cancelledByUserId: string;

--- a/backend/daterabbit-api/src/bookings/migrations/add-completion-duration-fields.ts
+++ b/backend/daterabbit-api/src/bookings/migrations/add-completion-duration-fields.ts
@@ -1,0 +1,14 @@
+import { DataSource } from 'typeorm';
+
+/**
+ * Idempotent bootstrap migration: adds completedAt, durationConfirmedBySeeker,
+ * and durationConfirmedAt columns to the bookings table.
+ * Called from main.ts before the app starts listening.
+ */
+export async function runAddCompletionDurationFieldsMigration(dataSource: DataSource): Promise<void> {
+  await dataSource.query(`
+    ALTER TABLE bookings ADD COLUMN IF NOT EXISTS "completedAt" TIMESTAMP;
+    ALTER TABLE bookings ADD COLUMN IF NOT EXISTS "durationConfirmedBySeeker" BOOLEAN;
+    ALTER TABLE bookings ADD COLUMN IF NOT EXISTS "durationConfirmedAt" TIMESTAMP;
+  `);
+}

--- a/backend/daterabbit-api/src/main.ts
+++ b/backend/daterabbit-api/src/main.ts
@@ -7,6 +7,7 @@ import { runRefreshTokensMigration } from './auth/migrations/create-refresh-toke
 import { runNotificationTablesMigration } from './notifications/migrations/create-notification-tables';
 import { runAddExpiredBookingStatusMigration } from './bookings/migrations/add-expired-booking-status';
 import { runAddProfileVideoUrlMigration } from './users/migrations/add-profile-video-url';
+import { runAddCompletionDurationFieldsMigration } from './bookings/migrations/add-completion-duration-fields';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule, {
@@ -48,6 +49,15 @@ async function bootstrap() {
     console.log('add_profile_video_url migration: OK');
   } catch (err) {
     console.error('add_profile_video_url migration failed:', err);
+    // Non-fatal: app still starts
+  }
+
+  try {
+    const dataSource = app.get<DataSource>(getDataSourceToken());
+    await runAddCompletionDurationFieldsMigration(dataSource);
+    console.log('add_completion_duration_fields migration: OK');
+  } catch (err) {
+    console.error('add_completion_duration_fields migration failed:', err);
     // Non-fatal: app still starts
   }
 

--- a/backend/daterabbit-api/src/payments/payments.service.ts
+++ b/backend/daterabbit-api/src/payments/payments.service.ts
@@ -312,6 +312,32 @@ export class PaymentsService {
     }
   }
 
+  // --- Proportional capture for date completion ---
+
+  async captureProportional(
+    bookingId: string,
+    actualHours: number,
+  ): Promise<{ captured: number; refunded: number }> {
+    const booking = await this.bookingsRepo.findOne({ where: { id: bookingId } });
+    if (!booking?.paymentIntentId) return { captured: 0, refunded: 0 };
+
+    const totalPrice = Number(booking.totalPrice);
+    const bookedDuration = Number(booking.duration);
+
+    if (actualHours >= bookedDuration) {
+      // Full capture — no refund needed
+      await this.capturePayment(bookingId);
+      return { captured: totalPrice, refunded: 0 };
+    }
+
+    // Capture full amount first, then refund proportional unused time
+    await this.capturePayment(bookingId);
+    const refundFraction = 1 - actualHours / bookedDuration;
+    const refundAmount = Math.round(totalPrice * refundFraction * 100) / 100;
+    await this.partialRefundForEndEarly(bookingId, actualHours);
+    return { captured: Math.round((totalPrice - refundAmount) * 100) / 100, refunded: refundAmount };
+  }
+
   // --- Partial refund for end-early ---
 
   async partialRefundForEndEarly(bookingId: string, actualHours: number): Promise<void> {


### PR DESCRIPTION
## Summary
- `PUT /bookings/:id/complete` now accepts optional `actualDuration` (minutes) — stores actual hours, defers payment capture to confirmation flow
- New `POST /bookings/:id/confirm-duration` endpoint for seeker to confirm or dispute reported duration
- Auto-capture cron fires every hour, captures payment after 24h if seeker hasn't confirmed
- `captureProportional()` in PaymentsService handles full capture or capture+proportional refund
- 3 new DB columns: `completedAt`, `durationConfirmedBySeeker`, `durationConfirmedAt`
- Idempotent migration registered in main.ts bootstrap

## Test plan
- [ ] Complete booking with actualDuration → verify completedAt and actualDurationHours stored
- [ ] Complete booking without actualDuration → verify backwards compat (immediate capture)
- [ ] POST confirm-duration { confirmed: true } → verify payment captured proportionally
- [ ] POST confirm-duration { confirmed: false } → verify no capture, left for admin
- [ ] Wait 24h (or adjust cutoff) → verify cron auto-captures
- [ ] Non-seeker calling confirm-duration → 403

Closes #372