### PR TITLE
feat: auth screens — welcome, role-select, profile-setup

### DIFF
--- a/app/(auth)/register.tsx
+++ b/app/(auth)/register.tsx
@@ -1,0 +1,239 @@
+import { useState } from "react";
+import {
+  View,
+  Text,
+  TextInput,
+  Pressable,
+  ScrollView,
+  KeyboardAvoidingView,
+  Platform,
+  ActivityIndicator,
+} from "react-native";
+import { router } from "expo-router";
+import { useAuth } from "@/contexts/AuthContext";
+import { Input } from "@/components/ui";
+import { colors } from "@/lib/theme";
+
+const API_URL = process.env.EXPO_PUBLIC_API_URL || "http://localhost:3000";
+
+interface FormData {
+  name: string;
+  age: string;
+  city: string;
+  bio: string;
+}
+
+interface FormErrors {
+  name?: string;
+  age?: string;
+  city?: string;
+  bio?: string;
+}
+
+function validate(form: FormData): FormErrors {
+  const errs: FormErrors = {};
+  const name = form.name.trim();
+  const age = parseInt(form.age, 10);
+  const city = form.city.trim();
+  const bio = form.bio.trim();
+
+  if (!name || name.length < 2) errs.name = "Name must be at least 2 characters";
+  else if (name.length > 50) errs.name = "Name must be 50 characters or less";
+
+  if (!form.age) errs.age = "Age is required";
+  else if (isNaN(age) || age < 18) errs.age = "Must be at least 18";
+  else if (age > 60) errs.age = "Must be 60 or younger";
+
+  if (!city || city.length < 1) errs.city = "City is required";
+
+  if (bio.length > 500) errs.bio = "Bio must be 500 characters or less";
+
+  return errs;
+}
+
+export default function RegisterScreen() {
+  const { token, user } = useAuth();
+  const [form, setForm] = useState<FormData>({ name: "", age: "", city: "", bio: "" });
+  const [errors, setErrors] = useState<FormErrors>({});
+  const [submitting, setSubmitting] = useState(false);
+  const [serverError, setServerError] = useState<string | null>(null);
+  const [biofocused, setBioFocused] = useState(false);
+
+  const update = (field: keyof FormData) => (val: string) => {
+    setForm((f) => ({ ...f, [field]: val }));
+    if (errors[field]) setErrors((e) => ({ ...e, [field]: undefined }));
+  };
+
+  const handleSubmit = async () => {
+    if (submitting) return;
+    const errs = validate(form);
+    if (Object.keys(errs).length > 0) {
+      setErrors(errs);
+      return;
+    }
+
+    setServerError(null);
+    setSubmitting(true);
+
+    const payload = {
+      name: form.name.trim(),
+      age: parseInt(form.age, 10),
+      city: form.city.trim(),
+      bio: form.bio.trim() || undefined,
+    };
+
+    try {
+      const res = await fetch(`${API_URL}/api/auth/me`, {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+          ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        },
+        body: JSON.stringify(payload),
+      });
+
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({ error: "Request failed" }));
+        setServerError(data.error || "Something went wrong");
+        return;
+      }
+
+      const data = await res.json();
+      const updatedUser = data.user || user;
+
+      if (!updatedUser?.role) {
+        router.replace("/(auth)/role-select");
+      } else {
+        router.replace("/(tabs)");
+      }
+    } catch {
+      if (__DEV__) {
+        // No role yet in dev — go to role-select
+        router.replace("/(auth)/role-select");
+      } else {
+        setServerError("Could not connect to server. Please try again.");
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const bioBorderColor = errors.bio
+    ? colors.error
+    : biofocused
+    ? colors.primary
+    : "#E6D5DC";
+
+  return (
+    <KeyboardAvoidingView
+      behavior={Platform.OS === "ios" ? "padding" : "height"}
+      className="flex-1 bg-[#FBF9FA]"
+    >
+      <ScrollView
+        contentContainerStyle={{ flexGrow: 1 }}
+        keyboardShouldPersistTaps="handled"
+      >
+        <View className="flex-1 px-6 py-16 max-w-[480px] w-full self-center">
+          <Text className="text-3xl font-extrabold text-[#201317] mb-2">
+            Set up your profile
+          </Text>
+          <Text className="text-base text-[#81656E] mb-8 leading-6">
+            Tell us a little about yourself
+          </Text>
+
+          <View className="gap-5">
+            <Input
+              label="Full name"
+              placeholder="Your name"
+              value={form.name}
+              onChangeText={update("name")}
+              error={errors.name}
+              autoCapitalize="words"
+            />
+
+            <Input
+              label="Age"
+              placeholder="Your age"
+              value={form.age}
+              onChangeText={update("age")}
+              error={errors.age}
+              keyboardType="numeric"
+            />
+
+            <Input
+              label="City"
+              placeholder="Where are you based?"
+              value={form.city}
+              onChangeText={update("city")}
+              error={errors.city}
+              autoCapitalize="words"
+            />
+
+            {/* Bio textarea */}
+            <View className="w-full">
+              <Text className="text-sm font-semibold text-[#201317] mb-2">
+                Bio{" "}
+                <Text className="text-[#81656E] font-normal">(optional)</Text>
+              </Text>
+              <View
+                style={{
+                  borderColor: bioBorderColor,
+                  borderWidth: 1,
+                  borderRadius: 12,
+                  backgroundColor: "#FFFFFF",
+                  padding: 14,
+                  minHeight: 100,
+                }}
+              >
+                <TextInput
+                  multiline
+                  placeholder="A few words about you..."
+                  placeholderTextColor={colors.textSecondary}
+                  value={form.bio}
+                  onChangeText={update("bio")}
+                  onFocus={() => setBioFocused(true)}
+                  onBlur={() => setBioFocused(false)}
+                  style={{
+                    fontSize: 16,
+                    color: colors.text,
+                    textAlignVertical: "top",
+                    minHeight: 72,
+                  }}
+                  maxLength={500}
+                />
+              </View>
+              <View className="flex-row justify-between mt-1">
+                {errors.bio ? (
+                  <Text className="text-xs text-[#DC2626]">{errors.bio}</Text>
+                ) : (
+                  <View />
+                )}
+                <Text className="text-xs text-[#81656E]">
+                  {form.bio.length}/500
+                </Text>
+              </View>
+            </View>
+          </View>
+
+          {serverError && (
+            <Text className="text-sm text-[#DC2626] mt-4">{serverError}</Text>
+          )}
+
+          <Pressable
+            onPress={handleSubmit}
+            disabled={submitting}
+            className={`mt-8 h-14 rounded-xl items-center justify-center ${
+              submitting ? "bg-[#E6D5DC]" : "bg-[#C52660] active:opacity-90"
+            }`}
+          >
+            {submitting ? (
+              <ActivityIndicator color="#ffffff" />
+            ) : (
+              <Text className="text-base font-bold text-white">Save & Continue</Text>
+            )}
+          </Pressable>
+        </View>
+      </ScrollView>
+    </KeyboardAvoidingView>
+  );
+}

--- a/app/(auth)/role-select.tsx
+++ b/app/(auth)/role-select.tsx
@@ -1,0 +1,134 @@
+import { useState } from "react";
+import { View, Text, Pressable, ActivityIndicator } from "react-native";
+import { router } from "expo-router";
+import { useAuth } from "@/contexts/AuthContext";
+
+const API_URL = process.env.EXPO_PUBLIC_API_URL || "http://localhost:3000";
+
+type Role = "seeker" | "companion";
+
+interface RoleCardProps {
+  title: string;
+  description: string;
+  role: Role;
+  selected: boolean;
+  onPress: () => void;
+}
+
+function RoleCard({ title, description, selected, onPress }: RoleCardProps) {
+  return (
+    <Pressable
+      onPress={onPress}
+      className={`w-full rounded-2xl border-2 p-5 ${
+        selected
+          ? "border-[#C52660] bg-[#FBF9FA]"
+          : "border-[#E6D5DC] bg-white"
+      }`}
+    >
+      <Text className="text-lg font-bold text-[#201317] mb-1">{title}</Text>
+      <Text className="text-sm text-[#81656E] leading-5">{description}</Text>
+    </Pressable>
+  );
+}
+
+export default function RoleSelectScreen() {
+  const { token } = useAuth();
+  const [selected, setSelected] = useState<Role | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleConfirm = async () => {
+    if (!selected || submitting) return;
+    setError(null);
+    setSubmitting(true);
+
+    try {
+      const res = await fetch(`${API_URL}/api/auth/me`, {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+          ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        },
+        body: JSON.stringify({ role: selected }),
+      });
+
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({ error: "Request failed" }));
+        setError(data.error || "Something went wrong");
+        return;
+      }
+
+      if (selected === "seeker") {
+        router.replace("/(seeker-verify)/intro" as never);
+      } else {
+        router.replace("/(comp-onboard)/step2" as never);
+      }
+    } catch {
+      if (__DEV__) {
+        if (selected === "seeker") {
+          router.replace("/(seeker-verify)/intro" as never);
+        } else {
+          router.replace("/(comp-onboard)/step2" as never);
+        }
+      } else {
+        setError("Could not connect to server. Please try again.");
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <View className="flex-1 bg-[#FBF9FA] px-6 py-16">
+      <View className="max-w-[480px] w-full self-center flex-1">
+        <Text className="text-3xl font-extrabold text-[#201317] mb-2">
+          How will you use DateRabbit?
+        </Text>
+        <Text className="text-base text-[#81656E] mb-8 leading-6">
+          Choose your role. You can change this later.
+        </Text>
+
+        <View className="gap-4">
+          <RoleCard
+            role="seeker"
+            title="I'm looking for a companion"
+            description="Browse profiles, book dates, and find your perfect match."
+            selected={selected === "seeker"}
+            onPress={() => setSelected("seeker")}
+          />
+          <RoleCard
+            role="companion"
+            title="I want to offer companionship"
+            description="Create a profile, set your availability, and meet interesting people."
+            selected={selected === "companion"}
+            onPress={() => setSelected("companion")}
+          />
+        </View>
+
+        {error && (
+          <Text className="text-sm text-[#DC2626] mt-4">{error}</Text>
+        )}
+
+        <Pressable
+          onPress={handleConfirm}
+          disabled={!selected || submitting}
+          className={`mt-8 h-14 rounded-xl items-center justify-center ${
+            selected && !submitting ? "bg-[#C52660] active:opacity-90" : "bg-[#E6D5DC]"
+          }`}
+        >
+          {submitting ? (
+            <ActivityIndicator color="#ffffff" />
+          ) : (
+            <Text
+              className={`text-base font-bold ${
+                selected ? "text-white" : "text-[#81656E]"
+              }`}
+            >
+              Continue
+            </Text>
+          )}
+        </Pressable>
+      </View>
+    </View>
+  );
+}

