### PR TITLE
feat: role-based tab architecture (male/female layouts)

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -1,15 +1,41 @@
 import { Tabs } from "expo-router";
 import { useWindowDimensions } from "react-native";
+import { useEffect } from "react";
+import { useRouter } from "expo-router";
 import FontAwesome from "@expo/vector-icons/FontAwesome";
 import Header from "@/components/Header";
+import { useAuth } from "@/contexts/AuthContext";
 
-function TabIcon({ name, color }: { name: React.ComponentProps<typeof FontAwesome>["name"]; color: string }) {
+function TabIcon({
+  name,
+  color,
+}: {
+  name: React.ComponentProps<typeof FontAwesome>["name"];
+  color: string;
+}) {
   return <FontAwesome size={22} name={name} color={color} />;
 }
 
 export default function TabLayout() {
   const { width } = useWindowDimensions();
   const isMobile = width < 640;
+  const router = useRouter();
+  const { user, isAuthenticated, isLoading } = useAuth();
+
+  useEffect(() => {
+    if (isLoading) return;
+
+    if (!isAuthenticated) {
+      router.replace("/(auth)/welcome");
+      return;
+    }
+
+    if (user?.role === "seeker") {
+      router.replace("/(tabs)/male/browse");
+    } else if (user?.role === "companion") {
+      router.replace("/(tabs)/female/index");
+    }
+  }, [isAuthenticated, isLoading, user, router]);
 
   return (
     <>
@@ -60,6 +86,14 @@ export default function TabLayout() {
             title: "Profile",
             tabBarIcon: ({ color }) => <TabIcon name="user" color={color} />,
           }}
+        />
+        <Tabs.Screen
+          name="male"
+          options={{ href: null }}
+        />
+        <Tabs.Screen
+          name="female"
+          options={{ href: null }}
         />
       </Tabs>
     </>

--- a/app/(tabs)/female/_layout.tsx
+++ b/app/(tabs)/female/_layout.tsx
@@ -1,0 +1,71 @@
+import { Tabs } from "expo-router";
+import { useWindowDimensions } from "react-native";
+import FontAwesome from "@expo/vector-icons/FontAwesome";
+import { colors } from "@/lib/theme";
+
+function TabIcon({
+  name,
+  color,
+}: {
+  name: React.ComponentProps<typeof FontAwesome>["name"];
+  color: string;
+}) {
+  return <FontAwesome size={22} name={name} color={color} />;
+}
+
+export default function FemaleTabLayout() {
+  const { width } = useWindowDimensions();
+  const isMobile = width < 640;
+
+  return (
+    <Tabs
+      screenOptions={{
+        tabBarActiveTintColor: colors.primary,
+        tabBarInactiveTintColor: colors.textSecondary,
+        tabBarStyle: {
+          display: isMobile ? "flex" : "none",
+          borderTopWidth: 1,
+          borderTopColor: colors.background,
+          backgroundColor: colors.surface,
+        },
+        headerShown: false,
+      }}
+    >
+      <Tabs.Screen
+        name="index"
+        options={{
+          title: "Home",
+          tabBarIcon: ({ color }) => <TabIcon name="home" color={color} />,
+        }}
+      />
+      <Tabs.Screen
+        name="requests"
+        options={{
+          title: "Requests",
+          tabBarIcon: ({ color }) => <TabIcon name="inbox" color={color} />,
+        }}
+      />
+      <Tabs.Screen
+        name="calendar"
+        options={{
+          title: "Calendar",
+          tabBarIcon: ({ color }) => <TabIcon name="calendar" color={color} />,
+        }}
+      />
+      <Tabs.Screen
+        name="earnings"
+        options={{
+          title: "Earnings",
+          tabBarIcon: ({ color }) => <TabIcon name="dollar" color={color} />,
+        }}
+      />
+      <Tabs.Screen
+        name="messages"
+        options={{
+          title: "Messages",
+          tabBarIcon: ({ color }) => <TabIcon name="comments" color={color} />,
+        }}
+      />
+    </Tabs>
+  );
+}

--- a/app/(tabs)/female/calendar.tsx
+++ b/app/(tabs)/female/calendar.tsx
@@ -1,0 +1,12 @@
+import { View, Text } from "react-native";
+import { colors } from "@/lib/theme";
+
+export default function CalendarScreen() {
+  return (
+    <View style={{ flex: 1, alignItems: "center", justifyContent: "center", backgroundColor: colors.background }}>
+      <Text style={{ color: colors.text, fontFamily: "PlusJakartaSans-SemiBold", fontSize: 18 }}>
+        Calendar
+      </Text>
+    </View>
+  );
+}

--- a/app/(tabs)/female/earnings.tsx
+++ b/app/(tabs)/female/earnings.tsx
@@ -1,0 +1,12 @@
+import { View, Text } from "react-native";
+import { colors } from "@/lib/theme";
+
+export default function EarningsScreen() {
+  return (
+    <View style={{ flex: 1, alignItems: "center", justifyContent: "center", backgroundColor: colors.background }}>
+      <Text style={{ color: colors.text, fontFamily: "PlusJakartaSans-SemiBold", fontSize: 18 }}>
+        Earnings
+      </Text>
+    </View>
+  );
+}

--- a/app/(tabs)/female/index.tsx
+++ b/app/(tabs)/female/index.tsx
@@ -1,0 +1,12 @@
+import { View, Text } from "react-native";
+import { colors } from "@/lib/theme";
+
+export default function CompanionDashboard() {
+  return (
+    <View style={{ flex: 1, alignItems: "center", justifyContent: "center", backgroundColor: colors.background }}>
+      <Text style={{ color: colors.text, fontFamily: "PlusJakartaSans-SemiBold", fontSize: 18 }}>
+        Companion Dashboard
+      </Text>
+    </View>
+  );
+}

--- a/app/(tabs)/female/messages.tsx
+++ b/app/(tabs)/female/messages.tsx
@@ -1,0 +1,12 @@
+import { View, Text } from "react-native";
+import { colors } from "@/lib/theme";
+
+export default function FemaleMessagesScreen() {
+  return (
+    <View style={{ flex: 1, alignItems: "center", justifyContent: "center", backgroundColor: colors.background }}>
+      <Text style={{ color: colors.text, fontFamily: "PlusJakartaSans-SemiBold", fontSize: 18 }}>
+        Messages
+      </Text>
+    </View>
+  );
+}

--- a/app/(tabs)/female/requests.tsx
+++ b/app/(tabs)/female/requests.tsx
@@ -1,0 +1,12 @@
+import { View, Text } from "react-native";
+import { colors } from "@/lib/theme";
+
+export default function RequestsScreen() {
+  return (
+    <View style={{ flex: 1, alignItems: "center", justifyContent: "center", backgroundColor: colors.background }}>
+      <Text style={{ color: colors.text, fontFamily: "PlusJakartaSans-SemiBold", fontSize: 18 }}>
+        Requests
+      </Text>
+    </View>
+  );
+}

--- a/app/(tabs)/male/_layout.tsx
+++ b/app/(tabs)/male/_layout.tsx
@@ -1,0 +1,71 @@
+import { Tabs } from "expo-router";
+import { useWindowDimensions } from "react-native";
+import FontAwesome from "@expo/vector-icons/FontAwesome";
+import { colors } from "@/lib/theme";
+
+function TabIcon({
+  name,
+  color,
+}: {
+  name: React.ComponentProps<typeof FontAwesome>["name"];
+  color: string;
+}) {
+  return <FontAwesome size={22} name={name} color={color} />;
+}
+
+export default function MaleTabLayout() {
+  const { width } = useWindowDimensions();
+  const isMobile = width < 640;
+
+  return (
+    <Tabs
+      screenOptions={{
+        tabBarActiveTintColor: colors.primary,
+        tabBarInactiveTintColor: colors.textSecondary,
+        tabBarStyle: {
+          display: isMobile ? "flex" : "none",
+          borderTopWidth: 1,
+          borderTopColor: colors.background,
+          backgroundColor: colors.surface,
+        },
+        headerShown: false,
+      }}
+    >
+      <Tabs.Screen
+        name="browse"
+        options={{
+          title: "Browse",
+          tabBarIcon: ({ color }) => <TabIcon name="home" color={color} />,
+        }}
+      />
+      <Tabs.Screen
+        name="bookings"
+        options={{
+          title: "Bookings",
+          tabBarIcon: ({ color }) => <TabIcon name="calendar" color={color} />,
+        }}
+      />
+      <Tabs.Screen
+        name="favorites"
+        options={{
+          title: "Favorites",
+          tabBarIcon: ({ color }) => <TabIcon name="heart" color={color} />,
+        }}
+      />
+      <Tabs.Screen
+        name="messages"
+        options={{
+          title: "Messages",
+          tabBarIcon: ({ color }) => <TabIcon name="comments" color={color} />,
+        }}
+      />
+      <Tabs.Screen
+        name="profile"
+        options={{
+          title: "Profile",
+          tabBarIcon: ({ color }) => <TabIcon name="user" color={color} />,
+        }}
+      />
+    </Tabs>
+  );
+}

--- a/app/(tabs)/male/bookings.tsx
+++ b/app/(tabs)/male/bookings.tsx
@@ -1,0 +1,12 @@
+import { View, Text } from "react-native";
+import { colors } from "@/lib/theme";
+
+export default function BookingsScreen() {
+  return (
+    <View style={{ flex: 1, alignItems: "center", justifyContent: "center", backgroundColor: colors.background }}>
+      <Text style={{ color: colors.text, fontFamily: "PlusJakartaSans-SemiBold", fontSize: 18 }}>
+        Bookings
+      </Text>
+    </View>
+  );
+}

--- a/app/(tabs)/male/browse.tsx
+++ b/app/(tabs)/male/browse.tsx
@@ -1,0 +1,12 @@
+import { View, Text } from "react-native";
+import { colors } from "@/lib/theme";
+
+export default function BrowseScreen() {
+  return (
+    <View style={{ flex: 1, alignItems: "center", justifyContent: "center", backgroundColor: colors.background }}>
+      <Text style={{ color: colors.text, fontFamily: "PlusJakartaSans-SemiBold", fontSize: 18 }}>
+        Seeker Home
+      </Text>
+    </View>
+  );
+}

--- a/app/(tabs)/male/favorites.tsx
+++ b/app/(tabs)/male/favorites.tsx
@@ -1,0 +1,12 @@
+import { View, Text } from "react-native";
+import { colors } from "@/lib/theme";
+
+export default function FavoritesScreen() {
+  return (
+    <View style={{ flex: 1, alignItems: "center", justifyContent: "center", backgroundColor: colors.background }}>
+      <Text style={{ color: colors.text, fontFamily: "PlusJakartaSans-SemiBold", fontSize: 18 }}>
+        Favorites
+      </Text>
+    </View>
+  );
+}

--- a/app/(tabs)/male/messages.tsx
+++ b/app/(tabs)/male/messages.tsx
@@ -1,0 +1,12 @@
+import { View, Text } from "react-native";
+import { colors } from "@/lib/theme";
+
+export default function MaleMessagesScreen() {
+  return (
+    <View style={{ flex: 1, alignItems: "center", justifyContent: "center", backgroundColor: colors.background }}>
+      <Text style={{ color: colors.text, fontFamily: "PlusJakartaSans-SemiBold", fontSize: 18 }}>
+        Messages
+      </Text>
+    </View>
+  );
+}

--- a/app/(tabs)/male/profile.tsx
+++ b/app/(tabs)/male/profile.tsx
@@ -1,0 +1,12 @@
+import { View, Text } from "react-native";
+import { colors } from "@/lib/theme";
+
+export default function MaleProfileScreen() {
+  return (
+    <View style={{ flex: 1, alignItems: "center", justifyContent: "center", backgroundColor: colors.background }}>
+      <Text style={{ color: colors.text, fontFamily: "PlusJakartaSans-SemiBold", fontSize: 18 }}>
+        Profile
+      </Text>
+    </View>
+  );
+}


### PR DESCRIPTION
## Summary
- Add `app/(tabs)/male/_layout.tsx` — 5-tab Seeker layout (browse/bookings/favorites/messages/profile) with brand colors
- Add `app/(tabs)/female/_layout.tsx` — 5-tab Companion layout (index/requests/calendar/earnings/messages) with brand colors
- Add 10 stub screens (placeholder text, compiling, theme colors)
- Update `app/(tabs)/_layout.tsx` — role-based redirect via `useAuth`: seeker → `/(tabs)/male/browse`, companion → `/(tabs)/female/index`, no auth → `/(auth)/welcome`
- Hide male/female sub-layouts from root tab bar via `href: null`

## Test plan
- [ ] TypeScript: 0 errors (`npx tsc --noEmit`)
- [ ] Seeker login → lands on browse tab
- [ ] Companion login → lands on female home tab
- [ ] Unauthenticated → redirected to welcome screen
- [ ] Tab bar hidden on desktop (width >= 640)

🤖 Generated with [Claude Code](https://claude.com/claude-code)