### PR TITLE
feat: verification flow — seeker verify (6 screens) + companion onboard (3 screens) + API stubs

### DIFF
--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -12,6 +12,7 @@ import bookingsRoutes from "./routes/bookings";
 import favoritesRoutes from "./routes/favorites";
 import reviewsRoutes from "./routes/reviews";
 import companionProfileRoutes from "./routes/companion-profile";
+import verificationRoutes, { companionStatusRouter } from "./routes/verification";
 
 const app = express();
 const PORT = process.env.PORT || 3500;
@@ -34,6 +35,8 @@ app.use("/api/bookings", bookingsRoutes);
 app.use("/api/favorites", favoritesRoutes);
 app.use("/api/reviews", reviewsRoutes);
 app.use("/api/companion", companionProfileRoutes);
+app.use("/api/companion", companionStatusRouter);
+app.use("/api/verification", verificationRoutes);
 
 app.listen(PORT, () => {
   console.log(`API server running on http://localhost:${PORT}`);

--- a/api/src/routes/verification.ts
+++ b/api/src/routes/verification.ts
@@ -1,0 +1,45 @@
+import { Router, Request, Response } from "express";
+import { authMiddleware } from "../middleware/auth";
+
+const router = Router();
+
+// GET /api/verification/status
+router.get("/status", authMiddleware, (_req: Request, res: Response) => {
+  console.log("[verification] GET /status");
+  res.json({ status: "pending", reason: null });
+});
+
+// POST /api/verification/photo-id
+router.post("/photo-id", authMiddleware, (req: Request, res: Response) => {
+  console.log("[verification] POST /photo-id", req.headers["content-type"]);
+  res.json({ success: true, message: "Government ID photo received" });
+});
+
+// POST /api/verification/selfie
+router.post("/selfie", authMiddleware, (req: Request, res: Response) => {
+  console.log("[verification] POST /selfie", req.headers["content-type"]);
+  res.json({ success: true, message: "Selfie photo received" });
+});
+
+// POST /api/verification/stripe-identity/start
+router.post("/stripe-identity/start", authMiddleware, (_req: Request, res: Response) => {
+  console.log("[verification] POST /stripe-identity/start");
+  res.json({ clientSecret: "mock_secret_123" });
+});
+
+// POST /api/verification/consent
+router.post("/consent", authMiddleware, (_req: Request, res: Response) => {
+  console.log("[verification] POST /consent");
+  res.json({ success: true, consentedAt: new Date().toISOString() });
+});
+
+// GET /api/companion/status
+// Registered separately in index.ts under /api/companion — we export a companion-status router too
+export const companionStatusRouter = Router();
+
+companionStatusRouter.get("/status", authMiddleware, (_req: Request, res: Response) => {
+  console.log("[companion] GET /status");
+  res.json({ status: "pending", reason: null });
+});
+
+export default router;

--- a/app/(comp-onboard)/_layout.tsx
+++ b/app/(comp-onboard)/_layout.tsx
@@ -1,0 +1,12 @@
+import { Stack } from "expo-router";
+
+export default function CompOnboardLayout() {
+  return (
+    <Stack
+      screenOptions={{
+        headerShown: false,
+        gestureEnabled: false,
+      }}
+    />
+  );
+}

--- a/app/(comp-onboard)/pending.tsx
+++ b/app/(comp-onboard)/pending.tsx
@@ -1,0 +1,99 @@
+import { useEffect, useRef, useState } from "react";
+import { View, Text, ScrollView, Pressable, Linking } from "react-native";
+import { router } from "expo-router";
+import { EmptyState, Button } from "@/components/ui";
+
+const API_URL = process.env.EXPO_PUBLIC_API_URL || "http://localhost:3500";
+const POLL_INTERVAL = 30_000;
+const SUPPORT_EMAIL = "support@daterabbit.app";
+
+type Status = "pending" | "approved" | "rejected";
+
+export default function CompOnboardPendingScreen() {
+  const [status, setStatus] = useState<Status>("pending");
+  const [reason, setReason] = useState<string | null>(null);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const poll = async () => {
+    try {
+      const res = await fetch(`${API_URL}/api/companion/status`);
+      if (!res.ok) return;
+      const data = await res.json();
+      if (data.status === "approved") {
+        setStatus("approved");
+        clearInterval(intervalRef.current!);
+        router.replace("/(tabs)/female/index");
+      } else if (data.status === "rejected") {
+        setStatus("rejected");
+        setReason(data.reason || null);
+        clearInterval(intervalRef.current!);
+      }
+    } catch {
+      // silent
+    }
+  };
+
+  useEffect(() => {
+    poll();
+    intervalRef.current = setInterval(poll, POLL_INTERVAL);
+    return () => {
+      if (intervalRef.current) clearInterval(intervalRef.current);
+    };
+  }, []);
+
+  const openSupport = () => {
+    Linking.openURL(`mailto:${SUPPORT_EMAIL}`);
+  };
+
+  if (status === "rejected") {
+    return (
+      <ScrollView className="flex-1 bg-[#FBF9FA]" contentContainerStyle={{ flexGrow: 1 }}>
+        <View className="flex-1 items-center justify-center px-6 py-12 max-w-lg w-full self-center">
+          <EmptyState
+            title="Application Not Approved"
+            message={reason || "Your application was not approved at this time."}
+          />
+          {reason && (
+            <View className="bg-red-50 border border-red-100 rounded-xl px-4 py-3 w-full mb-6">
+              <Text className="text-sm text-red-700">{reason}</Text>
+            </View>
+          )}
+          <Button
+            label="Contact Support"
+            onPress={openSupport}
+            variant="secondary"
+            size="lg"
+            fullWidth
+          />
+        </View>
+      </ScrollView>
+    );
+  }
+
+  return (
+    <ScrollView className="flex-1 bg-[#FBF9FA]" contentContainerStyle={{ flexGrow: 1 }}>
+      <View className="flex-1 items-center justify-center px-6 py-12 max-w-lg w-full self-center">
+        <View className="w-24 h-24 rounded-full bg-amber-100 items-center justify-center mb-6">
+          <Text className="text-5xl">📋</Text>
+        </View>
+
+        <EmptyState
+          title="Application Under Review"
+          message="We're reviewing your profile and documents. Companion approval takes 1-3 business days. You'll receive an email with the result."
+        />
+
+        <View className="bg-amber-50 border border-amber-100 rounded-xl px-4 py-3 w-full mt-4 mb-8">
+          <Text className="text-sm text-amber-700 text-center">
+            Checking status every 30 seconds...
+          </Text>
+        </View>
+
+        <Pressable onPress={openSupport} className="py-2">
+          <Text className="text-base text-[#C52660]">
+            Questions? Email {SUPPORT_EMAIL}
+          </Text>
+        </Pressable>
+      </View>
+    </ScrollView>
+  );
+}

--- a/app/(comp-onboard)/step2.tsx
+++ b/app/(comp-onboard)/step2.tsx
@@ -1,0 +1,201 @@
+import { useState } from "react";
+import { View, Text, ScrollView, Pressable, Image, ActivityIndicator } from "react-native";
+import * as ImagePicker from "expo-image-picker";
+import { router } from "expo-router";
+import { Button } from "@/components/ui";
+
+const API_URL = process.env.EXPO_PUBLIC_API_URL || "http://localhost:3500";
+const MIN_PHOTOS = 4;
+
+interface Photo {
+  uri: string;
+  url?: string;
+  uploading?: boolean;
+}
+
+export default function CompOnboardStep2Screen() {
+  const [photos, setPhotos] = useState<Photo[]>([]);
+  const [mainIndex, setMainIndex] = useState<number | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+
+  const addPhoto = async () => {
+    try {
+      const result = await ImagePicker.launchImageLibraryAsync({
+        mediaTypes: ["images"],
+        quality: 0.85,
+        allowsEditing: true,
+        aspect: [3, 4],
+      });
+      if (result.canceled || !result.assets[0]) return;
+
+      const uri = result.assets[0].uri;
+      const newIndex = photos.length;
+      setPhotos((prev) => [...prev, { uri, uploading: true }]);
+
+      // Upload photo
+      const form = new FormData();
+      const filename = uri.split("/").pop() || "photo.jpg";
+      form.append("file", { uri, name: filename, type: "image/jpeg" } as never);
+
+      const res = await fetch(`${API_URL}/api/upload/photo`, {
+        method: "POST",
+        body: form,
+      });
+
+      let url = uri; // fallback to local uri
+      if (res.ok) {
+        const data = await res.json();
+        url = data.url || data.imageUrl || uri;
+      }
+
+      setPhotos((prev) => {
+        const updated = [...prev];
+        updated[newIndex] = { uri, url, uploading: false };
+        return updated;
+      });
+
+      // Auto-select first photo as main
+      if (mainIndex === null) setMainIndex(0);
+    } catch {
+      // silent
+    }
+  };
+
+  const removePhoto = (index: number) => {
+    setPhotos((prev) => prev.filter((_, i) => i !== index));
+    if (mainIndex === index) {
+      setMainIndex(photos.length > 1 ? 0 : null);
+    } else if (mainIndex !== null && mainIndex > index) {
+      setMainIndex(mainIndex - 1);
+    }
+  };
+
+  const canProceed =
+    photos.length >= MIN_PHOTOS &&
+    mainIndex !== null &&
+    photos.every((p) => !p.uploading);
+
+  const save = async () => {
+    if (!canProceed) return;
+    setSaving(true);
+    setErrorMsg(null);
+    try {
+      const urls = photos.map((p) => p.url || p.uri);
+      const avatar = mainIndex !== null ? urls[mainIndex] : urls[0];
+
+      const res = await fetch(`${API_URL}/api/companion/profile`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ photos: urls, avatar }),
+      });
+
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.error || "Failed to save photos");
+      }
+
+      router.push("/(comp-onboard)/verify");
+    } catch (err) {
+      setErrorMsg(err instanceof Error ? err.message : "Something went wrong");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const photosNeeded = Math.max(0, MIN_PHOTOS - photos.length);
+
+  return (
+    <ScrollView className="flex-1 bg-[#FBF9FA]" contentContainerStyle={{ flexGrow: 1 }}>
+      <View className="flex-1 px-6 py-10 max-w-lg w-full self-center">
+        <Text className="text-2xl font-bold text-[#201317] mb-2">Your Photos</Text>
+        <Text className="text-base text-[#81656E] leading-6 mb-2">
+          Add at least {MIN_PHOTOS} photos of yourself. Select one as your main profile photo.
+        </Text>
+
+        {/* Progress */}
+        <View className="flex-row items-center mb-6">
+          <View className="flex-1 h-2 bg-gray-200 rounded-full overflow-hidden">
+            <View
+              className="h-2 bg-[#C52660] rounded-full"
+              style={{ width: `${Math.min(100, (photos.length / MIN_PHOTOS) * 100)}%` }}
+            />
+          </View>
+          <Text className="ml-3 text-sm font-semibold text-[#81656E]">
+            {photos.length}/{MIN_PHOTOS} minimum
+          </Text>
+        </View>
+
+        {/* Photo grid */}
+        <View className="flex-row flex-wrap gap-3 mb-6">
+          {photos.map((photo, idx) => (
+            <View key={idx} className="w-[calc(50%-6px)] aspect-[3/4] relative">
+              <Image
+                source={{ uri: photo.uri }}
+                className="w-full h-full rounded-xl"
+                resizeMode="cover"
+              />
+              {photo.uploading && (
+                <View className="absolute inset-0 bg-black/40 rounded-xl items-center justify-center">
+                  <ActivityIndicator color="white" />
+                </View>
+              )}
+              {/* Main badge */}
+              {mainIndex === idx && (
+                <View className="absolute top-2 left-2 bg-[#C52660] rounded-full px-2 py-0.5">
+                  <Text className="text-white text-xs font-semibold">Main</Text>
+                </View>
+              )}
+              {/* Delete button */}
+              <Pressable
+                onPress={() => removePhoto(idx)}
+                className="absolute top-2 right-2 w-7 h-7 bg-black/60 rounded-full items-center justify-center"
+              >
+                <Text className="text-white text-sm font-bold">×</Text>
+              </Pressable>
+              {/* Set main radio */}
+              {mainIndex !== idx && !photo.uploading && (
+                <Pressable
+                  onPress={() => setMainIndex(idx)}
+                  className="absolute bottom-2 left-2 bg-white/80 rounded-full px-2 py-0.5"
+                >
+                  <Text className="text-xs text-[#201317] font-medium">Set main</Text>
+                </Pressable>
+              )}
+            </View>
+          ))}
+
+          {/* Add photo button */}
+          <Pressable
+            onPress={addPhoto}
+            className="rounded-xl border-2 border-dashed border-gray-300 items-center justify-center bg-white"
+            style={{ width: "calc(50% - 6px)" as never, aspectRatio: 3 / 4 }}
+          >
+            <Text className="text-3xl text-gray-400 mb-1">+</Text>
+            <Text className="text-xs text-[#81656E]">Add photo</Text>
+          </Pressable>
+        </View>
+
+        {photosNeeded > 0 && (
+          <Text className="text-sm text-[#81656E] text-center mb-4">
+            Add {photosNeeded} more photo{photosNeeded !== 1 ? "s" : ""} to continue
+          </Text>
+        )}
+
+        {errorMsg && (
+          <Text className="text-sm text-[#DC2626] mb-4 text-center">{errorMsg}</Text>
+        )}
+
+        <Button
+          label="Next"
+          onPress={save}
+          variant="primary"
+          size="lg"
+          fullWidth
+          disabled={!canProceed || saving}
+          loading={saving}
+        />
+      </View>
+    </ScrollView>
+  );
+}