--- a/app/(auth)/welcome.tsx
+++ b/app/(auth)/welcome.tsx
@@ -1,0 +1,51 @@
+import { View, Text, Pressable } from "react-native";
+import { router } from "expo-router";
+import { Button } from "@/components/ui";
+
+export default function WelcomeScreen() {
+  return (
+    <View className="flex-1 bg-[#FBF9FA] justify-between px-6 py-16">
+      {/* Logo + tagline */}
+      <View className="flex-1 items-center justify-center gap-4">
+        <View className="w-20 h-20 rounded-full bg-[#C52660] items-center justify-center mb-2">
+          <Text className="text-4xl">🐇</Text>
+        </View>
+        <Text className="text-4xl font-extrabold text-[#201317] text-center leading-[48px]">
+          DateRabbit
+        </Text>
+        <Text className="text-base text-[#81656E] text-center leading-6 max-w-xs">
+          Find your perfect companion
+        </Text>
+      </View>
+
+      {/* Buttons */}
+      <View className="gap-3 w-full max-w-[480px] self-center">
+        <Button
+          label="Sign up"
+          variant="primary"
+          size="lg"
+          fullWidth
+          onPress={() => router.push("/(auth)/email")}
+        />
+        <Button
+          label="Log in"
+          variant="secondary"
+          size="lg"
+          fullWidth
+          onPress={() => router.push("/(auth)/email")}
+        />
+
+        {/* Legal links */}
+        <View className="flex-row justify-center gap-1 mt-2">
+          <Pressable onPress={() => router.push("/(legal)/terms" as never)}>
+            <Text className="text-sm text-[#81656E] underline">Terms</Text>
+          </Pressable>
+          <Text className="text-sm text-[#81656E]">·</Text>
+          <Pressable onPress={() => router.push("/(legal)/privacy" as never)}>
+            <Text className="text-sm text-[#81656E] underline">Privacy Policy</Text>
+          </Pressable>
+        </View>
+      </View>
+    </View>
+  );
+}


### PR DESCRIPTION
## Summary
- `welcome.tsx` — logo, tagline, Sign up / Log in buttons (both → email screen), Terms + Privacy links
- `role-select.tsx` — seeker/companion card picker, PATCH /api/auth/me, redirects to seeker-verify/intro or comp-onboard/step2
- `register.tsx` — name/age/city/bio form, client validation (name 2-50, age 18-60, city required, bio max 500), PATCH /api/auth/me, routes to role-select if no role, else tabs

## Test plan
- [ ] welcome: buttons navigate to email screen; legal links navigate correctly
- [ ] role-select: cards highlight on select; submitting shows spinner; seeker → seeker-verify/intro, companion → comp-onboard/step2
- [ ] register: validation fires before submit; age range enforced; bio char counter works; success routes correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)