### PR TITLE
fix(proto): remove header artifact from ProtoLayout

### DIFF
--- a/app/src/components/proto/ProtoLayout.tsx
+++ b/app/src/components/proto/ProtoLayout.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View, Text, StyleSheet, ScrollView } from 'react-native';
+import { StyleSheet, ScrollView } from 'react-native';
 
 interface Props {
   title: string;
@@ -7,13 +7,9 @@ interface Props {
   children: React.ReactNode;
 }
 
-export function ProtoLayout({ title, route, children }: Props) {
+export function ProtoLayout({ children }: Props) {
   return (
     <ScrollView style={styles.container} contentContainerStyle={styles.content}>
-      <View style={styles.header}>
-        <Text style={styles.title}>{title}</Text>
-        <Text style={styles.route}>{route}</Text>
-      </View>
       {children}
     </ScrollView>
   );
@@ -22,11 +18,4 @@ export function ProtoLayout({ title, route, children }: Props) {
 const styles = StyleSheet.create({
   container: { flex: 1, backgroundColor: '#F4F0EA' },
   content: { paddingBottom: 60 },
-  header: {
-    backgroundColor: '#000000',
-    padding: 16,
-    marginBottom: 24,
-  },
-  title: { fontSize: 18, fontWeight: '900', color: '#FFFFFF' },
-  route: { fontSize: 12, color: '#999999', fontFamily: 'monospace', marginTop: 2 },
 });


### PR DESCRIPTION
Remove black header (title + route) rendered inside iframe - it was duplicating the viewer's own navigation bar.