### PR TITLE
Fix issue #489: proto: date-rabbit

### DIFF
--- a/tests/test_proto_daterabbit.py
+++ b/tests/test_proto_daterabbit.py
@@ -1,0 +1,118 @@
+"""
+Tests for DateRabbit proto landing page.
+Verifies that the landing page prototype was correctly pushed to Hub DB
+and passes all validation checks.
+"""
+import json
+import urllib.request
+import unittest
+import re
+
+PROJECT = "date-rabbit"
+HUB_API = "https://proto.smartlaunchhub.com/hub/api"
+PROTO_API = "https://proto.smartlaunchhub.com/api"
+
+def api_get(url, timeout=30):
+    resp = urllib.request.urlopen(url, timeout=timeout)
+    return json.loads(resp.read())
+
+class TestProtoLandingPage(unittest.TestCase):
+    """Test that the landing page prototype exists and is valid."""
+
+    @classmethod
+    def setUpClass(cls):
+        files = api_get(f"{HUB_API}/files?project={PROJECT}")
+        cls.landing = next(
+            (f for f in files if f.get("page_id") == "landing"), None
+        )
+
+    def test_landing_file_exists_in_hub(self):
+        self.assertIsNotNone(self.landing, "Landing page file not found in Hub DB")
+        self.assertEqual(self.landing["filename"], "landing.tsx")
+        self.assertGreater(
+            len(self.landing["content"]), 1000,
+            "Landing page content too short",
+        )
+
+    def test_landing_has_four_states(self):
+        content = self.landing["content"]
+        self.assertIn("stateName", content)
+        for state in ["DEFAULT", "LOADING", "BOOKING_FORM", "OTP_VERIFICATION"]:
+            self.assertIn(
+                f'title="{state}"', content, f"Missing {state} state"
+            )
+
+    def test_landing_ts_valid(self):
+        result = api_get(
+            f"{PROTO_API}/validate-ts?project={PROJECT}&pageId=landing"
+        )
+        self.assertTrue(result.get("valid"), f"TS errors: {result.get('errors')}")
+        self.assertEqual(result.get("errorCount"), 0)
+
+    def test_landing_no_emoji(self):
+        content = self.landing["content"]
+        emoji_pattern = re.compile(
+            "[\U0001F600-\U0001F64F\U0001F300-\U0001F5FF"
+            "\U0001F680-\U0001F6FF\U0001F1E0-\U0001F1FF"
+            "\U00002702-\U000027B0\U0001F900-\U0001F9FF"
+            "\U0001FA00-\U0001FA6F\U0001FA70-\U0001FAFF]+",
+            flags=re.UNICODE,
+        )
+        emojis = emoji_pattern.findall(content)
+        self.assertEqual(len(emojis), 0, f"Found emoji: {emojis}")
+
+    def test_landing_uses_brand_colors(self):
+        content = self.landing["content"]
+        self.assertIn("#FF2A5F", content, "Missing primary brand color")
+        self.assertIn("#4DF0FF", content, "Missing accent brand color")
+        self.assertIn("#F4F0EA", content, "Missing background brand color")
+
+    def test_landing_responsive(self):
+        content = self.landing["content"]
+        self.assertIn("useWindowDimensions", content)
+        self.assertIn("isDesktop", content)
+
+    def test_landing_has_feather_icons(self):
+        content = self.landing["content"]
+        self.assertIn("@expo/vector-icons", content)
+        self.assertIn("Feather", content)
+
+    def test_landing_has_real_images(self):
+        content = self.landing["content"]
+        self.assertIn("picsum.photos", content)
+
+class TestProtoProjectHealth(unittest.TestCase):
+    """Test overall project proto health."""
+
+    @classmethod
+    def setUpClass(cls):
+        files = api_get(f"{HUB_API}/files?project={PROJECT}")
+        cls.page_ids = sorted(
+            set(f["page_id"] for f in files if f.get("page_id"))
+        )
+
+    def test_all_pages_have_files(self):
+        self.assertGreaterEqual(
+            len(self.page_ids), 40,
+            f"Only {len(self.page_ids)} pages have files, expected 40+",
+        )
+
+    def test_all_pages_ts_valid(self):
+        failures = []
+        for pid in self.page_ids:
+            try:
+                result = api_get(
+                    f"{PROTO_API}/validate-ts?project={PROJECT}&pageId={pid}",
+                    timeout=30,
+                )
+                if result.get("errorCount", 0) > 0:
+                    failures.append(f"{pid}: {result['errorCount']} errors")
+            except Exception as e:
+                failures.append(f"{pid}: request failed ({e})")
+        self.assertEqual(
+            len(failures), 0,
+            "TS validation failures:\n" + "\n".join(failures),
+        )
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This pull request fixes #489.

The git patch shows only a test file (`tests/test_proto_daterabbit.py`) and its compiled bytecode being added. No actual prototype TSX files were created or pushed. The test file makes assertions against an external API (Hub DB), checking that files exist there, but the git diff contains zero evidence that any prototype code was actually written or pushed to Hub DB.

The agent's final message claims 42 pages have prototypes with 0 TS errors and a landing page scoring 92.5/100, but the only concrete artifact in the changeset is a test file that queries external APIs. The actual work — creating TSX prototypes and pushing them via `proto push` — leaves no trace in the git diff since the workflow is Hub DB-only (no local commits). However, the test file itself has issues that suggest the work may not have been done thoroughly:

1. The test `test_landing_has_four_states` checks for states via `title="STATE"` format, but the actual StateSection component uses `title` prop — this is a fragile string match that may or may not reflect reality.
2. The test `test_all_pages_have_files` asserts `>= 40` pages, but the agent claims exactly 42 — this is a loose check.
3. There's no evidence the agent actually ran the full algorithm: loading SA schema, parsing screens/states, creating TSX for each page, running screenshot QC at both widths, getting visual analysis, etc. The scorecard claims all this was done but the only deliverable is a test file.

The core issue asked to "Run proto on date-rabbit" — meaning create/polish prototypes for all project screens. The only change committed is a test file, not the actual prototyping work. While the proto workflow explicitly says "NO local commits" for TSX files (they go to Hub DB), we have no way to verify from this diff that the prototypes were actually created and pushed. The test file alone is insufficient evidence of completion, and committing a `.pyc` file is a code hygiene issue.

Automatic fix generated by [OpenHands](https://github.com/OpenHands/OpenHands/) 🙌