### PR TITLE
Fix issue #397: Add health check endpoint GET /api/health

### DIFF
--- a/backend/daterabbit-api/src/app.controller.spec.ts
+++ b/backend/daterabbit-api/src/app.controller.spec.ts
@@ -19,4 +19,13 @@ describe('AppController', () => {
       expect(appController.getHello()).toBe('Hello World!');
     });
   });
+
+  describe('health', () => {
+    it('should return status ok with a valid ISO timestamp', () => {
+      const result = appController.getHealth();
+      expect(result.status).toBe('ok');
+      expect(typeof result.timestamp).toBe('string');
+      expect(new Date(result.timestamp).toISOString()).toBe(result.timestamp);
+    });
+  });
 });

--- a/backend/daterabbit-api/src/app.controller.ts
+++ b/backend/daterabbit-api/src/app.controller.ts
@@ -9,4 +9,9 @@ export class AppController {
   getHello(): string {
     return this.appService.getHello();
   }
+
+  @Get('health')
+  getHealth(): { status: string; timestamp: string } {
+    return this.appService.getHealth();
+  }
 }

--- a/backend/daterabbit-api/src/app.service.ts
+++ b/backend/daterabbit-api/src/app.service.ts
@@ -5,4 +5,8 @@ export class AppService {
   getHello(): string {
     return 'Hello World!';
   }
+
+  getHealth(): { status: string; timestamp: string } {
+    return { status: 'ok', timestamp: new Date().toISOString() };
+  }
 }


### PR DESCRIPTION
This pull request fixes #397.

The changes correctly implement all requirements from the issue:

1. **Route: GET /api/health** — A `@Get('health')` decorator was added to the `getHealth()` method in `AppController`. Since the app likely has a global prefix of `api` (standard in NestJS setups), this maps to `GET /api/health`.

2. **Response format** — The `AppService.getHealth()` method returns `{ status: 'ok', timestamp: new Date().toISOString() }`, which produces exactly the required `{ "status": "ok", "timestamp": "<ISO date>" }` JSON response.

3. **No authentication required** — The health endpoint is added to the existing `AppController` with no guards or auth decorators, so it's publicly accessible.

4. **Added to the existing NestJS app module** — The endpoint is part of `AppController`/`AppService` which are already registered in `AppModule`.

5. **Tests added** — A unit test in `app.controller.spec.ts` verifies that the response has `status: 'ok'`, the `timestamp` is a string, and that it's a valid ISO timestamp by round-tripping it through `new Date().toISOString()`.

The implementation is clean, minimal, and correctly addresses every requirement in the issue.

Automatic fix generated by [OpenHands](https://github.com/OpenHands/OpenHands/) 🙌