--- a/app/(comp-onboard)/verify.tsx
+++ b/app/(comp-onboard)/verify.tsx
@@ -1,0 +1,82 @@
+import { useState } from "react";
+import { View, Text, ScrollView } from "react-native";
+import { router } from "expo-router";
+import { Button } from "@/components/ui";
+
+const API_URL = process.env.EXPO_PUBLIC_API_URL || "http://localhost:3500";
+
+type State = "idle" | "processing" | "error";
+
+export default function CompOnboardVerifyScreen() {
+  const [state, setState] = useState<State>("idle");
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+
+  const startCheck = async () => {
+    setState("processing");
+    setErrorMsg(null);
+    try {
+      const res = await fetch(`${API_URL}/api/verification/stripe-identity/start`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+      });
+
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.error || "Failed to start identity check");
+      }
+
+      const data = await res.json();
+      // In production: open Stripe Identity SDK with data.clientSecret
+      console.log("[CompVerify] clientSecret:", data.clientSecret);
+
+      router.replace("/(comp-onboard)/pending");
+    } catch (err) {
+      setState("error");
+      setErrorMsg(err instanceof Error ? err.message : "Something went wrong");
+    }
+  };
+
+  return (
+    <ScrollView className="flex-1 bg-[#FBF9FA]" contentContainerStyle={{ flexGrow: 1 }}>
+      <View className="flex-1 px-6 py-10 max-w-lg w-full self-center items-center">
+        <Text className="text-2xl font-bold text-[#201317] mb-3 self-start">
+          Identity Verification
+        </Text>
+        <Text className="text-base text-[#81656E] leading-6 mb-8 self-start">
+          Required for companion approval. This process is quick and secure.
+        </Text>
+
+        <View className="w-24 h-24 rounded-full bg-[#FBF9FA] border-2 border-[#C52660] items-center justify-center mb-8">
+          <Text className="text-5xl">🛡️</Text>
+        </View>
+
+        <View className="bg-white rounded-2xl p-5 w-full mb-8 gap-3">
+          {[
+            "Upload a government-issued ID",
+            "Quick automated document check",
+            "Your data is encrypted and secure",
+          ].map((point, idx) => (
+            <View key={idx} className="flex-row items-start">
+              <Text className="text-[#059669] font-bold mr-3 mt-0.5">✓</Text>
+              <Text className="flex-1 text-base text-[#201317]">{point}</Text>
+            </View>
+          ))}
+        </View>
+
+        {errorMsg && (
+          <Text className="text-sm text-[#DC2626] mb-4 text-center">{errorMsg}</Text>
+        )}
+
+        <Button
+          label={state === "processing" ? "Starting..." : "Start Identity Check"}
+          onPress={startCheck}
+          variant="primary"
+          size="lg"
+          fullWidth
+          disabled={state === "processing"}
+          loading={state === "processing"}
+        />
+      </View>
+    </ScrollView>
+  );
+}

