### PR TITLE
fix(iter-2,phase-A): zero structural defects — 6 broken links + 2 missing PATCH routes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ expo-env.d.ts
 
 # Metro
 .metro-health-check*
+.metro-map/
 
 # debug
 npm-debug.*

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -8,7 +8,7 @@ import uploadRoutes from "./routes/upload";
 import messagesRoutes from "./routes/messages";
 
 const app = express();
-const PORT = process.env.PORT || 3000;
+const PORT = process.env.PORT || 3500;
 
 app.use(cors());
 app.use(express.json());

--- a/api/src/routes/auth.ts
+++ b/api/src/routes/auth.ts
@@ -185,4 +185,46 @@ router.get("/me", authMiddleware, async (req: Request, res: Response) => {
   }
 });
 
+// PATCH /api/auth/me
+// Accepts name/avatar today; role/age/city/bio await schema migration (Phase B).
+router.patch("/me", authMiddleware, async (req: Request, res: Response) => {
+  try {
+    const { name, avatar } = req.body ?? {};
+    const data: { name?: string; avatar?: string } = {};
+
+    if (name !== undefined) {
+      if (typeof name !== "string" || name.trim().length < 1 || name.trim().length > 80) {
+        res.status(400).json({ error: "Invalid name" });
+        return;
+      }
+      data.name = name.trim();
+    }
+    if (avatar !== undefined) {
+      if (typeof avatar !== "string" || avatar.length > 2048) {
+        res.status(400).json({ error: "Invalid avatar" });
+        return;
+      }
+      data.avatar = avatar;
+    }
+
+    const user = await prisma.user.update({
+      where: { id: req.user!.userId },
+      data,
+      select: {
+        id: true,
+        email: true,
+        name: true,
+        avatar: true,
+        role: true,
+        createdAt: true,
+      },
+    });
+
+    res.json({ user });
+  } catch (error) {
+    console.error("patch-me error:", error);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
 export default router;

--- a/app/(auth)/role-select.tsx
+++ b/app/(auth)/role-select.tsx
@@ -58,18 +58,10 @@ export default function RoleSelectScreen() {
         return;
       }
 
-      if (selected === "seeker") {
-        router.replace("/(seeker-verify)/intro" as never);
-      } else {
-        router.replace("/(comp-onboard)/step2" as never);
-      }
+      router.replace("/(tabs)");
     } catch {
       if (__DEV__) {
-        if (selected === "seeker") {
-          router.replace("/(seeker-verify)/intro" as never);
-        } else {
-          router.replace("/(comp-onboard)/step2" as never);
-        }
+        router.replace("/(tabs)");
       } else {
         setError("Could not connect to server. Please try again.");
       }

--- a/app/(auth)/welcome.tsx
+++ b/app/(auth)/welcome.tsx
@@ -37,11 +37,11 @@ export default function WelcomeScreen() {
 
         {/* Legal links */}
         <View className="flex-row justify-center gap-1 mt-2">
-          <Pressable onPress={() => router.push("/(legal)/terms" as never)}>
+          <Pressable onPress={() => router.push("/legal/terms")}>
             <Text className="text-sm text-[#81656E] underline">Terms</Text>
           </Pressable>
           <Text className="text-sm text-[#81656E]">·</Text>
-          <Pressable onPress={() => router.push("/(legal)/privacy" as never)}>
+          <Pressable onPress={() => router.push("/legal/privacy")}>
             <Text className="text-sm text-[#81656E] underline">Privacy Policy</Text>
           </Pressable>
         </View>


### PR DESCRIPTION
## Phase A — Foundation fixes (sdlc-loop iter 2)

Metromap flagged 6 broken links and 2 missing backend routes after auth/tab-architecture commits landed. This PR brings Phase A back to clean.

### Broken links (6 → 0)
- `app/(auth)/welcome.tsx`: `/(legal)/terms|privacy` → `/legal/terms|privacy` (plain segments, not a route group).
- `app/(auth)/role-select.tsx`: removed references to non-existent `/(seeker-verify)/intro` and `/(comp-onboard)/step2`. Both seeker and companion now `router.replace("/(tabs)")`; the tabs `_layout.tsx` already does role-based routing to male/female subpaths.

### Missing backend routes (2 → 0)
- Added `PATCH /api/auth/me` (authMiddleware, accepts `name` and `avatar`).
- Role / age / city / bio fields sent by `register.tsx` + `role-select.tsx` are accepted silently for now; full persistence requires a Prisma schema extension (new User columns + enum values) and is deferred to Phase B.

### Foundation hygiene
- `api/src/index.ts`: default `PORT` 3000 → 3500 (canonical port per root CLAUDE.md; without this the backend listens on 3000 when Doppler isn't loaded → metromap live-ping false failures).
- `.gitignore`: add `.metro-map/` to stop tool runtime dir from leaking into future commits.

## Verification
- `npx tsc --noEmit` on frontend: 0 errors
- `npx tsc --noEmit` on api: 0 errors
- `metromap report` after: `broken: 0, unregistered: 0, swallowed: 0, api calls: 5/5 ok (0 missing)`
- No new empty `catch {}` blocks introduced.

## Out of scope (deferred to later phases)
- Orphan `/brand` (design showcase, intentional) and `/(auth)/register` (will be linked once role-select flow is fleshed out).
- Prisma schema extension for role/age/city/bio.
- `no-safe-area` on 16 new gender-specific screens (Phase B).