### PR TITLE
ci: add proto-viewer update step to staging deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -182,6 +182,8 @@ jobs:
           sudo pm2 restart daterabbit || sudo pm2 start dist/main.js --name daterabbit --cwd /var/www/daterabbit/api -i 2
           sudo chown -R www-data:www-data /var/www/daterabbit/ 2>/dev/null || true
 
+      - name: Update proto-viewer
+        run: sudo npm i -g proto-viewer@latest && pm2 restart proto-date-rabbit || true
       - name: Deploy nginx config
         run: |
           CONF="/etc/nginx/sites-available/daterabbit"


### PR DESCRIPTION
Adds `sudo npm i -g proto-viewer@latest && pm2 restart proto-date-rabbit || true` after backend restart in staging deploy job.