--- a/app/(seeker-verify)/_layout.tsx
+++ b/app/(seeker-verify)/_layout.tsx
@@ -1,0 +1,12 @@
+import { Stack } from "expo-router";
+
+export default function SeekerVerifyLayout() {
+  return (
+    <Stack
+      screenOptions={{
+        headerShown: false,
+        gestureEnabled: false,
+      }}
+    />
+  );
+}

--- a/app/(seeker-verify)/consent.tsx
+++ b/app/(seeker-verify)/consent.tsx
@@ -1,0 +1,107 @@
+import { useState } from "react";
+import { View, Text, ScrollView, Pressable } from "react-native";
+import { router } from "expo-router";
+import { Button } from "@/components/ui";
+
+const API_URL = process.env.EXPO_PUBLIC_API_URL || "http://localhost:3500";
+
+const CONSENTS = [
+  { id: "genuine", label: "I confirm my identity documents are genuine" },
+  { id: "terms", label: "I agree to the Terms of Service and Privacy Policy" },
+  { id: "data", label: "I understand my data will be used for verification purposes" },
+];
+
+export default function ConsentScreen() {
+  const [checked, setChecked] = useState<Record<string, boolean>>({
+    genuine: false,
+    terms: false,
+    data: false,
+  });
+  const [loading, setLoading] = useState(false);
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+
+  const allChecked = CONSENTS.every((c) => checked[c.id]);
+
+  const toggle = (id: string) => {
+    setChecked((prev) => ({ ...prev, [id]: !prev[id] }));
+  };
+
+  const submit = async () => {
+    if (!allChecked) return;
+    setLoading(true);
+    setErrorMsg(null);
+    try {
+      const res = await fetch(`${API_URL}/api/verification/consent`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ consented: true }),
+      });
+
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.error || "Failed to submit consent");
+      }
+
+      router.replace("/(seeker-verify)/pending");
+    } catch (err) {
+      setErrorMsg(err instanceof Error ? err.message : "Something went wrong");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <ScrollView className="flex-1 bg-[#FBF9FA]" contentContainerStyle={{ flexGrow: 1 }}>
+      <View className="flex-1 px-6 py-10 max-w-lg w-full self-center">
+        <Text className="text-sm text-[#81656E] font-medium mb-2">Step 4 of 4</Text>
+        <Text className="text-2xl font-bold text-[#201317] mb-3">Consent</Text>
+        <Text className="text-base text-[#81656E] leading-6 mb-8">
+          Please review and confirm each statement below to complete your verification.
+        </Text>
+
+        <View className="bg-white rounded-2xl p-5 mb-8 gap-4">
+          {CONSENTS.map((item, idx) => (
+            <Pressable
+              key={item.id}
+              onPress={() => toggle(item.id)}
+              className={`flex-row items-start ${idx < CONSENTS.length - 1 ? "pb-4 border-b border-gray-100" : ""}`}
+            >
+              <View
+                className={`w-6 h-6 rounded border-2 items-center justify-center mt-0.5 mr-3 flex-shrink-0 ${
+                  checked[item.id]
+                    ? "bg-[#C52660] border-[#C52660]"
+                    : "border-gray-300 bg-white"
+                }`}
+              >
+                {checked[item.id] && (
+                  <Text className="text-white text-xs font-bold">✓</Text>
+                )}
+              </View>
+              <Text className="flex-1 text-base text-[#201317] leading-6">{item.label}</Text>
+            </Pressable>
+          ))}
+        </View>
+
+        {errorMsg && (
+          <Text className="text-sm text-[#DC2626] mb-4 text-center">{errorMsg}</Text>
+        )}
+
+        <Button
+          label="Agree & Complete"
+          onPress={submit}
+          variant="primary"
+          size="lg"
+          fullWidth
+          disabled={!allChecked || loading}
+          loading={loading}
+        />
+
+        {!allChecked && (
+          <Text className="text-xs text-[#81656E] text-center mt-3">
+            Please check all boxes to continue
+          </Text>
+        )}
+      </View>
+    </ScrollView>
+  );
+}

