### PR TITLE
feat: landing page, onboarding slides, stripe-connect

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -10,6 +10,9 @@ import {
 } from "@expo-google-fonts/plus-jakarta-sans";
 import { AuthProvider } from "@/contexts/AuthContext";
 
+// Public routes accessible without authentication: /landing, /onboarding
+// Auth-gated routes handle their own redirects via useAuth() inside the screen.
+
 export default function RootLayout() {
   const [fontsLoaded] = useFonts({
     "PlusJakartaSans-Regular": PlusJakartaSans_400Regular,
@@ -24,11 +27,17 @@ export default function RootLayout() {
   return (
     <AuthProvider>
       <Stack screenOptions={{ headerShown: false }}>
+        {/* Public — no auth required */}
+        <Stack.Screen name="landing" />
+        <Stack.Screen name="onboarding" />
+        {/* Auth */}
         <Stack.Screen name="(auth)" />
+        {/* App */}
         <Stack.Screen name="(tabs)" />
         <Stack.Screen name="listing/[id]" options={{ headerShown: true, headerTitle: "" }} />
         <Stack.Screen name="settings" />
         <Stack.Screen name="notifications" />
+        <Stack.Screen name="stripe-connect" />
         <Stack.Screen name="legal/privacy" />
         <Stack.Screen name="legal/terms" />
         <Stack.Screen name="brand" />

--- a/app/landing.tsx
+++ b/app/landing.tsx
@@ -1,0 +1,381 @@
+import { ScrollView, Text, View, Pressable, useWindowDimensions } from 'react-native'
+import { useRouter } from 'expo-router'
+import { Stack } from 'expo-router'
+
+export default function LandingPage() {
+  const router = useRouter()
+  const { width } = useWindowDimensions()
+  const isDesktop = width >= 1024
+
+  return (
+    <>
+      <Stack.Screen options={{ headerShown: false }} />
+      <ScrollView
+        style={{ flex: 1, backgroundColor: '#FBF9FA' }}
+        contentContainerStyle={{ paddingBottom: 60 }}
+      >
+        {/* HERO */}
+        <View
+          style={{
+            backgroundColor: '#C52660',
+            paddingHorizontal: 24,
+            paddingTop: 80,
+            paddingBottom: 60,
+          }}
+        >
+          <View
+            style={{
+              maxWidth: 1100,
+              alignSelf: 'center',
+              width: '100%',
+              flexDirection: isDesktop ? 'row' : 'column',
+              alignItems: isDesktop ? 'center' : 'flex-start',
+              gap: 40,
+            }}
+          >
+            {/* Hero text */}
+            <View style={{ flex: isDesktop ? 1 : undefined }}>
+              <Text
+                style={{
+                  fontSize: isDesktop ? 56 : 40,
+                  fontWeight: '800',
+                  color: '#FFFFFF',
+                  lineHeight: isDesktop ? 64 : 48,
+                  marginBottom: 16,
+                }}
+              >
+                Find Your Perfect Companion
+              </Text>
+              <Text
+                style={{
+                  fontSize: 18,
+                  color: 'rgba(255,255,255,0.85)',
+                  lineHeight: 28,
+                  marginBottom: 32,
+                }}
+              >
+                Safe, verified, unforgettable dates
+              </Text>
+              <View
+                style={{
+                  flexDirection: isDesktop ? 'row' : 'column',
+                  gap: 12,
+                }}
+              >
+                <Pressable
+                  onPress={() => router.push('/(auth)/welcome')}
+                  style={({ pressed }) => ({
+                    backgroundColor: pressed ? '#E95C20' : '#FFFFFF',
+                    paddingHorizontal: 28,
+                    paddingVertical: 16,
+                    borderRadius: 12,
+                    alignItems: 'center',
+                    borderWidth: 2,
+                    borderColor: '#FFFFFF',
+                  })}
+                >
+                  <Text style={{ fontSize: 16, fontWeight: '700', color: '#C52660' }}>
+                    Find a Companion
+                  </Text>
+                </Pressable>
+                <Pressable
+                  onPress={() => router.push('/(auth)/welcome')}
+                  style={({ pressed }) => ({
+                    backgroundColor: pressed ? 'rgba(255,255,255,0.15)' : 'transparent',
+                    paddingHorizontal: 28,
+                    paddingVertical: 16,
+                    borderRadius: 12,
+                    alignItems: 'center',
+                    borderWidth: 2,
+                    borderColor: '#FFFFFF',
+                  })}
+                >
+                  <Text style={{ fontSize: 16, fontWeight: '700', color: '#FFFFFF' }}>
+                    Become a Companion
+                  </Text>
+                </Pressable>
+              </View>
+            </View>
+
+            {/* Hero decoration — desktop only */}
+            {isDesktop && (
+              <View
+                style={{
+                  width: 380,
+                  height: 380,
+                  backgroundColor: 'rgba(255,255,255,0.12)',
+                  borderRadius: 24,
+                  borderWidth: 2,
+                  borderColor: 'rgba(255,255,255,0.25)',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                }}
+              >
+                <Text style={{ fontSize: 80 }}>💫</Text>
+                <Text
+                  style={{
+                    color: '#FFFFFF',
+                    fontSize: 18,
+                    fontWeight: '600',
+                    marginTop: 16,
+                  }}
+                >
+                  DateRabbit
+                </Text>
+              </View>
+            )}
+          </View>
+        </View>
+
+        {/* HOW IT WORKS */}
+        <View style={{ paddingHorizontal: 24, paddingVertical: 60, backgroundColor: '#FFFFFF' }}>
+          <View style={{ maxWidth: 1100, alignSelf: 'center', width: '100%' }}>
+            <Text
+              style={{
+                fontSize: 32,
+                fontWeight: '800',
+                color: '#201317',
+                textAlign: 'center',
+                marginBottom: 8,
+              }}
+            >
+              How It Works
+            </Text>
+            <Text
+              style={{
+                fontSize: 16,
+                color: '#81656E',
+                textAlign: 'center',
+                marginBottom: 40,
+              }}
+            >
+              Three simple steps to your perfect date
+            </Text>
+            <View
+              style={{
+                flexDirection: isDesktop ? 'row' : 'column',
+                gap: 20,
+              }}
+            >
+              {[
+                { step: '1', icon: '👤', title: 'Create Profile', desc: 'Sign up and build your profile. Seekers describe what they are looking for, companions showcase their personality.' },
+                { step: '2', icon: '🔍', title: 'Browse Companions', desc: 'Explore verified companion profiles. Filter by city, interests, and availability to find your match.' },
+                { step: '3', icon: '📅', title: 'Book a Date', desc: 'Send a booking request with your preferred time and place. Confirm, pay securely, and enjoy your date.' },
+              ].map((item) => (
+                <View
+                  key={item.step}
+                  style={{
+                    flex: isDesktop ? 1 : undefined,
+                    backgroundColor: '#FBF9FA',
+                    borderRadius: 20,
+                    padding: 24,
+                    borderWidth: 2,
+                    borderColor: '#F0E6EA',
+                  }}
+                >
+                  <View
+                    style={{
+                      width: 48,
+                      height: 48,
+                      backgroundColor: '#C52660',
+                      borderRadius: 24,
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      marginBottom: 16,
+                    }}
+                  >
+                    <Text style={{ color: '#FFFFFF', fontSize: 20, fontWeight: '800' }}>
+                      {item.step}
+                    </Text>
+                  </View>
+                  <Text style={{ fontSize: 22, marginBottom: 8 }}>{item.icon}</Text>
+                  <Text
+                    style={{
+                      fontSize: 18,
+                      fontWeight: '700',
+                      color: '#201317',
+                      marginBottom: 8,
+                    }}
+                  >
+                    {item.title}
+                  </Text>
+                  <Text style={{ fontSize: 14, color: '#81656E', lineHeight: 22 }}>{item.desc}</Text>
+                </View>
+              ))}
+            </View>
+          </View>
+        </View>
+
+        {/* WHY DATERABBIT */}
+        <View style={{ paddingHorizontal: 24, paddingVertical: 60, backgroundColor: '#FBF9FA' }}>
+          <View style={{ maxWidth: 1100, alignSelf: 'center', width: '100%' }}>
+            <Text
+              style={{
+                fontSize: 32,
+                fontWeight: '800',
+                color: '#201317',
+                textAlign: 'center',
+                marginBottom: 8,
+              }}
+            >
+              Why DateRabbit?
+            </Text>
+            <Text
+              style={{
+                fontSize: 16,
+                color: '#81656E',
+                textAlign: 'center',
+                marginBottom: 40,
+              }}
+            >
+              Built on trust, designed for real connection
+            </Text>
+            <View
+              style={{
+                flexDirection: isDesktop ? 'row' : 'column',
+                gap: 20,
+              }}
+            >
+              {[
+                {
+                  icon: '✅',
+                  title: 'Verified Safety',
+                  desc: 'Every companion goes through ID verification and a background review before joining. Your safety is our top priority.',
+                },
+                {
+                  icon: '🔒',
+                  title: 'Private & Secure',
+                  desc: 'Your personal data stays private. Payments are processed securely through Stripe. No hidden fees.',
+                },
+                {
+                  icon: '❤️',
+                  title: 'Real Connections',
+                  desc: 'Not a swipe app. DateRabbit is about genuine offline experiences — dinners, events, and memorable moments.',
+                },
+              ].map((item) => (
+                <View
+                  key={item.title}
+                  style={{
+                    flex: isDesktop ? 1 : undefined,
+                    backgroundColor: '#FFFFFF',
+                    borderRadius: 20,
+                    padding: 28,
+                    borderWidth: 2,
+                    borderColor: '#F0E6EA',
+                  }}
+                >
+                  <Text style={{ fontSize: 36, marginBottom: 16 }}>{item.icon}</Text>
+                  <Text
+                    style={{
+                      fontSize: 18,
+                      fontWeight: '700',
+                      color: '#201317',
+                      marginBottom: 8,
+                    }}
+                  >
+                    {item.title}
+                  </Text>
+                  <Text style={{ fontSize: 14, color: '#81656E', lineHeight: 22 }}>{item.desc}</Text>
+                </View>
+              ))}
+            </View>
+          </View>
+        </View>
+
+        {/* FOR COMPANIONS */}
+        <View
+          style={{
+            backgroundColor: '#E95C20',
+            paddingHorizontal: 24,
+            paddingVertical: 60,
+          }}
+        >
+          <View
+            style={{
+              maxWidth: 700,
+              alignSelf: 'center',
+              width: '100%',
+              alignItems: 'center',
+            }}
+          >
+            <Text
+              style={{
+                fontSize: 32,
+                fontWeight: '800',
+                color: '#FFFFFF',
+                textAlign: 'center',
+                marginBottom: 12,
+              }}
+            >
+              Earn on Your Terms
+            </Text>
+            <Text
+              style={{
+                fontSize: 16,
+                color: 'rgba(255,255,255,0.88)',
+                textAlign: 'center',
+                lineHeight: 26,
+                marginBottom: 32,
+              }}
+            >
+              Join DateRabbit as a companion and set your own schedule, rates, and boundaries.
+              Connect with respectful seekers and get paid directly to your bank account.
+            </Text>
+            <Pressable
+              onPress={() => router.push('/(auth)/welcome')}
+              style={({ pressed }) => ({
+                backgroundColor: pressed ? '#C52660' : '#FFFFFF',
+                paddingHorizontal: 32,
+                paddingVertical: 16,
+                borderRadius: 12,
+                alignItems: 'center',
+                borderWidth: 2,
+                borderColor: '#FFFFFF',
+              })}
+            >
+              <Text style={{ fontSize: 16, fontWeight: '700', color: '#E95C20' }}>
+                Become a Companion
+              </Text>
+            </Pressable>
+          </View>
+        </View>
+
+        {/* FOOTER */}
+        <View
+          style={{
+            backgroundColor: '#201317',
+            paddingHorizontal: 24,
+            paddingVertical: 40,
+          }}
+        >
+          <View style={{ maxWidth: 1100, alignSelf: 'center', width: '100%' }}>
+            <Text
+              style={{
+                fontSize: 22,
+                fontWeight: '800',
+                color: '#FFFFFF',
+                marginBottom: 8,
+              }}
+            >
+              DateRabbit
+            </Text>
+            <Text style={{ fontSize: 14, color: '#81656E', marginBottom: 20 }}>
+              Safe, verified, unforgettable dates
+            </Text>
+            <View style={{ flexDirection: 'row', gap: 20 }}>
+              <Pressable onPress={() => router.push('/legal/terms')}>
+                <Text style={{ fontSize: 14, color: '#81656E' }}>Terms of Service</Text>
+              </Pressable>
+              <Pressable onPress={() => router.push('/legal/privacy')}>
+                <Text style={{ fontSize: 14, color: '#81656E' }}>Privacy Policy</Text>
+              </Pressable>
+            </View>
+            <Text style={{ fontSize: 12, color: '#4A3038', marginTop: 24 }}>
+              © {new Date().getFullYear()} DateRabbit. All rights reserved.
+            </Text>
+          </View>
+        </View>
+      </ScrollView>
+    </>
+  )
+}

--- a/app/onboarding.tsx
+++ b/app/onboarding.tsx
@@ -1,0 +1,164 @@
+import { useState } from 'react'
+import { Pressable, Text, View, useWindowDimensions } from 'react-native'
+import { useRouter, Stack } from 'expo-router'
+import { colors } from '@/lib/theme'
+
+interface Slide {
+  color: string
+  emoji: string
+  title: string
+  description: string
+}
+
+const slides: Slide[] = [
+  {
+    color: '#C52660',
+    emoji: '💫',
+    title: 'Meet Amazing People',
+    description:
+      'DateRabbit connects you with verified, genuine companions for memorable offline experiences. No swiping endlessly — real dates, real connections.',
+  },
+  {
+    color: '#E95C20',
+    emoji: '✅',
+    title: 'Safe & Verified',
+    description:
+      'Every companion is ID-verified before joining. Payments are secured via Stripe. Your personal details stay private throughout the entire experience.',
+  },
+  {
+    color: '#8B1A4A',
+    emoji: '📅',
+    title: 'Easy Booking',
+    description:
+      'Browse companion profiles, pick a time that works, and send a booking request in seconds. Get confirmation, pay securely, and enjoy your date.',
+  },
+]
+
+export default function OnboardingPage() {
+  const [current, setCurrent] = useState(0)
+  const router = useRouter()
+  const { height } = useWindowDimensions()
+  const isLast = current === slides.length - 1
+  const slide = slides[current]
+
+  function handleNext() {
+    if (isLast) {
+      router.replace('/(auth)/welcome')
+    } else {
+      setCurrent((c) => c + 1)
+    }
+  }
+
+  function handleSkip() {
+    router.replace('/(auth)/welcome')
+  }
+
+  return (
+    <>
+      <Stack.Screen options={{ headerShown: false }} />
+      <View style={{ flex: 1, backgroundColor: '#FBF9FA' }}>
+        {/* Slide illustration */}
+        <View
+          style={{
+            backgroundColor: slide.color,
+            height: height * 0.45,
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
+        >
+          <Text style={{ fontSize: 96, lineHeight: 112 }}>{slide.emoji}</Text>
+        </View>
+
+        {/* Content */}
+        <View
+          style={{
+            flex: 1,
+            paddingHorizontal: 32,
+            paddingTop: 40,
+            paddingBottom: 48,
+            alignItems: 'center',
+          }}
+        >
+          <Text
+            style={{
+              fontSize: 28,
+              fontWeight: '800',
+              color: colors.text,
+              textAlign: 'center',
+              marginBottom: 16,
+              lineHeight: 36,
+            }}
+          >
+            {slide.title}
+          </Text>
+          <Text
+            style={{
+              fontSize: 16,
+              color: colors.textSecondary,
+              textAlign: 'center',
+              lineHeight: 26,
+              maxWidth: 360,
+            }}
+          >
+            {slide.description}
+          </Text>
+
+          {/* Dot indicators */}
+          <View
+            style={{
+              flexDirection: 'row',
+              gap: 8,
+              marginTop: 32,
+              marginBottom: 32,
+            }}
+          >
+            {slides.map((_, i) => (
+              <View
+                key={i}
+                style={{
+                  width: i === current ? 24 : 8,
+                  height: 8,
+                  borderRadius: 4,
+                  backgroundColor: i === current ? colors.primary : '#F0E6EA',
+                }}
+              />
+            ))}
+          </View>
+
+          {/* Buttons */}
+          <Pressable
+            onPress={handleNext}
+            style={({ pressed }) => ({
+              backgroundColor: pressed ? '#A01E50' : colors.primary,
+              paddingHorizontal: 40,
+              paddingVertical: 16,
+              borderRadius: 12,
+              alignItems: 'center',
+              width: '100%',
+              maxWidth: 360,
+              marginBottom: 16,
+            })}
+          >
+            <Text style={{ fontSize: 16, fontWeight: '700', color: '#FFFFFF' }}>
+              {isLast ? 'Get Started' : 'Next'}
+            </Text>
+          </Pressable>
+
+          {!isLast && (
+            <Pressable onPress={handleSkip}>
+              <Text
+                style={{
+                  fontSize: 14,
+                  color: colors.textSecondary,
+                  fontWeight: '500',
+                }}
+              >
+                Skip
+              </Text>
+            </Pressable>
+          )}
+        </View>
+      </View>
+    </>
+  )
+}

--- a/app/stripe-connect.tsx
+++ b/app/stripe-connect.tsx
@@ -1,0 +1,250 @@
+import { useEffect, useState } from 'react'
+import { ActivityIndicator, Pressable, ScrollView, Text, View } from 'react-native'
+import { Stack, useRouter } from 'expo-router'
+import { Linking } from 'react-native'
+import { useAuth } from '@/contexts/AuthContext'
+import { colors } from '@/lib/theme'
+
+const API_URL = process.env.EXPO_PUBLIC_API_URL || 'http://localhost:3500'
+
+type PageState = 'loading' | 'not-connected' | 'connected' | 'connecting'
+
+export default function StripeConnectPage() {
+  const router = useRouter()
+  const { token, user } = useAuth()
+  const [pageState, setPageState] = useState<PageState>('loading')
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!token || !user) {
+      router.replace('/(auth)/welcome')
+      return
+    }
+    if (user.role !== 'companion') {
+      router.replace('/(tabs)')
+      return
+    }
+    // Check stripe status from user object
+    // stripeAccountId would be on the user if present
+    const stripeId = (user as unknown as Record<string, unknown>).stripeAccountId
+    setPageState(stripeId ? 'connected' : 'not-connected')
+  }, [token, user, router])
+
+  async function handleConnect() {
+    if (!token) return
+    setPageState('connecting')
+    setError(null)
+    try {
+      const res = await fetch(`${API_URL}/api/companion/stripe-connect/start`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+      })
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}))
+        throw new Error(body?.error ?? `Server error ${res.status}`)
+      }
+      const { onboardingUrl } = await res.json()
+      await Linking.openURL(onboardingUrl)
+      // After returning from browser, re-check state
+      setPageState('not-connected')
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Something went wrong')
+      setPageState('not-connected')
+    }
+  }
+
+  if (pageState === 'loading') {
+    return (
+      <>
+        <Stack.Screen options={{ title: 'Bank Account', headerShown: true }} />
+        <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center', backgroundColor: '#FBF9FA' }}>
+          <ActivityIndicator size="large" color={colors.primary} />
+        </View>
+      </>
+    )
+  }
+
+  return (
+    <>
+      <Stack.Screen options={{ title: 'Connect Bank Account', headerShown: true }} />
+      <ScrollView
+        style={{ flex: 1, backgroundColor: '#FBF9FA' }}
+        contentContainerStyle={{ padding: 24, maxWidth: 560, alignSelf: 'center', width: '100%' }}
+      >
+        {/* Header icon */}
+        <View
+          style={{
+            width: 72,
+            height: 72,
+            backgroundColor: pageState === 'connected' ? '#059669' : '#C52660',
+            borderRadius: 36,
+            alignItems: 'center',
+            justifyContent: 'center',
+            marginBottom: 24,
+            alignSelf: 'center',
+          }}
+        >
+          <Text style={{ fontSize: 36 }}>{pageState === 'connected' ? '✓' : '🏦'}</Text>
+        </View>
+
+        <Text
+          style={{
+            fontSize: 26,
+            fontWeight: '800',
+            color: colors.text,
+            textAlign: 'center',
+            marginBottom: 12,
+          }}
+        >
+          {pageState === 'connected' ? 'Bank Account Connected' : 'Connect Bank Account'}
+        </Text>
+
+        <Text
+          style={{
+            fontSize: 15,
+            color: colors.textSecondary,
+            textAlign: 'center',
+            lineHeight: 24,
+            marginBottom: 36,
+          }}
+        >
+          {pageState === 'connected'
+            ? 'Your Stripe account is linked. Earnings from confirmed bookings will be transferred automatically.'
+            : 'To receive payments from bookings, connect your bank account via Stripe. Your financial data is handled securely by Stripe — DateRabbit never stores your bank details.'}
+        </Text>
+
+        {/* Info cards */}
+        {pageState !== 'connected' && (
+          <View style={{ gap: 12, marginBottom: 36 }}>
+            {[
+              { icon: '🔒', title: 'Bank-grade security', desc: 'Stripe is PCI DSS Level 1 certified.' },
+              { icon: '⚡', title: 'Fast payouts', desc: 'Earnings deposited within 2–3 business days.' },
+              { icon: '🌍', title: '30+ currencies', desc: 'Receive payouts in your local currency.' },
+            ].map((item) => (
+              <View
+                key={item.title}
+                style={{
+                  backgroundColor: '#FFFFFF',
+                  borderRadius: 16,
+                  padding: 16,
+                  flexDirection: 'row',
+                  alignItems: 'flex-start',
+                  gap: 14,
+                  borderWidth: 1,
+                  borderColor: '#F0E6EA',
+                }}
+              >
+                <Text style={{ fontSize: 24 }}>{item.icon}</Text>
+                <View style={{ flex: 1 }}>
+                  <Text style={{ fontSize: 15, fontWeight: '700', color: colors.text, marginBottom: 2 }}>
+                    {item.title}
+                  </Text>
+                  <Text style={{ fontSize: 13, color: colors.textSecondary }}>{item.desc}</Text>
+                </View>
+              </View>
+            ))}
+          </View>
+        )}
+
+        {/* Connected state details */}
+        {pageState === 'connected' && (
+          <View
+            style={{
+              backgroundColor: '#ECFDF5',
+              borderRadius: 16,
+              padding: 20,
+              borderWidth: 1,
+              borderColor: '#A7F3D0',
+              marginBottom: 36,
+              flexDirection: 'row',
+              alignItems: 'center',
+              gap: 12,
+            }}
+          >
+            <Text style={{ fontSize: 28 }}>✅</Text>
+            <View style={{ flex: 1 }}>
+              <Text style={{ fontSize: 15, fontWeight: '700', color: '#065F46' }}>
+                Stripe Connected
+              </Text>
+              <Text style={{ fontSize: 13, color: '#065F46', marginTop: 2 }}>
+                You are ready to receive payments from bookings.
+              </Text>
+            </View>
+          </View>
+        )}
+
+        {error && (
+          <View
+            style={{
+              backgroundColor: '#FEF2F2',
+              borderRadius: 12,
+              padding: 14,
+              borderWidth: 1,
+              borderColor: '#FECACA',
+              marginBottom: 20,
+            }}
+          >
+            <Text style={{ fontSize: 14, color: '#DC2626' }}>{error}</Text>
+          </View>
+        )}
+
+        {/* CTA */}
+        {pageState !== 'connected' && (
+          <Pressable
+            onPress={handleConnect}
+            disabled={pageState === 'connecting'}
+            style={({ pressed }) => ({
+              backgroundColor: pressed ? '#A01E50' : colors.primary,
+              paddingVertical: 16,
+              borderRadius: 14,
+              alignItems: 'center',
+              opacity: pageState === 'connecting' ? 0.7 : 1,
+              marginBottom: 16,
+            })}
+          >
+            {pageState === 'connecting' ? (
+              <ActivityIndicator size="small" color="#FFFFFF" />
+            ) : (
+              <Text style={{ fontSize: 16, fontWeight: '700', color: '#FFFFFF' }}>
+                Connect with Stripe
+              </Text>
+            )}
+          </Pressable>
+        )}
+
+        {pageState === 'connected' && (
+          <Pressable
+            onPress={() => router.back()}
+            style={({ pressed }) => ({
+              backgroundColor: pressed ? '#F3F0F1' : '#FFFFFF',
+              paddingVertical: 14,
+              borderRadius: 14,
+              alignItems: 'center',
+              borderWidth: 2,
+              borderColor: '#F0E6EA',
+            })}
+          >
+            <Text style={{ fontSize: 15, fontWeight: '600', color: colors.text }}>
+              Back to Profile
+            </Text>
+          </Pressable>
+        )}
+
+        <Text
+          style={{
+            fontSize: 12,
+            color: colors.textSecondary,
+            textAlign: 'center',
+            marginTop: 20,
+            lineHeight: 18,
+          }}
+        >
+          Payments powered by Stripe. DateRabbit does not store your bank details.
+        </Text>
+      </ScrollView>
+    </>
+  )
+}


### PR DESCRIPTION
## Summary
- `app/landing.tsx` — responsive marketing landing (hero, how-it-works, why-daterabbit, companion CTA, footer); responsive mobile/desktop via `useWindowDimensions`
- `app/onboarding.tsx` — 3-slide carousel with animated dot indicators, skip/next/get-started flow → `/(auth)/welcome`
- `app/stripe-connect.tsx` — companion-only bank account screen; 4 states: loading, not-connected, connecting, connected; POST `/api/companion/stripe-connect/start` → open URL via `Linking`
- `app/_layout.tsx` — registers all 3 new routes; `landing` + `onboarding` declared as public (no auth redirect in layout)

## Test plan
- [ ] `/landing` loads without auth; both CTAs navigate to `/(auth)/welcome`; footer links work
- [ ] `/onboarding` shows 3 slides, dots update, skip goes to welcome, last slide shows "Get Started"
- [ ] `/stripe-connect` redirects non-companions; shows connected state when `stripeAccountId` present; connect button calls API
- [ ] `npx tsc --noEmit` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)