### PR TITLE
fix: brand colors #FF69B4→primary, #FF3B30→error in edit-profile+setup

### DIFF
--- a/app/app/(auth)/profile-setup.tsx
+++ b/app/app/(auth)/profile-setup.tsx
@@ -21,7 +21,7 @@ import { usersApi, referralApi, citiesApi } from '../../src/services/api';
 import type { City } from '../../src/services/api';
 import { Button } from '../../src/components/Button';
 import { Icon } from '../../src/components/Icon';
-import { useTheme, spacing, typography, borderRadius } from '../../src/constants/theme';
+import { useTheme, colors, spacing, typography, borderRadius } from '../../src/constants/theme';
 import type { UserRole } from '../../src/types';
 
 // Web-only: native <select> for city (RN Modal doesn't work well on web)
@@ -36,7 +36,7 @@ const WebCitySelect = Platform.OS === 'web'
       const selectStyle = {
         width: '100%' as const,
         height: 48,
-        border: `2px solid ${hasError ? '#FF3B30' : c.border}`,
+        border: `2px solid ${hasError ? colors.error : c.border}`,
         borderRadius: 12,
         backgroundColor: c.surface,
         paddingLeft: 16,
@@ -365,7 +365,7 @@ export default function ProfileSetupScreen() {
                   </TouchableOpacity>
                 )}
                 {citiesError && (
-                  <Text style={[styles.hint, { color: '#FF3B30' }]}>Failed to load cities</Text>
+                  <Text style={[styles.hint, { color: colors.error }]}>Failed to load cities</Text>
                 )}
               </View>
             </View>
@@ -494,7 +494,7 @@ export default function ProfileSetupScreen() {
                 </View>
               ) : citiesError ? (
                 <View style={styles.cityPickerLoading}>
-                  <Text style={{ color: '#FF3B30', fontSize: typography.sizes.sm }}>Failed to load cities. Please try again.</Text>
+                  <Text style={{ color: colors.error, fontSize: typography.sizes.sm }}>Failed to load cities. Please try again.</Text>
                 </View>
               ) : (
                 <FlatList
@@ -701,7 +701,7 @@ const styles = StyleSheet.create({
     borderBottomWidth: 1,
   },
   cityItemSelected: {
-    backgroundColor: '#FF69B4',
+    backgroundColor: colors.primary,
   },
   cityItemText: {
     fontSize: typography.sizes.md,

--- a/app/app/(auth)/register.tsx
+++ b/app/app/(auth)/register.tsx
@@ -701,7 +701,7 @@ const styles = StyleSheet.create({
   errorBanner: {
     flexDirection: 'row',
     alignItems: 'center',
-    backgroundColor: '#FFF0F0',
+    backgroundColor: colors.errorLight,
     borderWidth: 1,
     borderColor: colors.error,
     borderRadius: borderRadius.md,

--- a/app/app/settings/edit-profile.tsx
+++ b/app/app/settings/edit-profile.tsx
@@ -22,7 +22,7 @@ import { useAuthStore } from '../../src/store/authStore';
 import { useImagePicker } from '../../src/hooks/useImagePicker';
 import { usersApi, citiesApi } from '../../src/services/api';
 import type { City } from '../../src/services/api';
-import { useTheme, spacing, typography, borderRadius } from '../../src/constants/theme';
+import { useTheme, colors, spacing, typography, borderRadius } from '../../src/constants/theme';
 import { showAlert } from '../../src/utils/alert';
 
 // Web-only: native <select> for city (RN Modal doesn't work well on web)
@@ -37,7 +37,7 @@ const WebCitySelect = Platform.OS === 'web'
       const selectStyle = {
         width: '100%' as const,
         height: 48,
-        border: `1px solid ${hasError ? '#FF3B30' : c.border}`,
+        border: `1px solid ${hasError ? colors.error : c.border}`,
         borderRadius: 12,
         backgroundColor: c.white,
         paddingLeft: 16,
@@ -301,7 +301,7 @@ export default function EditProfileScreen() {
               </TouchableOpacity>
             )}
             {citiesError && (
-              <Text style={[styles.hint, { color: '#FF3B30' }]}>Failed to load cities</Text>
+              <Text style={[styles.hint, { color: colors.error }]}>Failed to load cities</Text>
             )}
           </View>
 
@@ -422,7 +422,7 @@ export default function EditProfileScreen() {
                 </View>
               ) : citiesError ? (
                 <View style={styles.cityPickerLoading}>
-                  <Text style={{ color: '#FF3B30', fontSize: typography.sizes.sm }}>Failed to load cities. Please try again.</Text>
+                  <Text style={{ color: colors.error, fontSize: typography.sizes.sm }}>Failed to load cities. Please try again.</Text>
                 </View>
               ) : (
                 <FlatList
@@ -624,7 +624,7 @@ const styles = StyleSheet.create({
     borderBottomWidth: 1,
   },
   cityItemSelected: {
-    backgroundColor: '#FF69B4',
+    backgroundColor: colors.primary,
   },
   cityItemText: {
     fontSize: typography.sizes.md,


### PR DESCRIPTION
Fixes #385

## Changes
- `edit-profile.tsx`: add `colors` import; `#FF69B4` → `colors.primary` (cityItemSelected); `#FF3B30` → `colors.error` (3 places: WebCitySelect border, two error text nodes)
- `profile-setup.tsx`: same pattern — 4 replacements
- `register.tsx`: `#FFF0F0` → `colors.errorLight` in errorBanner

## Verification
`tsc --noEmit` — 0 errors before and after.