--- a/app/(seeker-verify)/intro.tsx
+++ b/app/(seeker-verify)/intro.tsx
@@ -1,0 +1,91 @@
+import { useEffect, useState } from "react";
+import { View, Text, ScrollView, Pressable, ActivityIndicator } from "react-native";
+import { router } from "expo-router";
+import { Button } from "@/components/ui";
+
+const API_URL = process.env.EXPO_PUBLIC_API_URL || "http://localhost:3500";
+
+const STEPS = [
+  { num: 1, label: "Government ID" },
+  { num: 2, label: "Selfie" },
+  { num: 3, label: "Identity Check" },
+  { num: 4, label: "Consent" },
+];
+
+export default function SeekerVerifyIntroScreen() {
+  const [loading, setLoading] = useState(true);
+  const [alreadyStarted, setAlreadyStarted] = useState(false);
+
+  useEffect(() => {
+    fetch(`${API_URL}/api/verification/status`)
+      .then((r) => r.json())
+      .then((data) => {
+        if (data.status && data.status !== "pending") {
+          setAlreadyStarted(true);
+        }
+      })
+      .catch(() => {})
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) {
+    return (
+      <View className="flex-1 bg-[#FBF9FA] items-center justify-center">
+        <ActivityIndicator color="#C52660" />
+      </View>
+    );
+  }
+
+  return (
+    <ScrollView className="flex-1 bg-[#FBF9FA]" contentContainerStyle={{ flexGrow: 1 }}>
+      <View className="flex-1 items-center px-6 py-12 max-w-lg w-full self-center">
+        {/* Header */}
+        <Text className="text-3xl font-bold text-[#201317] text-center mb-3">
+          Identity Verification
+        </Text>
+        <Text className="text-base text-[#81656E] text-center mb-10 leading-6">
+          We verify all seekers to ensure companion safety and build a trusted community.
+        </Text>
+
+        {alreadyStarted && (
+          <View className="bg-amber-50 border border-amber-200 rounded-xl px-4 py-3 mb-6 w-full">
+            <Text className="text-sm text-amber-700 font-medium">
+              You have a verification in progress. You can continue from where you left off.
+            </Text>
+          </View>
+        )}
+
+        {/* Steps list */}
+        <View className="w-full bg-white rounded-2xl p-5 mb-8">
+          {STEPS.map((step, idx) => (
+            <View
+              key={step.num}
+              className={`flex-row items-center py-3 ${idx < STEPS.length - 1 ? "border-b border-gray-100" : ""}`}
+            >
+              <View className="w-8 h-8 rounded-full bg-[#C52660] items-center justify-center mr-4">
+                <Text className="text-white text-sm font-bold">{step.num}</Text>
+              </View>
+              <Text className="text-base text-[#201317] font-medium">{step.label}</Text>
+            </View>
+          ))}
+        </View>
+
+        {/* CTA */}
+        <View className="w-full mb-4">
+          <Button
+            label="Start Verification"
+            onPress={() => router.push("/(seeker-verify)/photo-id")}
+            variant="primary"
+            size="lg"
+            fullWidth
+          />
+        </View>
+
+        {/* Exit link */}
+        <Pressable onPress={() => router.back()} className="py-3">
+          <Text className="text-base text-[#81656E]">I'll do this later</Text>
+        </Pressable>
+      </View>
+    </ScrollView>
+  );
+}

--- a/app/(seeker-verify)/pending.tsx
+++ b/app/(seeker-verify)/pending.tsx
@@ -1,0 +1,104 @@
+import { useEffect, useRef, useState } from "react";
+import { View, Text, ScrollView, Pressable, Linking } from "react-native";
+import { router } from "expo-router";
+import { EmptyState, Button } from "@/components/ui";
+
+const API_URL = process.env.EXPO_PUBLIC_API_URL || "http://localhost:3500";
+const POLL_INTERVAL = 30_000;
+const SUPPORT_EMAIL = "support@daterabbit.app";
+
+type Status = "pending" | "approved" | "rejected";
+
+export default function SeekerVerifyPendingScreen() {
+  const [status, setStatus] = useState<Status>("pending");
+  const [reason, setReason] = useState<string | null>(null);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const poll = async () => {
+    try {
+      const res = await fetch(`${API_URL}/api/verification/status`);
+      if (!res.ok) return;
+      const data = await res.json();
+      if (data.status === "approved") {
+        setStatus("approved");
+        clearInterval(intervalRef.current!);
+        router.replace("/(tabs)/male/browse");
+      } else if (data.status === "rejected") {
+        setStatus("rejected");
+        setReason(data.reason || null);
+        clearInterval(intervalRef.current!);
+      }
+    } catch {
+      // silent — will retry on next tick
+    }
+  };
+
+  useEffect(() => {
+    poll();
+    intervalRef.current = setInterval(poll, POLL_INTERVAL);
+    return () => {
+      if (intervalRef.current) clearInterval(intervalRef.current);
+    };
+  }, []);
+
+  const openSupport = () => {
+    Linking.openURL(`mailto:${SUPPORT_EMAIL}`);
+  };
+
+  if (status === "rejected") {
+    return (
+      <ScrollView className="flex-1 bg-[#FBF9FA]" contentContainerStyle={{ flexGrow: 1 }}>
+        <View className="flex-1 items-center justify-center px-6 py-12 max-w-lg w-full self-center">
+          <EmptyState
+            title="Verification Not Approved"
+            message={reason || "Your verification was not successful. Please review the requirements and try again."}
+          />
+          {reason && (
+            <View className="bg-red-50 border border-red-100 rounded-xl px-4 py-3 w-full mb-6">
+              <Text className="text-sm text-red-700">{reason}</Text>
+            </View>
+          )}
+          <View className="w-full mb-3">
+            <Button
+              label="Try Again"
+              onPress={() => router.replace("/(seeker-verify)/intro")}
+              variant="primary"
+              size="lg"
+              fullWidth
+            />
+          </View>
+          <Pressable onPress={openSupport} className="py-2">
+            <Text className="text-base text-[#C52660]">Contact Support</Text>
+          </Pressable>
+        </View>
+      </ScrollView>
+    );
+  }
+
+  return (
+    <ScrollView className="flex-1 bg-[#FBF9FA]" contentContainerStyle={{ flexGrow: 1 }}>
+      <View className="flex-1 items-center justify-center px-6 py-12 max-w-lg w-full self-center">
+        <View className="w-24 h-24 rounded-full bg-amber-100 items-center justify-center mb-6">
+          <Text className="text-5xl">⏳</Text>
+        </View>
+
+        <EmptyState
+          title="Under Review"
+          message="We're reviewing your documents. This usually takes 24-48 hours. You'll receive an email when the review is complete."
+        />
+
+        <View className="bg-amber-50 border border-amber-100 rounded-xl px-4 py-3 w-full mt-4 mb-8">
+          <Text className="text-sm text-amber-700 text-center">
+            Checking status every 30 seconds...
+          </Text>
+        </View>
+
+        <Pressable onPress={openSupport} className="py-2">
+          <Text className="text-base text-[#C52660]">
+            Need help? Email {SUPPORT_EMAIL}
+          </Text>
+        </Pressable>
+      </View>
+    </ScrollView>
+  );
+}

--- a/app/(seeker-verify)/photo-id.tsx
+++ b/app/(seeker-verify)/photo-id.tsx
@@ -1,0 +1,159 @@
+import { useState } from "react";
+import { View, Text, ScrollView, Pressable, Image, ActivityIndicator, Alert } from "react-native";
+import * as ImagePicker from "expo-image-picker";
+import { router } from "expo-router";
+import { Button } from "@/components/ui";
+
+const API_URL = process.env.EXPO_PUBLIC_API_URL || "http://localhost:3500";
+
+type State = "idle" | "picking" | "uploading" | "error";
+
+export default function PhotoIdScreen() {
+  const [state, setState] = useState<State>("idle");
+  const [imageUri, setImageUri] = useState<string | null>(null);
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+  const [progress, setProgress] = useState(0);
+
+  const pickImage = async () => {
+    setState("picking");
+    try {
+      const result = await ImagePicker.launchImageLibraryAsync({
+        mediaTypes: ["images"],
+        quality: 0.9,
+        allowsEditing: true,
+      });
+      if (!result.canceled && result.assets[0]) {
+        setImageUri(result.assets[0].uri);
+        setState("idle");
+      } else {
+        setState("idle");
+      }
+    } catch {
+      setState("error");
+      setErrorMsg("Could not open image picker");
+    }
+  };
+
+  const takePhoto = async () => {
+    setState("picking");
+    try {
+      const perm = await ImagePicker.requestCameraPermissionsAsync();
+      if (!perm.granted) {
+        Alert.alert("Permission needed", "Please allow camera access in Settings.");
+        setState("idle");
+        return;
+      }
+      const result = await ImagePicker.launchCameraAsync({
+        quality: 0.9,
+        allowsEditing: true,
+      });
+      if (!result.canceled && result.assets[0]) {
+        setImageUri(result.assets[0].uri);
+        setState("idle");
+      } else {
+        setState("idle");
+      }
+    } catch {
+      setState("error");
+      setErrorMsg("Could not open camera");
+    }
+  };
+
+  const upload = async () => {
+    if (!imageUri) return;
+    setState("uploading");
+    setErrorMsg(null);
+    setProgress(0);
+
+    try {
+      const form = new FormData();
+      const filename = imageUri.split("/").pop() || "photo-id.jpg";
+      form.append("file", { uri: imageUri, name: filename, type: "image/jpeg" } as never);
+
+      // Simulate progress
+      const interval = setInterval(() => {
+        setProgress((p) => Math.min(p + 20, 80));
+      }, 300);
+
+      const res = await fetch(`${API_URL}/api/verification/photo-id`, {
+        method: "POST",
+        body: form,
+      });
+
+      clearInterval(interval);
+      setProgress(100);
+
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.error || "Upload failed");
+      }
+
+      router.push("/(seeker-verify)/selfie");
+    } catch (err) {
+      setState("error");
+      setErrorMsg(err instanceof Error ? err.message : "Upload failed");
+    }
+  };
+
+  return (
+    <ScrollView className="flex-1 bg-[#FBF9FA]" contentContainerStyle={{ flexGrow: 1 }}>
+      <View className="flex-1 px-6 py-10 max-w-lg w-full self-center">
+        {/* Step indicator */}
+        <Text className="text-sm text-[#81656E] font-medium mb-2">Step 1 of 4</Text>
+        <Text className="text-2xl font-bold text-[#201317] mb-3">Government ID</Text>
+        <Text className="text-base text-[#81656E] leading-6 mb-8">
+          Take a clear photo of your government-issued ID (front side). Make sure all text is readable and there is no glare.
+        </Text>
+
+        {/* Preview or placeholder */}
+        {imageUri ? (
+          <View className="w-full aspect-video rounded-2xl overflow-hidden mb-6 border border-gray-200">
+            <Image source={{ uri: imageUri }} className="w-full h-full" resizeMode="cover" />
+          </View>
+        ) : (
+          <View className="w-full aspect-video rounded-2xl border-2 border-dashed border-gray-300 items-center justify-center mb-6 bg-white">
+            <Text className="text-4xl mb-2">🪪</Text>
+            <Text className="text-sm text-[#81656E]">No photo selected</Text>
+          </View>
+        )}
+
+        {/* Picker buttons */}
+        <View className="flex-row gap-3 mb-6">
+          <View className="flex-1">
+            <Button label="From Library" onPress={pickImage} variant="secondary" size="md" fullWidth />
+          </View>
+          <View className="flex-1">
+            <Button label="Camera" onPress={takePhoto} variant="secondary" size="md" fullWidth />
+          </View>
+        </View>
+
+        {/* Progress bar */}
+        {state === "uploading" && (
+          <View className="mb-4">
+            <View className="h-2 bg-gray-200 rounded-full overflow-hidden">
+              <View
+                className="h-2 bg-[#C52660] rounded-full"
+                style={{ width: `${progress}%` }}
+              />
+            </View>
+            <Text className="text-xs text-[#81656E] mt-1 text-center">Uploading... {progress}%</Text>
+          </View>
+        )}
+
+        {errorMsg && (
+          <Text className="text-sm text-[#DC2626] mb-4 text-center">{errorMsg}</Text>
+        )}
+
+        <Button
+          label={state === "uploading" ? "Uploading..." : "Upload & Continue"}
+          onPress={upload}
+          variant="primary"
+          size="lg"
+          fullWidth
+          disabled={!imageUri || state === "uploading"}
+          loading={state === "uploading"}
+        />
+      </View>
+    </ScrollView>
+  );
+}

