### PR TITLE
feat: booking + payment flow (5 screens)

### DIFF
--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -13,6 +13,7 @@ import favoritesRoutes from "./routes/favorites";
 import reviewsRoutes from "./routes/reviews";
 import companionProfileRoutes from "./routes/companion-profile";
 import verificationRoutes, { companionStatusRouter } from "./routes/verification";
+import paymentsRoutes from "./routes/payments";
 
 const app = express();
 const PORT = process.env.PORT || 3500;
@@ -37,6 +38,7 @@ app.use("/api/reviews", reviewsRoutes);
 app.use("/api/companion", companionProfileRoutes);
 app.use("/api/companion", companionStatusRouter);
 app.use("/api/verification", verificationRoutes);
+app.use("/api/payments", paymentsRoutes);
 
 app.listen(PORT, () => {
   console.log(`API server running on http://localhost:${PORT}`);

--- a/api/src/routes/payments.ts
+++ b/api/src/routes/payments.ts
@@ -1,0 +1,47 @@
+import { Router, Request, Response } from "express";
+import { authMiddleware } from "../middleware/auth";
+import { prisma } from "../lib/prisma";
+
+const router = Router();
+
+// POST /api/payments/bookings/:bookingId/pay — stub Stripe authorization
+router.post("/bookings/:bookingId/pay", authMiddleware, async (req: Request, res: Response) => {
+  try {
+    const userId = req.user!.userId;
+    const bookingId = req.params["bookingId"] as string;
+
+    const booking = await prisma.booking.findUnique({
+      where: { id: bookingId },
+      select: { id: true, seekerId: true, status: true },
+    });
+
+    if (!booking) {
+      res.status(404).json({ error: "Booking not found" });
+      return;
+    }
+
+    if (booking.seekerId !== userId) {
+      res.status(403).json({ error: "Forbidden" });
+      return;
+    }
+
+    if (booking.status !== "PENDING" && booking.status !== "ACCEPTED") {
+      res.status(400).json({ error: "Booking is not in a payable state" });
+      return;
+    }
+
+    // Stub: in production this would create a Stripe PaymentIntent and confirm it
+    // For now we just mark the booking as PAID
+    await prisma.booking.update({
+      where: { id: bookingId },
+      data: { status: "PAID" },
+    });
+
+    res.json({ success: true, message: "Payment authorized" });
+  } catch (error) {
+    console.error("payment error:", error);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+export default router;

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -43,6 +43,11 @@ export default function RootLayout() {
         <Stack.Screen name="brand" />
         <Stack.Screen name="(seeker-verify)" />
         <Stack.Screen name="(comp-onboard)" />
+        <Stack.Screen name="booking/[id]" options={{ headerShown: true, headerTitle: "Book a Date" }} />
+        <Stack.Screen name="booking/[bookingId]/sent" options={{ headerShown: false, gestureEnabled: false }} />
+        <Stack.Screen name="booking/[bookingId]/complete" options={{ headerShown: true, headerTitle: "Complete Date" }} />
+        <Stack.Screen name="payment/[bookingId]" options={{ headerShown: true, headerTitle: "Payment" }} />
+        <Stack.Screen name="reviews/new" options={{ headerShown: true, headerTitle: "Write a Review" }} />
       </Stack>
     </AuthProvider>
   );

--- a/app/booking/[bookingId]/complete.tsx
+++ b/app/booking/[bookingId]/complete.tsx
@@ -1,0 +1,326 @@
+import { useState, useEffect } from 'react'
+import {
+  View,
+  Text,
+  ScrollView,
+  TextInput,
+  KeyboardAvoidingView,
+  Platform,
+} from 'react-native'
+import { useLocalSearchParams, router } from 'expo-router'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import { Card } from '@/components/ui/Card'
+import { Button } from '@/components/ui/Button'
+import { LoadingState } from '@/components/ui/LoadingState'
+import { ErrorState } from '@/components/ui/ErrorState'
+import { useAuth } from '@/contexts/AuthContext'
+import { colors } from '@/lib/theme'
+
+const API_URL = process.env.EXPO_PUBLIC_API_URL || 'http://localhost:3500'
+
+interface BookingData {
+  id: string
+  activity: string
+  durationHours: number
+  actualDuration: number | null
+  status: string
+  seekerId: string
+  companion: {
+    userId: string
+    displayName: string
+    user: { name: string | null }
+  }
+  completedAt: string | null
+}
+
+export default function BookingCompleteScreen() {
+  const { bookingId } = useLocalSearchParams<{ bookingId: string }>()
+  const { token, user } = useAuth()
+  const insets = useSafeAreaInsets()
+
+  const [booking, setBooking] = useState<BookingData | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [fetchError, setFetchError] = useState<string | null>(null)
+
+  // Companion mode
+  const [durationInput, setDurationInput] = useState('')
+  const [durationError, setDurationError] = useState<string | null>(null)
+  const [submittingDuration, setSubmittingDuration] = useState(false)
+  const [durationSubmitError, setDurationSubmitError] = useState<string | null>(null)
+
+  // Seeker mode
+  const [showDisputeInput, setShowDisputeInput] = useState(false)
+  const [disputeReason, setDisputeReason] = useState('')
+  const [submittingConfirm, setSubmittingConfirm] = useState(false)
+  const [submittingDispute, setSubmittingDispute] = useState(false)
+  const [actionError, setActionError] = useState<string | null>(null)
+
+  useEffect(() => {
+    fetchBooking()
+  }, [bookingId])
+
+  async function fetchBooking() {
+    setLoading(true)
+    setFetchError(null)
+    try {
+      const res = await fetch(`${API_URL}/api/bookings/${bookingId}`, {
+        headers: token ? { Authorization: `Bearer ${token}` } : {},
+      })
+      if (!res.ok) throw new Error('Booking not found')
+      const data = await res.json()
+      setBooking(data.booking)
+    } catch (e: unknown) {
+      setFetchError(e instanceof Error ? e.message : 'Failed to load booking')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  async function handleSubmitDuration() {
+    const dur = parseFloat(durationInput)
+    if (isNaN(dur) || dur < 0.5) {
+      setDurationError('Minimum duration is 0.5 hours')
+      return
+    }
+    if (dur % 0.5 !== 0) {
+      setDurationError('Must be in 0.5h increments')
+      return
+    }
+    setDurationError(null)
+    setSubmittingDuration(true)
+    setDurationSubmitError(null)
+    try {
+      const res = await fetch(`${API_URL}/api/bookings/${bookingId}/complete`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        },
+        body: JSON.stringify({ actualDuration: dur }),
+      })
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.error || 'Failed to submit duration')
+      router.replace('/(tabs)/female/bookings' as never)
+    } catch (e: unknown) {
+      setDurationSubmitError(e instanceof Error ? e.message : 'Something went wrong')
+    } finally {
+      setSubmittingDuration(false)
+    }
+  }
+
+  async function handleConfirm() {
+    setSubmittingConfirm(true)
+    setActionError(null)
+    try {
+      const res = await fetch(`${API_URL}/api/bookings/${bookingId}/confirm-duration`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        },
+      })
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.error || 'Failed to confirm')
+      router.replace('/reviews/new' as never)
+    } catch (e: unknown) {
+      setActionError(e instanceof Error ? e.message : 'Something went wrong')
+    } finally {
+      setSubmittingConfirm(false)
+    }
+  }
+
+  async function handleDispute() {
+    if (!showDisputeInput) {
+      setShowDisputeInput(true)
+      return
+    }
+    if (!disputeReason.trim()) {
+      setActionError('Please provide a reason for the dispute')
+      return
+    }
+    setSubmittingDispute(true)
+    setActionError(null)
+    try {
+      const res = await fetch(`${API_URL}/api/bookings/${bookingId}/dispute`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        },
+        body: JSON.stringify({ reason: disputeReason.trim() }),
+      })
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.error || 'Failed to submit dispute')
+      router.replace('/(tabs)/male/bookings' as never)
+    } catch (e: unknown) {
+      setActionError(e instanceof Error ? e.message : 'Something went wrong')
+    } finally {
+      setSubmittingDispute(false)
+    }
+  }
+
+  if (loading) return <LoadingState />
+  if (fetchError || !booking)
+    return <ErrorState message={fetchError || 'Booking not found'} onRetry={fetchBooking} />
+
+  // Determine role: is current user the companion?
+  const isCompanion = user?.id === booking.companion.userId
+  const companionName = booking.companion.displayName || booking.companion.user.name || 'Companion'
+
+  // Countdown: 48h from completedAt
+  let countdownText = ''
+  if (!isCompanion && booking.completedAt) {
+    const deadline = new Date(booking.completedAt).getTime() + 48 * 60 * 60 * 1000
+    const remaining = deadline - Date.now()
+    if (remaining > 0) {
+      const hoursLeft = Math.floor(remaining / (1000 * 60 * 60))
+      const minsLeft = Math.floor((remaining % (1000 * 60 * 60)) / (1000 * 60))
+      countdownText = `${hoursLeft}h ${minsLeft}m remaining to respond`
+    }
+  }
+
+  return (
+    <KeyboardAvoidingView
+      behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+      className="flex-1 bg-[#FBF9FA]"
+    >
+      <ScrollView
+        className="flex-1"
+        contentContainerStyle={{ padding: 16, paddingBottom: insets.bottom + 100 }}
+        keyboardShouldPersistTaps="handled"
+      >
+        <Text className="text-2xl font-bold text-[#201317] mb-2">Complete Date</Text>
+        <Text className="text-base text-[#81656E] mb-6">{booking.activity}</Text>
+
+        {isCompanion ? (
+          // Companion view: enter actual duration
+          <Card variant="outlined" padding="md">
+            <Text className="text-base font-bold text-[#201317] mb-2">
+              How long was the date?
+            </Text>
+            <Text className="text-sm text-[#81656E] mb-4">
+              Booked for {booking.durationHours}h. Enter actual duration.
+            </Text>
+
+            <View>
+              <Text className="text-sm font-semibold text-[#201317] mb-2">Actual Duration (hours)</Text>
+              <View
+                style={{
+                  borderColor: durationError ? colors.error : '#E6D5DC',
+                  borderWidth: 1,
+                  borderRadius: 12,
+                  backgroundColor: '#FFFFFF',
+                  paddingHorizontal: 14,
+                  height: 48,
+                  justifyContent: 'center',
+                }}
+              >
+                <TextInput
+                  style={{ fontSize: 16, color: colors.text }}
+                  placeholder="e.g. 2.5"
+                  placeholderTextColor={colors.textSecondary}
+                  value={durationInput}
+                  onChangeText={setDurationInput}
+                  keyboardType="decimal-pad"
+                />
+              </View>
+              {durationError && (
+                <Text className="text-xs text-[#DC2626] mt-1">{durationError}</Text>
+              )}
+              <Text className="text-xs text-[#81656E] mt-1">Minimum 0.5h, steps of 0.5h</Text>
+            </View>
+
+            {durationSubmitError && (
+              <View className="mt-3 bg-red-50 rounded-xl p-3">
+                <Text className="text-sm text-[#DC2626]">{durationSubmitError}</Text>
+              </View>
+            )}
+
+            <View className="mt-4">
+              <Button
+                label="Submit Duration"
+                onPress={handleSubmitDuration}
+                variant="primary"
+                size="lg"
+                fullWidth
+                loading={submittingDuration}
+                disabled={submittingDuration}
+              />
+            </View>
+          </Card>
+        ) : (
+          // Seeker view: confirm or dispute
+          <View className="gap-4">
+            <Card variant="outlined" padding="md">
+              <Text className="text-base font-bold text-[#201317] mb-1">
+                Duration Submitted by {companionName}
+              </Text>
+              <Text className="text-3xl font-bold text-[#C52660] mt-2">
+                {booking.actualDuration ?? '—'}h
+              </Text>
+              <Text className="text-sm text-[#81656E] mt-1">
+                Originally booked for {booking.durationHours}h
+              </Text>
+              {countdownText ? (
+                <Text className="text-xs text-[#D97706] mt-3 font-semibold">{countdownText}</Text>
+              ) : null}
+            </Card>
+
+            {showDisputeInput && (
+              <Card variant="outlined" padding="md">
+                <Text className="text-sm font-semibold text-[#201317] mb-2">Dispute Reason</Text>
+                <View
+                  style={{
+                    borderColor: '#E6D5DC',
+                    borderWidth: 1,
+                    borderRadius: 12,
+                    backgroundColor: '#FFFFFF',
+                    paddingHorizontal: 14,
+                    paddingVertical: 12,
+                    minHeight: 80,
+                  }}
+                >
+                  <TextInput
+                    style={{ fontSize: 16, color: colors.text }}
+                    placeholder="Describe the issue..."
+                    placeholderTextColor={colors.textSecondary}
+                    value={disputeReason}
+                    onChangeText={setDisputeReason}
+                    multiline
+                    numberOfLines={3}
+                    textAlignVertical="top"
+                  />
+                </View>
+              </Card>
+            )}
+
+            {actionError && (
+              <View className="bg-red-50 rounded-xl p-3">
+                <Text className="text-sm text-[#DC2626]">{actionError}</Text>
+              </View>
+            )}
+
+            <Button
+              label="Confirm Duration"
+              onPress={handleConfirm}
+              variant="primary"
+              size="lg"
+              fullWidth
+              loading={submittingConfirm}
+              disabled={submittingConfirm || submittingDispute}
+            />
+            <Button
+              label={showDisputeInput ? 'Submit Dispute' : 'Dispute'}
+              onPress={handleDispute}
+              variant="secondary"
+              size="lg"
+              fullWidth
+              loading={submittingDispute}
+              disabled={submittingConfirm || submittingDispute}
+            />
+          </View>
+        )}
+      </ScrollView>
+    </KeyboardAvoidingView>
+  )
+}

