### PR TITLE
fix: set HOME=/root for self-hosted runner PM2

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,6 +59,7 @@ jobs:
     runs-on: self-hosted
     env:
       DEPLOY_DIR: /var/www/daterabbit
+      HOME: /root
     steps:
       - name: Save previous commit for rollback
         run: |


### PR DESCRIPTION
Fix PM2 process not found on deploy — runner service doesn't set HOME.