--- a/app/(seeker-verify)/selfie.tsx
+++ b/app/(seeker-verify)/selfie.tsx
@@ -1,0 +1,153 @@
+import { useState } from "react";
+import { View, Text, ScrollView, Pressable, Image, Alert } from "react-native";
+import * as ImagePicker from "expo-image-picker";
+import { router } from "expo-router";
+import { Button } from "@/components/ui";
+
+const API_URL = process.env.EXPO_PUBLIC_API_URL || "http://localhost:3500";
+
+type State = "idle" | "picking" | "uploading" | "error";
+
+export default function SelfieScreen() {
+  const [state, setState] = useState<State>("idle");
+  const [imageUri, setImageUri] = useState<string | null>(null);
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+  const [progress, setProgress] = useState(0);
+
+  const pickImage = async () => {
+    setState("picking");
+    try {
+      const result = await ImagePicker.launchImageLibraryAsync({
+        mediaTypes: ["images"],
+        quality: 0.9,
+        allowsEditing: true,
+        aspect: [1, 1],
+      });
+      if (!result.canceled && result.assets[0]) {
+        setImageUri(result.assets[0].uri);
+        setState("idle");
+      } else {
+        setState("idle");
+      }
+    } catch {
+      setState("error");
+      setErrorMsg("Could not open image picker");
+    }
+  };
+
+  const takePhoto = async () => {
+    setState("picking");
+    try {
+      const perm = await ImagePicker.requestCameraPermissionsAsync();
+      if (!perm.granted) {
+        Alert.alert("Permission needed", "Please allow camera access in Settings.");
+        setState("idle");
+        return;
+      }
+      const result = await ImagePicker.launchCameraAsync({
+        quality: 0.9,
+        allowsEditing: true,
+        aspect: [1, 1],
+      });
+      if (!result.canceled && result.assets[0]) {
+        setImageUri(result.assets[0].uri);
+        setState("idle");
+      } else {
+        setState("idle");
+      }
+    } catch {
+      setState("error");
+      setErrorMsg("Could not open camera");
+    }
+  };
+
+  const upload = async () => {
+    if (!imageUri) return;
+    setState("uploading");
+    setErrorMsg(null);
+    setProgress(0);
+
+    try {
+      const form = new FormData();
+      const filename = imageUri.split("/").pop() || "selfie.jpg";
+      form.append("file", { uri: imageUri, name: filename, type: "image/jpeg" } as never);
+
+      const interval = setInterval(() => {
+        setProgress((p) => Math.min(p + 20, 80));
+      }, 300);
+
+      const res = await fetch(`${API_URL}/api/verification/selfie`, {
+        method: "POST",
+        body: form,
+      });
+
+      clearInterval(interval);
+      setProgress(100);
+
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.error || "Upload failed");
+      }
+
+      router.push("/(seeker-verify)/stripe-identity");
+    } catch (err) {
+      setState("error");
+      setErrorMsg(err instanceof Error ? err.message : "Upload failed");
+    }
+  };
+
+  return (
+    <ScrollView className="flex-1 bg-[#FBF9FA]" contentContainerStyle={{ flexGrow: 1 }}>
+      <View className="flex-1 px-6 py-10 max-w-lg w-full self-center">
+        <Text className="text-sm text-[#81656E] font-medium mb-2">Step 2 of 4</Text>
+        <Text className="text-2xl font-bold text-[#201317] mb-3">Selfie</Text>
+        <Text className="text-base text-[#81656E] leading-6 mb-8">
+          Take a clear selfie — look directly at the camera, with good lighting and no glasses or hat.
+        </Text>
+
+        {imageUri ? (
+          <View className="w-48 h-48 rounded-full overflow-hidden border-2 border-[#C52660] self-center mb-6">
+            <Image source={{ uri: imageUri }} className="w-full h-full" resizeMode="cover" />
+          </View>
+        ) : (
+          <View className="w-48 h-48 rounded-full border-2 border-dashed border-gray-300 items-center justify-center self-center mb-6 bg-white">
+            <Text className="text-4xl mb-1">🤳</Text>
+            <Text className="text-xs text-[#81656E]">No photo</Text>
+          </View>
+        )}
+
+        <View className="flex-row gap-3 mb-6">
+          <View className="flex-1">
+            <Button label="From Library" onPress={pickImage} variant="secondary" size="md" fullWidth />
+          </View>
+          <View className="flex-1">
+            <Button label="Camera" onPress={takePhoto} variant="secondary" size="md" fullWidth />
+          </View>
+        </View>
+
+        {state === "uploading" && (
+          <View className="mb-4">
+            <View className="h-2 bg-gray-200 rounded-full overflow-hidden">
+              <View className="h-2 bg-[#C52660] rounded-full" style={{ width: `${progress}%` }} />
+            </View>
+            <Text className="text-xs text-[#81656E] mt-1 text-center">Uploading... {progress}%</Text>
+          </View>
+        )}
+
+        {errorMsg && (
+          <Text className="text-sm text-[#DC2626] mb-4 text-center">{errorMsg}</Text>
+        )}
+
+        <Button
+          label={state === "uploading" ? "Uploading..." : "Upload & Continue"}
+          onPress={upload}
+          variant="primary"
+          size="lg"
+          fullWidth
+          disabled={!imageUri || state === "uploading"}
+          loading={state === "uploading"}
+        />
+      </View>
+    </ScrollView>
+  );
+}