--- a/app/booking/[bookingId]/sent.tsx
+++ b/app/booking/[bookingId]/sent.tsx
@@ -1,0 +1,46 @@
+import { View, Text } from 'react-native'
+import { useLocalSearchParams, router } from 'expo-router'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import { Button } from '@/components/ui/Button'
+
+export default function BookingSentScreen() {
+  const { bookingId } = useLocalSearchParams<{ bookingId: string }>()
+  const insets = useSafeAreaInsets()
+
+  return (
+    <View
+      className="flex-1 bg-[#FBF9FA] items-center justify-center px-8"
+      style={{ paddingBottom: insets.bottom + 24, paddingTop: insets.top + 24 }}
+    >
+      {/* Success icon */}
+      <View className="w-24 h-24 rounded-full bg-[#D1FAE5] items-center justify-center mb-6">
+        <Text style={{ fontSize: 48 }}>&#10003;</Text>
+      </View>
+
+      <Text className="text-3xl font-bold text-[#201317] text-center mb-3">
+        Date Request Sent!
+      </Text>
+
+      <Text className="text-base text-[#81656E] text-center max-w-xs leading-6">
+        We'll notify you when your companion responds. This usually happens within 24 hours.
+      </Text>
+
+      <View className="mt-10 w-full gap-3">
+        <Button
+          label="View My Bookings"
+          onPress={() => router.replace('/(tabs)/male/bookings' as never)}
+          variant="primary"
+          size="lg"
+          fullWidth
+        />
+        <Button
+          label="Browse More"
+          onPress={() => router.replace('/(tabs)/male/browse' as never)}
+          variant="secondary"
+          size="lg"
+          fullWidth
+        />
+      </View>
+    </View>
+  )
+}

