### PR TITLE
fix(nginx): allow iframe embedding for proto-viewer

### DIFF
--- a/server/nginx-daterabbit.conf
+++ b/server/nginx-daterabbit.conf
@@ -13,11 +13,10 @@ server {
 
     # Security headers — applied at server level (inherited by locations without own add_header)
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
-    add_header X-Frame-Options "SAMEORIGIN" always;
     add_header X-Content-Type-Options "nosniff" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
     add_header Permissions-Policy "camera=(), microphone=(), geolocation=(self)" always;
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://js.stripe.com https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://daterabbit-api.smartlaunchhub.com https://*.stripe.com https://static.cloudflareinsights.com; font-src 'self' data:; frame-ancestors 'self';" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://js.stripe.com https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://daterabbit-api.smartlaunchhub.com https://*.stripe.com https://static.cloudflareinsights.com; font-src 'self' data:; frame-ancestors *;" always;
 
     # API proxy to NestJS backend
     location /api/ {
@@ -55,11 +54,10 @@ server {
         expires 1y;
         add_header Cache-Control "public, immutable";
         add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
-        add_header X-Frame-Options "SAMEORIGIN" always;
         add_header X-Content-Type-Options "nosniff" always;
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
         add_header Permissions-Policy "camera=(), microphone=(), geolocation=(self)" always;
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://js.stripe.com https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://daterabbit-api.smartlaunchhub.com https://*.stripe.com https://static.cloudflareinsights.com; font-src 'self' data:; frame-ancestors 'self';" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://js.stripe.com https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://daterabbit-api.smartlaunchhub.com https://*.stripe.com https://static.cloudflareinsights.com; font-src 'self' data:; frame-ancestors *;" always;
     }
 
     # Uploads served from backend
@@ -68,11 +66,10 @@ server {
         expires 30d;
         add_header Cache-Control "public, immutable";
         add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
-        add_header X-Frame-Options "SAMEORIGIN" always;
         add_header X-Content-Type-Options "nosniff" always;
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
         add_header Permissions-Policy "camera=(), microphone=(), geolocation=(self)" always;
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://js.stripe.com https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://daterabbit-api.smartlaunchhub.com https://*.stripe.com https://static.cloudflareinsights.com; font-src 'self' data:; frame-ancestors 'self';" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://js.stripe.com https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://daterabbit-api.smartlaunchhub.com https://*.stripe.com https://static.cloudflareinsights.com; font-src 'self' data:; frame-ancestors *;" always;
     }
 
     # Expo static assets (long cache)
@@ -81,22 +78,20 @@ server {
         expires 1y;
         add_header Cache-Control "public, immutable";
         add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
-        add_header X-Frame-Options "SAMEORIGIN" always;
         add_header X-Content-Type-Options "nosniff" always;
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
         add_header Permissions-Policy "camera=(), microphone=(), geolocation=(self)" always;
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://js.stripe.com https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://daterabbit-api.smartlaunchhub.com https://*.stripe.com https://static.cloudflareinsights.com; font-src 'self' data:; frame-ancestors 'self';" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://js.stripe.com https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://daterabbit-api.smartlaunchhub.com https://*.stripe.com https://static.cloudflareinsights.com; font-src 'self' data:; frame-ancestors *;" always;
     }
 
     # PWA manifest — exact match to prevent SPA catch-all from returning HTML
     location = /manifest.json {
         add_header Content-Type "application/manifest+json" always;
         add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
-        add_header X-Frame-Options "SAMEORIGIN" always;
         add_header X-Content-Type-Options "nosniff" always;
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
         add_header Permissions-Policy "camera=(), microphone=(), geolocation=(self)" always;
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://js.stripe.com https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://daterabbit-api.smartlaunchhub.com https://*.stripe.com https://static.cloudflareinsights.com; font-src 'self' data:; frame-ancestors 'self';" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://js.stripe.com https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://daterabbit-api.smartlaunchhub.com https://*.stripe.com https://static.cloudflareinsights.com; font-src 'self' data:; frame-ancestors *;" always;
         try_files $uri =404;
     }
 


### PR DESCRIPTION
Remove X-Frame-Options SAMEORIGIN and change frame-ancestors from 'self' to * across all location blocks. Required for proto-viewer to embed daterabbit pages in iframe.