--- a/app/(seeker-verify)/stripe-identity.tsx
+++ b/app/(seeker-verify)/stripe-identity.tsx
@@ -1,0 +1,84 @@
+import { useState } from "react";
+import { View, Text, ScrollView } from "react-native";
+import { router } from "expo-router";
+import { Button } from "@/components/ui";
+
+const API_URL = process.env.EXPO_PUBLIC_API_URL || "http://localhost:3500";
+
+type State = "idle" | "processing" | "error";
+
+export default function StripeIdentityScreen() {
+  const [state, setState] = useState<State>("idle");
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+
+  const startCheck = async () => {
+    setState("processing");
+    setErrorMsg(null);
+    try {
+      const res = await fetch(`${API_URL}/api/verification/stripe-identity/start`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+      });
+
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.error || "Failed to start identity check");
+      }
+
+      const data = await res.json();
+      // In production: open Stripe Identity SDK with data.clientSecret
+      // Here: simulate success
+      console.log("[StripeIdentity] clientSecret:", data.clientSecret);
+
+      router.push("/(seeker-verify)/consent");
+    } catch (err) {
+      setState("error");
+      setErrorMsg(err instanceof Error ? err.message : "Something went wrong");
+    }
+  };
+
+  return (
+    <ScrollView className="flex-1 bg-[#FBF9FA]" contentContainerStyle={{ flexGrow: 1 }}>
+      <View className="flex-1 px-6 py-10 max-w-lg w-full self-center items-center">
+        <Text className="text-sm text-[#81656E] font-medium mb-2 self-start">Step 3 of 4</Text>
+        <Text className="text-2xl font-bold text-[#201317] mb-3 self-start">Identity Check</Text>
+
+        <View className="w-20 h-20 rounded-full bg-[#FBF9FA] border-2 border-[#C52660] items-center justify-center my-8">
+          <Text className="text-4xl">🛡️</Text>
+        </View>
+
+        <Text className="text-base text-[#81656E] text-center leading-6 mb-4">
+          We use{" "}
+          <Text className="font-semibold text-[#201317]">Stripe Identity</Text>{" "}
+          for secure, automated document verification. Your information is encrypted and never stored on our servers.
+        </Text>
+
+        <View className="bg-blue-50 border border-blue-100 rounded-xl px-4 py-3 w-full mb-10">
+          <Text className="text-sm text-blue-700 text-center">
+            This check typically takes under 60 seconds.
+          </Text>
+        </View>
+
+        {errorMsg && (
+          <Text className="text-sm text-[#DC2626] mb-4 text-center">{errorMsg}</Text>
+        )}
+
+        {state === "processing" ? (
+          <View className="items-center mb-6">
+            <Text className="text-base text-[#81656E] mb-2">Processing...</Text>
+          </View>
+        ) : null}
+
+        <Button
+          label={state === "processing" ? "Starting..." : "Start Identity Check"}
+          onPress={startCheck}
+          variant="primary"
+          size="lg"
+          fullWidth
+          disabled={state === "processing"}
+          loading={state === "processing"}
+        />
+      </View>
+    </ScrollView>
+  );
+}

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -32,6 +32,8 @@ export default function RootLayout() {
         <Stack.Screen name="legal/privacy" />
         <Stack.Screen name="legal/terms" />
         <Stack.Screen name="brand" />
+        <Stack.Screen name="(seeker-verify)" />
+        <Stack.Screen name="(comp-onboard)" />
       </Stack>
     </AuthProvider>
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "expo": "~54.0.33",
         "expo-constants": "~18.0.13",
         "expo-font": "~14.0.11",
+        "expo-image-picker": "^55.0.19",
         "expo-linking": "~8.0.11",
         "expo-router": "~6.0.23",
         "expo-splash-screen": "~31.0.13",
@@ -4343,6 +4344,27 @@
         "expo": "*",
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/expo-image-loader": {
+      "version": "55.0.0",
+      "resolved": "https://registry.npmjs.org/expo-image-loader/-/expo-image-loader-55.0.0.tgz",
+      "integrity": "sha512-NOjp56wDrfuA5aiNAybBIjqIn1IxKeGJ8CECWZncQ/GzjZfyTYAHTCyeApYkdKkMBLHINzI4BbTGSlbCa0fXXQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-image-picker": {
+      "version": "55.0.19",
+      "resolved": "https://registry.npmjs.org/expo-image-picker/-/expo-image-picker-55.0.19.tgz",
+      "integrity": "sha512-PqOOfRz7+hbB9IFN0LfNxpJJwuPlUG0Abr0qM3Wc61OJ7FFyuKJ50QJ/fFItzSuoXifET1YIFBiXx5nA8Gkinw==",
+      "license": "MIT",
+      "dependencies": {
+        "expo-image-loader": "~55.0.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-keep-awake": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "expo": "~54.0.33",
     "expo-constants": "~18.0.13",
     "expo-font": "~14.0.11",
+    "expo-image-picker": "^55.0.19",
     "expo-linking": "~8.0.11",
     "expo-router": "~6.0.23",
     "expo-splash-screen": "~31.0.13",


### PR DESCRIPTION
## Summary
- **app/(seeker-verify)/**: 6 screens — intro, photo-id, selfie, stripe-identity, consent, pending (forced flow, no back)
- **app/(comp-onboard)/**: 3 screens — step2 (photo grid min 4 + main selector), verify (Stripe Identity stub), pending (poll + approved/rejected states)
- **api/src/routes/verification.ts**: all 6 endpoints stubbed (GET status, POST photo-id/selfie/stripe-identity/start/consent, GET companion/status)
- expo-image-picker installed for photo upload in photo-id, selfie, step2

## Test plan
- [ ] Seeker verify flow: intro → photo-id (pick + upload) → selfie → stripe-identity → consent (all 3 checkboxes) → pending (polls every 30s)
- [ ] Comp onboard: step2 (add 4+ photos, set main) → verify → pending
- [ ] Pending screens: approved navigates away, rejected shows reason + retry
- [ ] API stubs return correct mock data

🤖 Generated with [Claude Code](https://claude.com/claude-code)