--- a/app/booking/[id].tsx
+++ b/app/booking/[id].tsx
@@ -1,0 +1,490 @@
+import { useState, useEffect } from 'react'
+import {
+  View,
+  Text,
+  ScrollView,
+  KeyboardAvoidingView,
+  Platform,
+  TextInput,
+  Pressable,
+  ActivityIndicator,
+} from 'react-native'
+import { useLocalSearchParams, router } from 'expo-router'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import { Card } from '@/components/ui/Card'
+import { Input } from '@/components/ui/Input'
+import { Button } from '@/components/ui/Button'
+import { Badge } from '@/components/ui/Badge'
+import { LoadingState } from '@/components/ui/LoadingState'
+import { ErrorState } from '@/components/ui/ErrorState'
+import { useAuth } from '@/contexts/AuthContext'
+import { colors } from '@/lib/theme'
+
+const API_URL = process.env.EXPO_PUBLIC_API_URL || 'http://localhost:3500'
+
+const PLATFORM_FEE_RATE = 0.15
+const STRIPE_FEE_RATE = 0.029
+const STRIPE_FEE_FIXED = 0.3
+
+interface CompanionData {
+  id: string
+  displayName: string
+  hourlyRate: number
+  user: { name: string | null }
+}
+
+interface BookingData {
+  id: string
+  date: string
+  durationHours: number
+  activity: string
+  location: string
+  notes: string | null
+  status: string
+  totalAmount: number
+  platformFee: number
+  stripeFee: number
+  companion: {
+    id: string
+    displayName: string
+    user: { name: string | null }
+  }
+}
+
+function calcFees(hourlyRate: number, durationHours: number) {
+  const subtotal = hourlyRate * durationHours
+  const platformFee = parseFloat((subtotal * PLATFORM_FEE_RATE).toFixed(2))
+  const stripeFee = parseFloat((subtotal * STRIPE_FEE_RATE + STRIPE_FEE_FIXED).toFixed(2))
+  const total = parseFloat((subtotal + platformFee + stripeFee).toFixed(2))
+  return { subtotal, platformFee, stripeFee, total }
+}
+
+// ---- New booking form ----
+function NewBookingForm({ companionId }: { companionId: string }) {
+  const { token } = useAuth()
+  const insets = useSafeAreaInsets()
+
+  const [companion, setCompanion] = useState<CompanionData | null>(null)
+  const [loadingCompanion, setLoadingCompanion] = useState(true)
+  const [companionError, setCompanionError] = useState<string | null>(null)
+
+  const [activity, setActivity] = useState('')
+  const [date, setDate] = useState('')
+  const [duration, setDuration] = useState('2')
+  const [location, setLocation] = useState('')
+  const [notes, setNotes] = useState('')
+
+  const [errors, setErrors] = useState<Record<string, string>>({})
+  const [submitting, setSubmitting] = useState(false)
+  const [submitError, setSubmitError] = useState<string | null>(null)
+
+  useEffect(() => {
+    fetchCompanion()
+  }, [companionId])
+
+  async function fetchCompanion() {
+    setLoadingCompanion(true)
+    setCompanionError(null)
+    try {
+      const res = await fetch(`${API_URL}/api/companions/${companionId}`, {
+        headers: token ? { Authorization: `Bearer ${token}` } : {},
+      })
+      if (!res.ok) throw new Error('Companion not found')
+      const data = await res.json()
+      setCompanion(data.companion)
+    } catch (e: unknown) {
+      setCompanionError(e instanceof Error ? e.message : 'Failed to load companion')
+    } finally {
+      setLoadingCompanion(false)
+    }
+  }
+
+  function validate() {
+    const newErrors: Record<string, string> = {}
+    if (!activity.trim()) newErrors['activity'] = 'Activity is required'
+    if (!date.trim()) newErrors['date'] = 'Date is required'
+    if (!location.trim()) newErrors['location'] = 'Location is required'
+    const dur = parseFloat(duration)
+    if (isNaN(dur) || dur < 0.5) newErrors['duration'] = 'Minimum 0.5 hours'
+    if (dur % 0.5 !== 0) newErrors['duration'] = 'Must be in 0.5h increments'
+    if (notes.length > 500) newErrors['notes'] = 'Max 500 characters'
+    // Basic future date check
+    if (date.trim()) {
+      const d = new Date(date.trim())
+      if (isNaN(d.getTime())) newErrors['date'] = 'Invalid date format (YYYY-MM-DD HH:MM)'
+      else if (d < new Date()) newErrors['date'] = 'Date must be in the future'
+    }
+    setErrors(newErrors)
+    return Object.keys(newErrors).length === 0
+  }
+
+  async function handleSubmit() {
+    if (!validate() || !companion) return
+    setSubmitting(true)
+    setSubmitError(null)
+    try {
+      const res = await fetch(`${API_URL}/api/bookings`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        },
+        body: JSON.stringify({
+          companionId,
+          date: new Date(date.trim()).toISOString(),
+          durationHours: parseFloat(duration),
+          activity: activity.trim(),
+          location: location.trim(),
+          notes: notes.trim() || undefined,
+        }),
+      })
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.error || 'Failed to create booking')
+      router.replace(`/payment/${data.booking.id}` as never)
+    } catch (e: unknown) {
+      setSubmitError(e instanceof Error ? e.message : 'Something went wrong')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  if (loadingCompanion) return <LoadingState />
+  if (companionError || !companion)
+    return <ErrorState message={companionError || 'Companion not found'} onRetry={fetchCompanion} />
+
+  const dur = parseFloat(duration) || 0
+  const fees = companion ? calcFees(companion.hourlyRate, dur) : null
+  const companionName = companion.displayName || companion.user.name || 'Companion'
+
+  return (
+    <KeyboardAvoidingView
+      behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+      className="flex-1 bg-[#FBF9FA]"
+    >
+      <ScrollView
+        className="flex-1"
+        contentContainerStyle={{ padding: 16, paddingBottom: 120 }}
+        keyboardShouldPersistTaps="handled"
+      >
+        {/* Header info */}
+        <View className="mb-6">
+          <Text className="text-2xl font-bold text-[#201317]">Book a Date</Text>
+          <Text className="text-base text-[#81656E] mt-1">with {companionName}</Text>
+        </View>
+
+        {/* Form fields */}
+        <View className="gap-4">
+          <Input
+            label="Activity"
+            placeholder="e.g. Dinner, Museum tour, Coffee..."
+            value={activity}
+            onChangeText={setActivity}
+            error={errors['activity']}
+            autoCapitalize="sentences"
+          />
+
+          <View>
+            <Text className="text-sm font-semibold text-[#201317] mb-2">Date & Time</Text>
+            <View
+              style={{
+                borderColor: errors['date'] ? colors.error : '#E6D5DC',
+                borderWidth: 1,
+                borderRadius: 12,
+                backgroundColor: '#FFFFFF',
+                paddingHorizontal: 14,
+                height: 48,
+                justifyContent: 'center',
+              }}
+            >
+              <TextInput
+                style={{ fontSize: 16, color: colors.text }}
+                placeholder="YYYY-MM-DD HH:MM"
+                placeholderTextColor={colors.textSecondary}
+                value={date}
+                onChangeText={setDate}
+                autoCapitalize="none"
+              />
+            </View>
+            {errors['date'] && (
+              <Text className="text-xs text-[#DC2626] mt-1.5">{errors['date']}</Text>
+            )}
+          </View>
+
+          <View>
+            <Text className="text-sm font-semibold text-[#201317] mb-2">Duration (hours)</Text>
+            <View
+              style={{
+                borderColor: errors['duration'] ? colors.error : '#E6D5DC',
+                borderWidth: 1,
+                borderRadius: 12,
+                backgroundColor: '#FFFFFF',
+                paddingHorizontal: 14,
+                height: 48,
+                justifyContent: 'center',
+              }}
+            >
+              <TextInput
+                style={{ fontSize: 16, color: colors.text }}
+                placeholder="e.g. 2, 2.5, 3"
+                placeholderTextColor={colors.textSecondary}
+                value={duration}
+                onChangeText={setDuration}
+                keyboardType="decimal-pad"
+              />
+            </View>
+            {errors['duration'] && (
+              <Text className="text-xs text-[#DC2626] mt-1.5">{errors['duration']}</Text>
+            )}
+            <Text className="text-xs text-[#81656E] mt-1">Minimum 0.5h, steps of 0.5h</Text>
+          </View>
+
+          <Input
+            label="Location"
+            placeholder="e.g. Manhattan, NYC"
+            value={location}
+            onChangeText={setLocation}
+            error={errors['location']}
+            autoCapitalize="words"
+          />
+
+          <View>
+            <Text className="text-sm font-semibold text-[#201317] mb-2">
+              Notes <Text className="text-[#81656E] font-normal">(optional)</Text>
+            </Text>
+            <View
+              style={{
+                borderColor: '#E6D5DC',
+                borderWidth: 1,
+                borderRadius: 12,
+                backgroundColor: '#FFFFFF',
+                paddingHorizontal: 14,
+                paddingVertical: 12,
+                minHeight: 96,
+              }}
+            >
+              <TextInput
+                style={{ fontSize: 16, color: colors.text }}
+                placeholder="Any special requests or preferences..."
+                placeholderTextColor={colors.textSecondary}
+                value={notes}
+                onChangeText={setNotes}
+                multiline
+                numberOfLines={4}
+                textAlignVertical="top"
+                maxLength={500}
+              />
+            </View>
+            <Text className="text-xs text-[#81656E] mt-1 text-right">{notes.length}/500</Text>
+            {errors['notes'] && (
+              <Text className="text-xs text-[#DC2626] mt-1">{errors['notes']}</Text>
+            )}
+          </View>
+        </View>
+
+        {/* Price breakdown */}
+        {fees && dur >= 0.5 && (
+          <View className="mt-6">
+            <Card variant="outlined" padding="md">
+              <Text className="text-base font-bold text-[#201317] mb-3">Price Breakdown</Text>
+              <View className="gap-2">
+                <PriceLine
+                  label={`${companionName}'s rate`}
+                  value={`$${companion.hourlyRate}/hr`}
+                />
+                <PriceLine label="Duration" value={`${dur}h`} />
+                <PriceLine label="Subtotal" value={`$${fees.subtotal.toFixed(2)}`} />
+                <View className="h-px bg-[#F0E6EA] my-1" />
+                <PriceLine label="Platform fee (15%)" value={`$${fees.platformFee.toFixed(2)}`} muted />
+                <PriceLine label="Stripe fee (3%)" value={`$${fees.stripeFee.toFixed(2)}`} muted />
+                <View className="h-px bg-[#F0E6EA] my-1" />
+                <View className="flex-row justify-between items-center">
+                  <Text className="text-base font-bold text-[#201317]">Total</Text>
+                  <Text className="text-base font-bold text-[#C52660]">${fees.total.toFixed(2)}</Text>
+                </View>
+              </View>
+            </Card>
+          </View>
+        )}
+
+        {submitError && (
+          <View className="mt-4 bg-red-50 rounded-xl p-3">
+            <Text className="text-sm text-[#DC2626]">{submitError}</Text>
+          </View>
+        )}
+      </ScrollView>
+
+      {/* Sticky CTA */}
+      <View
+        style={{
+          position: 'absolute',
+          bottom: 0,
+          left: 0,
+          right: 0,
+          paddingBottom: insets.bottom + 16,
+          paddingTop: 12,
+          paddingHorizontal: 16,
+          backgroundColor: '#FFFFFF',
+          borderTopWidth: 1,
+          borderTopColor: '#F0E6EA',
+        }}
+      >
+        <Button
+          label={submitting ? 'Creating booking...' : 'Continue to Payment'}
+          onPress={handleSubmit}
+          variant="primary"
+          size="lg"
+          fullWidth
+          loading={submitting}
+          disabled={submitting}
+        />
+      </View>
+    </KeyboardAvoidingView>
+  )
+}
+
+// ---- Existing booking view ----
+function ExistingBookingView({ bookingId }: { bookingId: string }) {
+  const { token } = useAuth()
+  const [booking, setBooking] = useState<BookingData | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    fetchBooking()
+  }, [bookingId])
+
+  async function fetchBooking() {
+    setLoading(true)
+    setError(null)
+    try {
+      const res = await fetch(`${API_URL}/api/bookings/${bookingId}`, {
+        headers: token ? { Authorization: `Bearer ${token}` } : {},
+      })
+      if (!res.ok) throw new Error('Booking not found')
+      const data = await res.json()
+      setBooking(data.booking)
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : 'Failed to load booking')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  if (loading) return <LoadingState />
+  if (error || !booking)
+    return <ErrorState message={error || 'Booking not found'} onRetry={fetchBooking} />
+
+  const companionName = booking.companion.displayName || 'Companion'
+  const dateStr = new Date(booking.date).toLocaleDateString('en-US', {
+    weekday: 'long',
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  })
+  const timeStr = new Date(booking.date).toLocaleTimeString('en-US', {
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+
+  return (
+    <ScrollView className="flex-1 bg-[#FBF9FA]" contentContainerStyle={{ padding: 16 }}>
+      <Text className="text-2xl font-bold text-[#201317] mb-6">Booking Details</Text>
+      <Card variant="outlined" padding="md">
+        <View className="gap-4">
+          <DetailRow label="Companion" value={companionName} />
+          <DetailRow label="Date" value={`${dateStr} at ${timeStr}`} />
+          <DetailRow label="Activity" value={booking.activity} />
+          <DetailRow label="Location" value={booking.location} />
+          <DetailRow label="Duration" value={`${booking.durationHours}h`} />
+          {booking.notes && <DetailRow label="Notes" value={booking.notes} />}
+          <View className="flex-row justify-between items-center">
+            <Text className="text-sm font-semibold text-[#81656E]">Status</Text>
+            <Badge label={booking.status} variant={statusToVariant(booking.status)} />
+          </View>
+        </View>
+      </Card>
+
+      <View className="mt-4">
+        <Card variant="outlined" padding="md">
+          <Text className="text-base font-bold text-[#201317] mb-3">Price Breakdown</Text>
+          <View className="gap-2">
+            <PriceLine
+              label="Platform fee"
+              value={`$${booking.platformFee.toFixed(2)}`}
+              muted
+            />
+            <PriceLine label="Stripe fee" value={`$${booking.stripeFee.toFixed(2)}`} muted />
+            <View className="h-px bg-[#F0E6EA] my-1" />
+            <View className="flex-row justify-between items-center">
+              <Text className="text-base font-bold text-[#201317]">Total</Text>
+              <Text className="text-base font-bold text-[#C52660]">
+                ${booking.totalAmount.toFixed(2)}
+              </Text>
+            </View>
+          </View>
+        </Card>
+      </View>
+    </ScrollView>
+  )
+}
+
+// ---- Helpers ----
+function PriceLine({ label, value, muted = false }: { label: string; value: string; muted?: boolean }) {
+  return (
+    <View className="flex-row justify-between items-center">
+      <Text className={`text-sm ${muted ? 'text-[#81656E]' : 'text-[#201317]'}`}>{label}</Text>
+      <Text className={`text-sm ${muted ? 'text-[#81656E]' : 'text-[#201317] font-medium'}`}>
+        {value}
+      </Text>
+    </View>
+  )
+}
+
+function DetailRow({ label, value }: { label: string; value: string }) {
+  return (
+    <View>
+      <Text className="text-xs font-semibold text-[#81656E] uppercase tracking-wide">{label}</Text>
+      <Text className="text-base text-[#201317] mt-0.5">{value}</Text>
+    </View>
+  )
+}
+
+function statusToVariant(status: string): 'neutral' | 'success' | 'warning' | 'error' {
+  switch (status.toLowerCase()) {
+    case 'accepted':
+    case 'paid':
+    case 'completed':
+      return 'success'
+    case 'pending':
+      return 'warning'
+    case 'declined':
+    case 'disputed':
+      return 'error'
+    default:
+      return 'neutral'
+  }
+}
+
+// ---- Route ----
+// /booking/[id] — id is either a companionId (new booking) or bookingId (existing)
+// Distinguish by query param: ?mode=new or ?mode=view (defaults to view)
+export default function BookingScreen() {
+  const { id, mode, companionId } = useLocalSearchParams<{
+    id: string
+    mode?: string
+    companionId?: string
+  }>()
+
+  // If companionId param passed, or mode=new — show new booking form
+  const effectiveCompanionId = companionId || (mode === 'new' ? id : null)
+
+  return (
+    <View className="flex-1 bg-[#FBF9FA]">
+      {effectiveCompanionId ? (
+        <NewBookingForm companionId={effectiveCompanionId} />
+      ) : (
+        <ExistingBookingView bookingId={id} />
+      )}
+    </View>
+  )
+}

--- a/app/payment/[bookingId].tsx
+++ b/app/payment/[bookingId].tsx
@@ -1,0 +1,332 @@
+import { useState, useEffect } from 'react'
+import {
+  View,
+  Text,
+  ScrollView,
+  KeyboardAvoidingView,
+  Platform,
+  TextInput,
+  ActivityIndicator,
+} from 'react-native'
+import { useLocalSearchParams, router } from 'expo-router'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import { Card } from '@/components/ui/Card'
+import { Button } from '@/components/ui/Button'
+import { LoadingState } from '@/components/ui/LoadingState'
+import { ErrorState } from '@/components/ui/ErrorState'
+import { useAuth } from '@/contexts/AuthContext'
+import { colors } from '@/lib/theme'
+
+const API_URL = process.env.EXPO_PUBLIC_API_URL || 'http://localhost:3500'
+
+interface BookingData {
+  id: string
+  date: string
+  durationHours: number
+  activity: string
+  location: string
+  totalAmount: number
+  platformFee: number
+  stripeFee: number
+  companion: {
+    displayName: string
+    hourlyRate: number
+    user: { name: string | null }
+  }
+}
+
+function formatCardNumber(raw: string) {
+  const digits = raw.replace(/\D/g, '').slice(0, 16)
+  return digits.replace(/(.{4})/g, '$1 ').trim()
+}
+
+function formatExpiry(raw: string) {
+  const digits = raw.replace(/\D/g, '').slice(0, 4)
+  if (digits.length >= 3) return digits.slice(0, 2) + '/' + digits.slice(2)
+  return digits
+}
+
+export default function PaymentScreen() {
+  const { bookingId } = useLocalSearchParams<{ bookingId: string }>()
+  const { token } = useAuth()
+  const insets = useSafeAreaInsets()
+
+  const [booking, setBooking] = useState<BookingData | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [fetchError, setFetchError] = useState<string | null>(null)
+
+  // Card form state
+  const [cardNumber, setCardNumber] = useState('')
+  const [expiry, setExpiry] = useState('')
+  const [cvc, setCvc] = useState('')
+  const [zip, setZip] = useState('')
+  const [cardErrors, setCardErrors] = useState<Record<string, string>>({})
+
+  const [processing, setProcessing] = useState(false)
+  const [payError, setPayError] = useState<string | null>(null)
+
+  useEffect(() => {
+    fetchBooking()
+  }, [bookingId])
+
+  async function fetchBooking() {
+    setLoading(true)
+    setFetchError(null)
+    try {
+      const res = await fetch(`${API_URL}/api/bookings/${bookingId}`, {
+        headers: token ? { Authorization: `Bearer ${token}` } : {},
+      })
+      if (!res.ok) throw new Error('Booking not found')
+      const data = await res.json()
+      setBooking(data.booking)
+    } catch (e: unknown) {
+      setFetchError(e instanceof Error ? e.message : 'Failed to load booking')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  function validateCard() {
+    const errs: Record<string, string> = {}
+    const rawCard = cardNumber.replace(/\s/g, '')
+    if (rawCard.length < 16) errs['cardNumber'] = 'Enter a valid 16-digit card number'
+    const expiryParts = expiry.split('/')
+    const month = parseInt(expiryParts[0] ?? '', 10)
+    const year = parseInt(expiryParts[1] ?? '', 10)
+    const now = new Date()
+    const expYear = 2000 + (year || 0)
+    if (!month || month < 1 || month > 12 || !year || expYear < now.getFullYear() ||
+      (expYear === now.getFullYear() && month < now.getMonth() + 1)) {
+      errs['expiry'] = 'Invalid expiry date'
+    }
+    if (cvc.replace(/\D/g, '').length < 3) errs['cvc'] = 'Enter a valid CVC'
+    if (zip.replace(/\D/g, '').length < 5) errs['zip'] = 'Enter a valid ZIP code'
+    setCardErrors(errs)
+    return Object.keys(errs).length === 0
+  }
+
+  async function handlePay() {
+    if (!validateCard() || !booking) return
+    setProcessing(true)
+    setPayError(null)
+    try {
+      const res = await fetch(`${API_URL}/api/payments/bookings/${bookingId}/pay`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        },
+        body: JSON.stringify({ bookingId }),
+      })
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.error || 'Payment failed')
+      // Navigate to confirmation, no back
+      router.replace(`/booking/${bookingId}/sent` as never)
+    } catch (e: unknown) {
+      setPayError(e instanceof Error ? e.message : 'Payment failed. Please try again.')
+    } finally {
+      setProcessing(false)
+    }
+  }
+
+  if (loading) return <LoadingState />
+  if (fetchError || !booking)
+    return <ErrorState message={fetchError || 'Booking not found'} onRetry={fetchBooking} />
+
+  const companionName = booking.companion.displayName || booking.companion.user.name || 'Companion'
+  const subtotal = booking.companion.hourlyRate * booking.durationHours
+
+  return (
+    <KeyboardAvoidingView
+      behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+      className="flex-1 bg-[#FBF9FA]"
+    >
+      <ScrollView
+        className="flex-1"
+        contentContainerStyle={{ padding: 16, paddingBottom: 120 }}
+        keyboardShouldPersistTaps="handled"
+      >
+        <Text className="text-2xl font-bold text-[#201317] mb-6">Payment</Text>
+
+        {/* Price breakdown */}
+        <Card variant="outlined" padding="md">
+          <Text className="text-base font-bold text-[#201317] mb-3">Order Summary</Text>
+          <View className="gap-2">
+            <PriceLine label={`Date with ${companionName}`} value="" />
+            <PriceLine label={`${companionName}'s rate`} value={`$${booking.companion.hourlyRate}/hr`} muted />
+            <PriceLine label="Duration" value={`${booking.durationHours}h`} muted />
+            <PriceLine label="Subtotal" value={`$${subtotal.toFixed(2)}`} />
+            <View className="h-px bg-[#F0E6EA] my-1" />
+            <PriceLine label="Platform fee (15%)" value={`$${booking.platformFee.toFixed(2)}`} muted />
+            <PriceLine label="Stripe fee (3%)" value={`$${booking.stripeFee.toFixed(2)}`} muted />
+            <View className="h-px bg-[#F0E6EA] my-1" />
+            <View className="flex-row justify-between items-center">
+              <Text className="text-base font-bold text-[#201317]">Total</Text>
+              <Text className="text-base font-bold text-[#C52660]">
+                ${booking.totalAmount.toFixed(2)}
+              </Text>
+            </View>
+          </View>
+        </Card>
+
+        {/* Stripe badge */}
+        <View className="flex-row items-center justify-center mt-4 mb-2 gap-1.5">
+          <Text className="text-xs text-[#81656E]">Secure payment powered by Stripe</Text>
+        </View>
+
+        {/* Mock card form */}
+        <Card variant="outlined" padding="md">
+          <Text className="text-base font-bold text-[#201317] mb-4">Card Details</Text>
+          <View className="gap-4">
+            {/* Card number */}
+            <View>
+              <Text className="text-sm font-semibold text-[#201317] mb-2">Card Number</Text>
+              <CardInput
+                placeholder="1234 5678 9012 3456"
+                value={cardNumber}
+                onChangeText={(t) => setCardNumber(formatCardNumber(t))}
+                keyboardType="number-pad"
+                maxLength={19}
+                error={cardErrors['cardNumber']}
+              />
+            </View>
+            {/* Expiry + CVC */}
+            <View className="flex-row gap-3">
+              <View className="flex-1">
+                <Text className="text-sm font-semibold text-[#201317] mb-2">Expiry</Text>
+                <CardInput
+                  placeholder="MM/YY"
+                  value={expiry}
+                  onChangeText={(t) => setExpiry(formatExpiry(t))}
+                  keyboardType="number-pad"
+                  maxLength={5}
+                  error={cardErrors['expiry']}
+                />
+              </View>
+              <View className="flex-1">
+                <Text className="text-sm font-semibold text-[#201317] mb-2">CVC</Text>
+                <CardInput
+                  placeholder="123"
+                  value={cvc}
+                  onChangeText={(t) => setCvc(t.replace(/\D/g, '').slice(0, 4))}
+                  keyboardType="number-pad"
+                  maxLength={4}
+                  error={cardErrors['cvc']}
+                  secureTextEntry
+                />
+              </View>
+            </View>
+            {/* ZIP */}
+            <View>
+              <Text className="text-sm font-semibold text-[#201317] mb-2">ZIP Code</Text>
+              <CardInput
+                placeholder="10001"
+                value={zip}
+                onChangeText={(t) => setZip(t.replace(/\D/g, '').slice(0, 10))}
+                keyboardType="number-pad"
+                maxLength={10}
+                error={cardErrors['zip']}
+              />
+            </View>
+          </View>
+        </Card>
+
+        {payError && (
+          <View className="mt-4 bg-red-50 rounded-xl p-3">
+            <Text className="text-sm text-[#DC2626]">{payError}</Text>
+          </View>
+        )}
+      </ScrollView>
+
+      {/* Sticky Pay button */}
+      <View
+        style={{
+          position: 'absolute',
+          bottom: 0,
+          left: 0,
+          right: 0,
+          paddingBottom: insets.bottom + 16,
+          paddingTop: 12,
+          paddingHorizontal: 16,
+          backgroundColor: '#FFFFFF',
+          borderTopWidth: 1,
+          borderTopColor: '#F0E6EA',
+        }}
+      >
+        <Button
+          label={processing ? 'Processing...' : `Pay $${booking.totalAmount.toFixed(2)}`}
+          onPress={handlePay}
+          variant="primary"
+          size="lg"
+          fullWidth
+          loading={processing}
+          disabled={processing}
+        />
+      </View>
+    </KeyboardAvoidingView>
+  )
+}
+
+// ---- Helper components ----
+
+function PriceLine({ label, value, muted = false }: { label: string; value: string; muted?: boolean }) {
+  return (
+    <View className="flex-row justify-between items-center">
+      <Text className={`text-sm ${muted ? 'text-[#81656E]' : 'text-[#201317]'}`}>{label}</Text>
+      {value ? (
+        <Text className={`text-sm ${muted ? 'text-[#81656E]' : 'text-[#201317] font-medium'}`}>
+          {value}
+        </Text>
+      ) : null}
+    </View>
+  )
+}
+
+function CardInput({
+  placeholder,
+  value,
+  onChangeText,
+  keyboardType,
+  maxLength,
+  error,
+  secureTextEntry,
+}: {
+  placeholder: string
+  value: string
+  onChangeText: (t: string) => void
+  keyboardType?: 'default' | 'number-pad' | 'decimal-pad'
+  maxLength?: number
+  error?: string
+  secureTextEntry?: boolean
+}) {
+  const [focused, setFocused] = useState(false)
+  return (
+    <View>
+      <View
+        style={{
+          borderColor: error ? colors.error : focused ? colors.primary : '#E6D5DC',
+          borderWidth: 1,
+          borderRadius: 12,
+          backgroundColor: '#FFFFFF',
+          paddingHorizontal: 14,
+          height: 48,
+          justifyContent: 'center',
+        }}
+      >
+        <TextInput
+          style={{ fontSize: 16, color: colors.text }}
+          placeholder={placeholder}
+          placeholderTextColor={colors.textSecondary}
+          value={value}
+          onChangeText={onChangeText}
+          keyboardType={keyboardType}
+          maxLength={maxLength}
+          secureTextEntry={secureTextEntry}
+          onFocus={() => setFocused(true)}
+          onBlur={() => setFocused(false)}
+        />
+      </View>
+      {error && <Text className="text-xs text-[#DC2626] mt-1">{error}</Text>}
+    </View>
+  )
+}

--- a/app/reviews/new.tsx
+++ b/app/reviews/new.tsx
@@ -1,0 +1,194 @@
+import { useState } from 'react'
+import {
+  View,
+  Text,
+  TextInput,
+  ScrollView,
+  Pressable,
+  KeyboardAvoidingView,
+  Platform,
+} from 'react-native'
+import { useLocalSearchParams, router } from 'expo-router'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import { Button } from '@/components/ui/Button'
+import { useAuth } from '@/contexts/AuthContext'
+import { colors } from '@/lib/theme'
+
+const API_URL = process.env.EXPO_PUBLIC_API_URL || 'http://localhost:3500'
+
+const MAX_COMMENT = 1000
+
+function StarPicker({
+  value,
+  onChange,
+}: {
+  value: number
+  onChange: (n: number) => void
+}) {
+  return (
+    <View className="flex-row gap-2">
+      {[1, 2, 3, 4, 5].map((star) => (
+        <Pressable
+          key={star}
+          onPress={() => onChange(star)}
+          accessibilityLabel={`Rate ${star} star${star > 1 ? 's' : ''}`}
+          style={{ padding: 4 }}
+        >
+          <Text
+            style={{
+              fontSize: 40,
+              color: star <= value ? '#D97706' : '#E6D5DC',
+            }}
+          >
+            {star <= value ? '★' : '☆'}
+          </Text>
+        </Pressable>
+      ))}
+    </View>
+  )
+}
+
+export default function WriteReviewScreen() {
+  const { bookingId } = useLocalSearchParams<{ bookingId?: string }>()
+  const { token } = useAuth()
+  const insets = useSafeAreaInsets()
+
+  const [rating, setRating] = useState(0)
+  const [comment, setComment] = useState('')
+  const [ratingError, setRatingError] = useState<string | null>(null)
+  const [submitError, setSubmitError] = useState<string | null>(null)
+  const [submitting, setSubmitting] = useState(false)
+
+  function validate() {
+    if (rating < 1 || rating > 5) {
+      setRatingError('Please select a rating')
+      return false
+    }
+    setRatingError(null)
+    return true
+  }
+
+  async function handleSubmit() {
+    if (!validate()) return
+    setSubmitting(true)
+    setSubmitError(null)
+    try {
+      const res = await fetch(`${API_URL}/api/reviews`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        },
+        body: JSON.stringify({
+          bookingId: bookingId || undefined,
+          rating,
+          comment: comment.trim() || undefined,
+        }),
+      })
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.error || 'Failed to submit review')
+      router.replace('/(tabs)/male/bookings' as never)
+    } catch (e: unknown) {
+      setSubmitError(e instanceof Error ? e.message : 'Something went wrong')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <KeyboardAvoidingView
+      behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+      className="flex-1 bg-[#FBF9FA]"
+    >
+      <ScrollView
+        className="flex-1"
+        contentContainerStyle={{ padding: 16, paddingBottom: 120 }}
+        keyboardShouldPersistTaps="handled"
+      >
+        <Text className="text-2xl font-bold text-[#201317] mb-2">Write a Review</Text>
+        <Text className="text-base text-[#81656E] mb-8">
+          Share your experience to help others.
+        </Text>
+
+        {/* Star picker */}
+        <View className="mb-6">
+          <Text className="text-sm font-semibold text-[#201317] mb-3">Your Rating</Text>
+          <StarPicker value={rating} onChange={(n) => { setRating(n); setRatingError(null) }} />
+          {ratingError && (
+            <Text className="text-xs text-[#DC2626] mt-2">{ratingError}</Text>
+          )}
+          {rating > 0 && (
+            <Text className="text-sm text-[#81656E] mt-2">
+              {['', 'Poor', 'Fair', 'Good', 'Very Good', 'Excellent'][rating]}
+            </Text>
+          )}
+        </View>
+
+        {/* Comment */}
+        <View className="mb-4">
+          <Text className="text-sm font-semibold text-[#201317] mb-2">
+            Comment <Text className="text-[#81656E] font-normal">(optional)</Text>
+          </Text>
+          <View
+            style={{
+              borderColor: '#E6D5DC',
+              borderWidth: 1,
+              borderRadius: 12,
+              backgroundColor: '#FFFFFF',
+              paddingHorizontal: 14,
+              paddingVertical: 12,
+              minHeight: 120,
+            }}
+          >
+            <TextInput
+              style={{ fontSize: 16, color: colors.text, textAlignVertical: 'top' }}
+              placeholder="Share your experience..."
+              placeholderTextColor={colors.textSecondary}
+              value={comment}
+              onChangeText={(t) => setComment(t.slice(0, MAX_COMMENT))}
+              multiline
+              numberOfLines={5}
+              textAlignVertical="top"
+              maxLength={MAX_COMMENT}
+            />
+          </View>
+          <Text className="text-xs text-[#81656E] mt-1 text-right">
+            {comment.length}/{MAX_COMMENT}
+          </Text>
+        </View>
+
+        {submitError && (
+          <View className="bg-red-50 rounded-xl p-3 mb-4">
+            <Text className="text-sm text-[#DC2626]">{submitError}</Text>
+          </View>
+        )}
+      </ScrollView>
+
+      {/* Sticky CTA */}
+      <View
+        style={{
+          position: 'absolute',
+          bottom: 0,
+          left: 0,
+          right: 0,
+          paddingBottom: insets.bottom + 16,
+          paddingTop: 12,
+          paddingHorizontal: 16,
+          backgroundColor: '#FFFFFF',
+          borderTopWidth: 1,
+          borderTopColor: '#F0E6EA',
+        }}
+      >
+        <Button
+          label="Submit Review"
+          onPress={handleSubmit}
+          variant="primary"
+          size="lg"
+          fullWidth
+          loading={submitting}
+          disabled={submitting}
+        />
+      </View>
+    </KeyboardAvoidingView>
+  )
+}


### PR DESCRIPTION
## Summary
- 5 new screens: booking form, payment, booking sent confirmation, date completion, write review
- Payment API stub: POST /api/payments/bookings/:bookingId/pay
- All screens registered in root _layout.tsx

## Screens
- **app/booking/[id].tsx** — new booking form (companion rate fetch, price breakdown with platform+Stripe fees, date/duration/location/activity/notes validation) + read-only existing booking view with status badge
- **app/payment/[bookingId].tsx** — mock Stripe card form (card number with auto-formatting, expiry, CVC, ZIP), price breakdown, sticky Pay button
- **app/booking/[bookingId]/sent.tsx** — success confirmation, no back button (replace nav)
- **app/booking/[bookingId]/complete.tsx** — companion mode: submit actual duration; seeker mode: confirm or dispute with 48h countdown
- **app/reviews/new.tsx** — 5-star tap picker + optional 1000-char comment

## Test plan
- [ ] /booking/[companionId]?mode=new — form loads companion rate, price breakdown updates on duration change
- [ ] Submit booking -> redirects to /payment/[bookingId]
- [ ] Payment screen: card validation catches bad card/expiry/CVC/ZIP
- [ ] Pay -> redirects to /booking/[id]/sent (no back button)
- [ ] /booking/[id]/sent: both nav buttons work
- [ ] /booking/[id]/complete as companion: submit duration
- [ ] /booking/[id]/complete as seeker: confirm or dispute
- [ ] /reviews/new?bookingId=X: requires rating, submits, redirects

🤖 Generated with [Claude Code](https://claude.com/claude-code)