### PR TITLE
feat: admin screens (6 screens) + admin API routes

### DIFF
--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -14,6 +14,8 @@ import reviewsRoutes from "./routes/reviews";
 import companionProfileRoutes from "./routes/companion-profile";
 import verificationRoutes, { companionStatusRouter } from "./routes/verification";
 import paymentsRoutes from "./routes/payments";
+import adminRoutes, { requireAdmin } from "./routes/admin";
+import { authMiddleware } from "./middleware/auth";
 
 const app = express();
 const PORT = process.env.PORT || 3500;
@@ -39,6 +41,7 @@ app.use("/api/companion", companionProfileRoutes);
 app.use("/api/companion", companionStatusRouter);
 app.use("/api/verification", verificationRoutes);
 app.use("/api/payments", paymentsRoutes);
+app.use("/api/admin", authMiddleware, requireAdmin, adminRoutes);
 
 app.listen(PORT, () => {
   console.log(`API server running on http://localhost:${PORT}`);

--- a/api/src/routes/admin.ts
+++ b/api/src/routes/admin.ts
@@ -99,8 +99,9 @@ router.get("/users", async (req: Request, res: Response) => {
 router.post("/users/:id/ban", async (req: Request, res: Response) => {
   try {
     // Stub: field not in schema yet
+    const id = req.params["id"] as string;
     const user = await prisma.user.findUnique({
-      where: { id: req.params.id },
+      where: { id },
       select: { id: true },
     });
     if (!user) {
@@ -117,8 +118,9 @@ router.post("/users/:id/ban", async (req: Request, res: Response) => {
 // POST /api/admin/users/:id/unban — stub
 router.post("/users/:id/unban", async (req: Request, res: Response) => {
   try {
+    const id = req.params["id"] as string;
     const user = await prisma.user.findUnique({
-      where: { id: req.params.id },
+      where: { id },
       select: { id: true },
     });
     if (!user) {
@@ -155,8 +157,9 @@ router.get("/verifications", async (req: Request, res: Response) => {
 // PUT /api/admin/verifications/:id/approve
 router.put("/verifications/:id/approve", async (req: Request, res: Response) => {
   try {
+    const id = req.params["id"] as string;
     await prisma.verificationRequest.update({
-      where: { id: req.params.id },
+      where: { id },
       data: { status: "APPROVED" },
     });
     res.json({ success: true });
@@ -169,9 +172,10 @@ router.put("/verifications/:id/approve", async (req: Request, res: Response) => 
 // PUT /api/admin/verifications/:id/reject
 router.put("/verifications/:id/reject", async (req: Request, res: Response) => {
   try {
+    const id = req.params["id"] as string;
     const { reason } = req.body as { reason?: string };
     await prisma.verificationRequest.update({
-      where: { id: req.params.id },
+      where: { id },
       data: { status: "REJECTED", notes: reason || null },
     });
     res.json({ success: true });
@@ -222,8 +226,9 @@ router.get("/bookings", async (req: Request, res: Response) => {
 // POST /api/admin/bookings/:id/cancel
 router.post("/bookings/:id/cancel", async (req: Request, res: Response) => {
   try {
+    const id = req.params["id"] as string;
     await prisma.booking.update({
-      where: { id: req.params.id },
+      where: { id },
       data: { status: "CANCELLED" },
     });
     res.json({ success: true });
@@ -273,6 +278,7 @@ router.post("/cities", async (req: Request, res: Response) => {
 // PATCH /api/admin/cities/:id
 router.patch("/cities/:id", async (req: Request, res: Response) => {
   try {
+    const id = req.params["id"] as string;
     const { isActive, name, country } = req.body as {
       isActive?: boolean;
       name?: string;
@@ -284,7 +290,7 @@ router.patch("/cities/:id", async (req: Request, res: Response) => {
     if (country !== undefined) data.country = country;
 
     const city = await prisma.city.update({
-      where: { id: req.params.id },
+      where: { id },
       data,
     });
     res.json({ city });

--- a/api/src/routes/admin.ts
+++ b/api/src/routes/admin.ts
@@ -1,0 +1,297 @@
+import { Router, Request, Response, NextFunction } from "express";
+import { prisma } from "../lib/prisma";
+
+const router = Router();
+
+// Middleware: require ADMIN role (looks up DB since JWT has no role field)
+export async function requireAdmin(req: Request, res: Response, next: NextFunction): Promise<void> {
+  if (!req.user) {
+    res.status(401).json({ error: "Unauthorized" });
+    return;
+  }
+  try {
+    const user = await prisma.user.findUnique({
+      where: { id: req.user.userId },
+      select: { role: true },
+    });
+    if (!user || user.role !== "ADMIN") {
+      res.status(403).json({ error: "Admin access required" });
+      return;
+    }
+    next();
+  } catch {
+    res.status(500).json({ error: "Internal server error" });
+  }
+}
+
+// GET /api/admin/stats
+router.get("/stats", async (_req: Request, res: Response) => {
+  try {
+    const [users, pendingVerifications, activeBookings] = await Promise.all([
+      prisma.user.count(),
+      prisma.verificationRequest.count({ where: { status: "PENDING" } }),
+      prisma.booking.count({
+        where: { status: { in: ["ACCEPTED", "PAID", "PENDING"] } },
+      }),
+    ]);
+
+    res.json({
+      users,
+      pendingVerifications,
+      activeBookings,
+      openDisputes: 0, // No Dispute model yet
+    });
+  } catch (error) {
+    console.error("admin/stats error:", error);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+// GET /api/admin/users?search&role&page&limit
+router.get("/users", async (req: Request, res: Response) => {
+  try {
+    const { search = "", role = "", page = "1", limit = "20" } = req.query;
+    const pageNum = parseInt(page as string, 10);
+    const limitNum = Math.min(parseInt(limit as string, 10), 100);
+    const skip = (pageNum - 1) * limitNum;
+
+    const where: Record<string, unknown> = {};
+    if (role && role !== "ALL") {
+      where.role = role as string;
+    }
+    if (search) {
+      where.OR = [
+        { name: { contains: search as string, mode: "insensitive" } },
+        { email: { contains: search as string, mode: "insensitive" } },
+      ];
+    }
+
+    const [users, total] = await Promise.all([
+      prisma.user.findMany({
+        where,
+        select: {
+          id: true,
+          email: true,
+          name: true,
+          avatar: true,
+          role: true,
+          isVerified: true,
+          createdAt: true,
+        },
+        orderBy: { createdAt: "desc" },
+        skip,
+        take: limitNum,
+      }),
+      prisma.user.count({ where }),
+    ]);
+
+    // isBanned doesn't exist in schema — expose as false always for now
+    const usersWithBan = users.map((u: typeof users[number]) => ({ ...u, isBanned: false }));
+
+    res.json({ users: usersWithBan, total, page: pageNum, limit: limitNum });
+  } catch (error) {
+    console.error("admin/users error:", error);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+// POST /api/admin/users/:id/ban — stub (no isBanned field yet)
+router.post("/users/:id/ban", async (req: Request, res: Response) => {
+  try {
+    // Stub: field not in schema yet
+    const user = await prisma.user.findUnique({
+      where: { id: req.params.id },
+      select: { id: true },
+    });
+    if (!user) {
+      res.status(404).json({ error: "User not found" });
+      return;
+    }
+    res.json({ success: true });
+  } catch (error) {
+    console.error("admin/ban error:", error);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+// POST /api/admin/users/:id/unban — stub
+router.post("/users/:id/unban", async (req: Request, res: Response) => {
+  try {
+    const user = await prisma.user.findUnique({
+      where: { id: req.params.id },
+      select: { id: true },
+    });
+    if (!user) {
+      res.status(404).json({ error: "User not found" });
+      return;
+    }
+    res.json({ success: true });
+  } catch (error) {
+    console.error("admin/unban error:", error);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+// GET /api/admin/verifications?status
+router.get("/verifications", async (req: Request, res: Response) => {
+  try {
+    const { status = "PENDING" } = req.query;
+    const verifications = await prisma.verificationRequest.findMany({
+      where: { status: status as "PENDING" | "APPROVED" | "REJECTED" },
+      include: {
+        user: {
+          select: { id: true, email: true, name: true, role: true },
+        },
+      },
+      orderBy: { createdAt: "desc" },
+    });
+    res.json({ verifications });
+  } catch (error) {
+    console.error("admin/verifications error:", error);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+// PUT /api/admin/verifications/:id/approve
+router.put("/verifications/:id/approve", async (req: Request, res: Response) => {
+  try {
+    await prisma.verificationRequest.update({
+      where: { id: req.params.id },
+      data: { status: "APPROVED" },
+    });
+    res.json({ success: true });
+  } catch (error) {
+    console.error("admin/verifications/approve error:", error);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+// PUT /api/admin/verifications/:id/reject
+router.put("/verifications/:id/reject", async (req: Request, res: Response) => {
+  try {
+    const { reason } = req.body as { reason?: string };
+    await prisma.verificationRequest.update({
+      where: { id: req.params.id },
+      data: { status: "REJECTED", notes: reason || null },
+    });
+    res.json({ success: true });
+  } catch (error) {
+    console.error("admin/verifications/reject error:", error);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+// GET /api/admin/bookings?status&page
+router.get("/bookings", async (req: Request, res: Response) => {
+  try {
+    const { status = "", page = "1", limit = "20" } = req.query;
+    const pageNum = parseInt(page as string, 10);
+    const limitNum = Math.min(parseInt(limit as string, 10), 100);
+    const skip = (pageNum - 1) * limitNum;
+
+    const where: Record<string, unknown> = {};
+    if (status && status !== "ALL") {
+      where.status = status as string;
+    }
+
+    const [bookings, total] = await Promise.all([
+      prisma.booking.findMany({
+        where,
+        include: {
+          seeker: { select: { id: true, name: true, avatar: true } },
+          companion: {
+            include: {
+              user: { select: { id: true, name: true, avatar: true } },
+            },
+          },
+        },
+        orderBy: { createdAt: "desc" },
+        skip,
+        take: limitNum,
+      }),
+      prisma.booking.count({ where }),
+    ]);
+
+    res.json({ bookings, total, page: pageNum, limit: limitNum });
+  } catch (error) {
+    console.error("admin/bookings error:", error);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+// POST /api/admin/bookings/:id/cancel
+router.post("/bookings/:id/cancel", async (req: Request, res: Response) => {
+  try {
+    await prisma.booking.update({
+      where: { id: req.params.id },
+      data: { status: "CANCELLED" },
+    });
+    res.json({ success: true });
+  } catch (error) {
+    console.error("admin/bookings/cancel error:", error);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+// GET /api/admin/disputes — stub (no Dispute model)
+router.get("/disputes", async (_req: Request, res: Response) => {
+  res.json({ disputes: [] });
+});
+
+// PUT /api/admin/disputes/:id/resolve — stub
+router.put("/disputes/:id/resolve", async (req: Request, res: Response) => {
+  res.json({ success: true });
+});
+
+// GET /api/admin/cities
+router.get("/cities", async (_req: Request, res: Response) => {
+  try {
+    const cities = await prisma.city.findMany({ orderBy: { name: "asc" } });
+    res.json({ cities });
+  } catch (error) {
+    console.error("admin/cities error:", error);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+// POST /api/admin/cities
+router.post("/cities", async (req: Request, res: Response) => {
+  try {
+    const { name, country } = req.body as { name?: string; country?: string };
+    if (!name || !country) {
+      res.status(400).json({ error: "name and country are required" });
+      return;
+    }
+    const city = await prisma.city.create({ data: { name, country } });
+    res.status(201).json({ city });
+  } catch (error) {
+    console.error("admin/cities POST error:", error);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+// PATCH /api/admin/cities/:id
+router.patch("/cities/:id", async (req: Request, res: Response) => {
+  try {
+    const { isActive, name, country } = req.body as {
+      isActive?: boolean;
+      name?: string;
+      country?: string;
+    };
+    const data: Record<string, unknown> = {};
+    if (isActive !== undefined) data.isActive = isActive;
+    if (name !== undefined) data.name = name;
+    if (country !== undefined) data.country = country;
+
+    const city = await prisma.city.update({
+      where: { id: req.params.id },
+      data,
+    });
+    res.json({ city });
+  } catch (error) {
+    console.error("admin/cities PATCH error:", error);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+export default router;

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -48,6 +48,7 @@ export default function RootLayout() {
         <Stack.Screen name="booking/[bookingId]/complete" options={{ headerShown: true, headerTitle: "Complete Date" }} />
         <Stack.Screen name="payment/[bookingId]" options={{ headerShown: true, headerTitle: "Payment" }} />
         <Stack.Screen name="reviews/new" options={{ headerShown: true, headerTitle: "Write a Review" }} />
+        <Stack.Screen name="admin" />
       </Stack>
     </AuthProvider>
   );

--- a/app/admin/_layout.tsx
+++ b/app/admin/_layout.tsx
@@ -1,0 +1,38 @@
+import { useEffect } from 'react'
+import { Stack, useRouter } from 'expo-router'
+import { useAuth } from '@/contexts/AuthContext'
+
+export default function AdminLayout() {
+  const { user, isLoading } = useAuth()
+  const router = useRouter()
+
+  useEffect(() => {
+    if (!isLoading && user?.role !== 'ADMIN') {
+      router.replace('/')
+    }
+  }, [user, isLoading, router])
+
+  if (isLoading) return null
+  if (user?.role !== 'ADMIN') return null
+
+  return (
+    <Stack
+      screenOptions={{
+        headerStyle: { backgroundColor: '#C52660' },
+        headerTintColor: '#FFFFFF',
+        headerTitleStyle: { fontFamily: 'PlusJakartaSans-SemiBold' },
+        headerBackVisible: true,
+      }}
+    >
+      <Stack.Screen
+        name="index"
+        options={{ title: 'Admin Dashboard', headerBackVisible: false }}
+      />
+      <Stack.Screen name="users" options={{ title: 'Users' }} />
+      <Stack.Screen name="verifications" options={{ title: 'Verifications' }} />
+      <Stack.Screen name="bookings" options={{ title: 'Bookings' }} />
+      <Stack.Screen name="disputes" options={{ title: 'Disputes' }} />
+      <Stack.Screen name="cities" options={{ title: 'Cities' }} />
+    </Stack>
+  )
+}

--- a/app/admin/bookings.tsx
+++ b/app/admin/bookings.tsx
@@ -1,0 +1,228 @@
+import { useCallback, useEffect, useState } from 'react'
+import {
+  ActivityIndicator,
+  FlatList,
+  Pressable,
+  Text,
+  View,
+} from 'react-native'
+import { useAuth } from '@/contexts/AuthContext'
+import { Badge } from '@/components/ui'
+
+const API_URL = process.env.EXPO_PUBLIC_API_URL || 'http://localhost:3500'
+
+type StatusFilter = 'ALL' | 'PENDING' | 'ACCEPTED' | 'PAID' | 'COMPLETED' | 'DISPUTED' | 'CANCELLED'
+
+const STATUS_FILTERS: StatusFilter[] = [
+  'ALL', 'PENDING', 'ACCEPTED', 'PAID', 'COMPLETED', 'DISPUTED', 'CANCELLED',
+]
+
+const CANCELLABLE: StatusFilter[] = ['PENDING', 'ACCEPTED', 'PAID']
+
+function statusVariant(status: string): 'neutral' | 'warning' | 'success' | 'error' | 'primary' {
+  if (status === 'COMPLETED') return 'success'
+  if (status === 'CANCELLED') return 'neutral'
+  if (status === 'DISPUTED') return 'error'
+  if (status === 'PENDING') return 'warning'
+  if (status === 'ACCEPTED' || status === 'PAID') return 'primary'
+  return 'neutral'
+}
+
+interface BookingUser {
+  id: string
+  name: string | null
+  avatar: string | null
+}
+
+interface BookingCompanion {
+  user: BookingUser
+}
+
+interface AdminBooking {
+  id: string
+  status: string
+  date: string
+  totalAmount: number
+  seeker: BookingUser
+  companion: BookingCompanion
+  createdAt: string
+}
+
+function BookingRow({
+  item,
+  token,
+  onCancel,
+}: {
+  item: AdminBooking
+  token: string | null
+  onCancel: (id: string) => void
+}) {
+  const [cancelling, setCancelling] = useState(false)
+  const canCancel = CANCELLABLE.includes(item.status as StatusFilter)
+
+  async function cancel() {
+    try {
+      setCancelling(true)
+      const res = await fetch(`${API_URL}/api/admin/bookings/${item.id}/cancel`, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      if (res.ok) onCancel(item.id)
+    } catch (err) {
+      console.error(err)
+    } finally {
+      setCancelling(false)
+    }
+  }
+
+  return (
+    <View className="bg-white border-b border-[#F0E6EA] px-4 py-3">
+      <View className="flex-row items-center justify-between mb-1">
+        <View className="flex-1">
+          <Text className="text-sm font-semibold text-[#201317]">
+            {item.seeker.name ?? 'Seeker'} → {item.companion.user.name ?? 'Companion'}
+          </Text>
+          <Text className="text-xs text-[#81656E]">
+            {new Date(item.date).toLocaleDateString()} · ${item.totalAmount.toFixed(2)}
+          </Text>
+        </View>
+        <View className="items-end gap-1">
+          <Badge label={item.status} variant={statusVariant(item.status)} />
+          {canCancel && (
+            <Pressable
+              onPress={cancel}
+              disabled={cancelling}
+              className="bg-[#DC2626] rounded-lg px-3 py-1 active:opacity-80"
+            >
+              {cancelling ? (
+                <ActivityIndicator color="#fff" size="small" />
+              ) : (
+                <Text className="text-white text-xs font-semibold">Cancel</Text>
+              )}
+            </Pressable>
+          )}
+        </View>
+      </View>
+    </View>
+  )
+}
+
+export default function AdminBookings() {
+  const { token } = useAuth()
+  const [filter, setFilter] = useState<StatusFilter>('ALL')
+  const [bookings, setBookings] = useState<AdminBooking[]>([])
+  const [loading, setLoading] = useState(true)
+  const [loadingMore, setLoadingMore] = useState(false)
+  const [page, setPage] = useState(1)
+  const [total, setTotal] = useState(0)
+  const [error, setError] = useState<string | null>(null)
+
+  const fetchBookings = useCallback(
+    async (nextPage = 1, append = false) => {
+      try {
+        if (nextPage === 1) setLoading(true)
+        else setLoadingMore(true)
+        setError(null)
+
+        const params = new URLSearchParams({
+          page: String(nextPage),
+          limit: '20',
+          ...(filter !== 'ALL' ? { status: filter } : {}),
+        })
+
+        const res = await fetch(`${API_URL}/api/admin/bookings?${params}`, {
+          headers: { Authorization: `Bearer ${token}` },
+        })
+        if (!res.ok) throw new Error(`HTTP ${res.status}`)
+        const data = await res.json()
+
+        setTotal(data.total)
+        setBookings((prev) => (append ? [...prev, ...data.bookings] : data.bookings))
+        setPage(nextPage)
+      } catch (err) {
+        setError('Failed to load bookings')
+        console.error(err)
+      } finally {
+        setLoading(false)
+        setLoadingMore(false)
+      }
+    },
+    [token, filter]
+  )
+
+  useEffect(() => {
+    fetchBookings(1)
+  }, [fetchBookings])
+
+  function handleCancel(id: string) {
+    setBookings((prev) =>
+      prev.map((b) => (b.id === id ? { ...b, status: 'CANCELLED' } : b))
+    )
+  }
+
+  return (
+    <View className="flex-1 bg-[#FBF9FA]">
+      {/* Filter scroll */}
+      <View className="flex-row flex-wrap px-4 pt-3 pb-2 gap-2">
+        {STATUS_FILTERS.map((f) => (
+          <Pressable
+            key={f}
+            onPress={() => setFilter(f)}
+            className={`px-3 py-1.5 rounded-full border ${
+              filter === f ? 'bg-[#C52660] border-[#C52660]' : 'bg-white border-[#F0E6EA]'
+            }`}
+          >
+            <Text
+              className={`text-xs font-semibold ${
+                filter === f ? 'text-white' : 'text-[#81656E]'
+              }`}
+            >
+              {f}
+            </Text>
+          </Pressable>
+        ))}
+      </View>
+
+      {error && (
+        <View className="mx-4 mb-2 bg-[#FEE2E2] rounded-xl p-3">
+          <Text className="text-[#DC2626] text-sm">{error}</Text>
+        </View>
+      )}
+
+      {loading ? (
+        <View className="flex-1 items-center justify-center">
+          <ActivityIndicator color="#C52660" />
+        </View>
+      ) : bookings.length === 0 ? (
+        <View className="flex-1 items-center justify-center">
+          <Text className="text-[#81656E]">No bookings found</Text>
+        </View>
+      ) : (
+        <FlatList
+          data={bookings}
+          keyExtractor={(b) => b.id}
+          renderItem={({ item }) => (
+            <BookingRow item={item} token={token} onCancel={handleCancel} />
+          )}
+          onEndReached={() => {
+            if (!loadingMore && bookings.length < total) fetchBookings(page + 1, true)
+          }}
+          onEndReachedThreshold={0.3}
+          ListFooterComponent={
+            loadingMore ? (
+              <View className="py-4 items-center">
+                <ActivityIndicator color="#C52660" />
+              </View>
+            ) : null
+          }
+        />
+      )}
+
+      <View className="px-4 py-2 bg-white border-t border-[#F0E6EA]">
+        <Text className="text-xs text-[#81656E]">
+          {bookings.length} of {total} bookings
+        </Text>
+      </View>
+    </View>
+  )
+}

--- a/app/admin/cities.tsx
+++ b/app/admin/cities.tsx
@@ -1,0 +1,205 @@
+import { useEffect, useState } from 'react'
+import {
+  ActivityIndicator,
+  FlatList,
+  Pressable,
+  Switch,
+  Text,
+  TextInput,
+  View,
+} from 'react-native'
+import { useAuth } from '@/contexts/AuthContext'
+
+const API_URL = process.env.EXPO_PUBLIC_API_URL || 'http://localhost:3500'
+
+interface City {
+  id: string
+  name: string
+  country: string
+  isActive: boolean
+}
+
+function CityRow({
+  item,
+  token,
+  onToggle,
+}: {
+  item: City
+  token: string | null
+  onToggle: (id: string, isActive: boolean) => void
+}) {
+  const [toggling, setToggling] = useState(false)
+
+  async function toggle(value: boolean) {
+    try {
+      setToggling(true)
+      const res = await fetch(`${API_URL}/api/admin/cities/${item.id}`, {
+        method: 'PATCH',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ isActive: value }),
+      })
+      if (res.ok) onToggle(item.id, value)
+    } catch (err) {
+      console.error(err)
+    } finally {
+      setToggling(false)
+    }
+  }
+
+  return (
+    <View className="bg-white border-b border-[#F0E6EA] px-4 py-3 flex-row items-center">
+      <View className="flex-1">
+        <Text className="text-sm font-semibold text-[#201317]">{item.name}</Text>
+        <Text className="text-xs text-[#81656E]">{item.country}</Text>
+      </View>
+      {toggling ? (
+        <ActivityIndicator color="#C52660" size="small" />
+      ) : (
+        <Switch
+          value={item.isActive}
+          onValueChange={toggle}
+          trackColor={{ false: '#F5EEF0', true: '#C52660' }}
+          thumbColor="#FFFFFF"
+        />
+      )}
+    </View>
+  )
+}
+
+export default function AdminCities() {
+  const { token } = useAuth()
+  const [cities, setCities] = useState<City[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  // Add city form
+  const [newName, setNewName] = useState('')
+  const [newCountry, setNewCountry] = useState('')
+  const [adding, setAdding] = useState(false)
+  const [addError, setAddError] = useState<string | null>(null)
+
+  useEffect(() => {
+    fetchCities()
+  }, [])
+
+  async function fetchCities() {
+    try {
+      setLoading(true)
+      setError(null)
+      const res = await fetch(`${API_URL}/api/admin/cities`, {
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      const data = await res.json()
+      setCities(data.cities)
+    } catch (err) {
+      setError('Failed to load cities')
+      console.error(err)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  async function addCity() {
+    const name = newName.trim()
+    const country = newCountry.trim()
+    if (!name || !country) {
+      setAddError('Name and country are required')
+      return
+    }
+    try {
+      setAdding(true)
+      setAddError(null)
+      const res = await fetch(`${API_URL}/api/admin/cities`, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ name, country }),
+      })
+      if (!res.ok) {
+        const data = await res.json()
+        throw new Error(data.error ?? `HTTP ${res.status}`)
+      }
+      const data = await res.json()
+      setCities((prev) => [...prev, data.city].sort((a, b) => a.name.localeCompare(b.name)))
+      setNewName('')
+      setNewCountry('')
+    } catch (err) {
+      setAddError(err instanceof Error ? err.message : 'Failed to add city')
+    } finally {
+      setAdding(false)
+    }
+  }
+
+  function handleToggle(id: string, isActive: boolean) {
+    setCities((prev) => prev.map((c) => (c.id === id ? { ...c, isActive } : c)))
+  }
+
+  return (
+    <View className="flex-1 bg-[#FBF9FA]">
+      {/* Add city form */}
+      <View className="bg-white px-4 pt-3 pb-4 border-b border-[#F0E6EA]">
+        <Text className="text-sm font-semibold text-[#201317] mb-2">Add City</Text>
+        <View className="flex-row gap-2 mb-2">
+          <TextInput
+            value={newName}
+            onChangeText={setNewName}
+            placeholder="City name"
+            placeholderTextColor="#81656E"
+            className="flex-1 bg-[#FBF9FA] border border-[#F0E6EA] rounded-xl px-3 py-2.5 text-sm text-[#201317]"
+          />
+          <TextInput
+            value={newCountry}
+            onChangeText={setNewCountry}
+            placeholder="Country"
+            placeholderTextColor="#81656E"
+            className="w-28 bg-[#FBF9FA] border border-[#F0E6EA] rounded-xl px-3 py-2.5 text-sm text-[#201317]"
+          />
+        </View>
+        {addError && (
+          <Text className="text-xs text-[#DC2626] mb-2">{addError}</Text>
+        )}
+        <Pressable
+          onPress={addCity}
+          disabled={adding}
+          className="bg-[#C52660] rounded-xl py-2.5 items-center active:opacity-80"
+        >
+          {adding ? (
+            <ActivityIndicator color="#fff" size="small" />
+          ) : (
+            <Text className="text-white text-sm font-semibold">Save City</Text>
+          )}
+        </Pressable>
+      </View>
+
+      {error && (
+        <View className="mx-4 mt-3 bg-[#FEE2E2] rounded-xl p-3">
+          <Text className="text-[#DC2626] text-sm">{error}</Text>
+        </View>
+      )}
+
+      {loading ? (
+        <View className="flex-1 items-center justify-center">
+          <ActivityIndicator color="#C52660" />
+        </View>
+      ) : cities.length === 0 ? (
+        <View className="flex-1 items-center justify-center">
+          <Text className="text-[#81656E]">No cities yet</Text>
+        </View>
+      ) : (
+        <FlatList
+          data={cities}
+          keyExtractor={(c) => c.id}
+          renderItem={({ item }) => (
+            <CityRow item={item} token={token} onToggle={handleToggle} />
+          )}
+        />
+      )}
+    </View>
+  )
+}

--- a/app/admin/disputes.tsx
+++ b/app/admin/disputes.tsx
@@ -1,0 +1,192 @@
+import { useEffect, useState } from 'react'
+import {
+  ActivityIndicator,
+  FlatList,
+  Pressable,
+  Text,
+  View,
+} from 'react-native'
+import { useAuth } from '@/contexts/AuthContext'
+import { Badge } from '@/components/ui'
+
+const API_URL = process.env.EXPO_PUBLIC_API_URL || 'http://localhost:3500'
+
+interface DisputeBookingUser {
+  id: string
+  name: string | null
+}
+
+interface DisputeBooking {
+  id: string
+  date: string
+  totalAmount: number
+  seeker: DisputeBookingUser
+  companion: { user: DisputeBookingUser }
+}
+
+interface Dispute {
+  id: string
+  status: string
+  reason?: string
+  winner?: string | null
+  createdAt: string
+  booking: DisputeBooking
+}
+
+function DisputeCard({
+  item,
+  token,
+  onResolve,
+}: {
+  item: Dispute
+  token: string | null
+  onResolve: (id: string) => void
+}) {
+  const [actioning, setActioning] = useState<null | 'seeker' | 'companion'>(null)
+
+  async function resolve(winner: 'seeker' | 'companion') {
+    try {
+      setActioning(winner)
+      const res = await fetch(`${API_URL}/api/admin/disputes/${item.id}/resolve`, {
+        method: 'PUT',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ winner }),
+      })
+      if (res.ok) onResolve(item.id)
+    } catch (err) {
+      console.error(err)
+    } finally {
+      setActioning(null)
+    }
+  }
+
+  const bk = item.booking
+
+  return (
+    <View className="bg-white mx-4 mb-3 rounded-2xl border border-[#F0E6EA] p-4">
+      <View className="flex-row items-start justify-between mb-2">
+        <View className="flex-1">
+          <Text className="text-sm font-semibold text-[#201317]">
+            {bk.seeker.name ?? 'Seeker'} vs {bk.companion.user.name ?? 'Companion'}
+          </Text>
+          <Text className="text-xs text-[#81656E]">
+            Booking {new Date(bk.date).toLocaleDateString()} · ${bk.totalAmount.toFixed(2)}
+          </Text>
+          {item.reason && (
+            <Text className="text-xs text-[#81656E] mt-1" numberOfLines={2}>
+              Claim: {item.reason}
+            </Text>
+          )}
+        </View>
+        <Badge
+          label={item.status}
+          variant={item.status === 'RESOLVED' ? 'success' : 'error'}
+        />
+      </View>
+
+      {item.winner && (
+        <View className="bg-[#D1FAE5] rounded-lg px-3 py-2 mb-2">
+          <Text className="text-xs text-[#059669] font-semibold">
+            Resolved in favour of {item.winner}
+          </Text>
+        </View>
+      )}
+
+      {item.status === 'OPEN' && (
+        <View className="flex-row gap-2 mt-2">
+          <Pressable
+            onPress={() => resolve('seeker')}
+            disabled={actioning !== null}
+            className="flex-1 bg-[#C52660] rounded-xl py-2.5 items-center active:opacity-80"
+          >
+            {actioning === 'seeker' ? (
+              <ActivityIndicator color="#fff" size="small" />
+            ) : (
+              <Text className="text-white text-sm font-semibold">Favour Seeker</Text>
+            )}
+          </Pressable>
+          <Pressable
+            onPress={() => resolve('companion')}
+            disabled={actioning !== null}
+            className="flex-1 bg-[#E95C20] rounded-xl py-2.5 items-center active:opacity-80"
+          >
+            {actioning === 'companion' ? (
+              <ActivityIndicator color="#fff" size="small" />
+            ) : (
+              <Text className="text-white text-sm font-semibold">Favour Companion</Text>
+            )}
+          </Pressable>
+        </View>
+      )}
+    </View>
+  )
+}
+
+export default function AdminDisputes() {
+  const { token } = useAuth()
+  const [disputes, setDisputes] = useState<Dispute[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    fetchDisputes()
+  }, [])
+
+  async function fetchDisputes() {
+    try {
+      setLoading(true)
+      setError(null)
+      const res = await fetch(`${API_URL}/api/admin/disputes`, {
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      const data = await res.json()
+      setDisputes(data.disputes)
+    } catch (err) {
+      setError('Failed to load disputes')
+      console.error(err)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  function handleResolve(id: string) {
+    setDisputes((prev) => prev.filter((d) => d.id !== id))
+  }
+
+  if (loading) {
+    return (
+      <View className="flex-1 items-center justify-center bg-[#FBF9FA]">
+        <ActivityIndicator color="#C52660" />
+      </View>
+    )
+  }
+
+  return (
+    <View className="flex-1 bg-[#FBF9FA]">
+      {error && (
+        <View className="mx-4 mt-3 bg-[#FEE2E2] rounded-xl p-3">
+          <Text className="text-[#DC2626] text-sm">{error}</Text>
+        </View>
+      )}
+
+      {disputes.length === 0 ? (
+        <View className="flex-1 items-center justify-center">
+          <Text className="text-[#81656E]">No disputes</Text>
+        </View>
+      ) : (
+        <FlatList
+          data={disputes}
+          keyExtractor={(d) => d.id}
+          contentContainerClassName="pt-3 pb-6"
+          renderItem={({ item }) => (
+            <DisputeCard item={item} token={token} onResolve={handleResolve} />
+          )}
+        />
+      )}
+    </View>
+  )
+}

--- a/app/admin/index.tsx
+++ b/app/admin/index.tsx
@@ -1,0 +1,117 @@
+import { useEffect, useState } from 'react'
+import { ScrollView, Text, View, Pressable, ActivityIndicator } from 'react-native'
+import { useRouter } from 'expo-router'
+import { useAuth } from '@/contexts/AuthContext'
+
+const API_URL = process.env.EXPO_PUBLIC_API_URL || 'http://localhost:3500'
+
+interface Stats {
+  users: number
+  pendingVerifications: number
+  activeBookings: number
+  openDisputes: number
+}
+
+function StatCard({
+  label,
+  value,
+  loading,
+}: {
+  label: string
+  value: number
+  loading: boolean
+}) {
+  return (
+    <View className="flex-1 bg-white rounded-2xl p-4 border border-[#F0E6EA]">
+      {loading ? (
+        <ActivityIndicator color="#C52660" />
+      ) : (
+        <Text className="text-2xl font-bold text-[#201317]">{value}</Text>
+      )}
+      <Text className="text-xs text-[#81656E] mt-1 font-medium">{label}</Text>
+    </View>
+  )
+}
+
+function QuickLink({ label, route }: { label: string; route: string }) {
+  const router = useRouter()
+  return (
+    <Pressable
+      onPress={() => router.push(route as never)}
+      className="flex-row items-center justify-between bg-white rounded-xl px-4 py-3 border border-[#F0E6EA] active:opacity-70"
+    >
+      <Text className="text-base text-[#201317] font-medium">{label}</Text>
+      <Text className="text-[#C52660] text-lg">›</Text>
+    </Pressable>
+  )
+}
+
+export default function AdminDashboard() {
+  const { token } = useAuth()
+  const [stats, setStats] = useState<Stats | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    fetchStats()
+  }, [])
+
+  async function fetchStats() {
+    try {
+      setLoading(true)
+      setError(null)
+      const res = await fetch(`${API_URL}/api/admin/stats`, {
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      const data = await res.json()
+      setStats(data)
+    } catch (err) {
+      setError('Failed to load stats')
+      console.error(err)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <ScrollView className="flex-1 bg-[#FBF9FA]" contentContainerClassName="p-4 max-w-5xl w-full self-center">
+      <Text className="text-2xl font-bold text-[#201317] mb-4">Overview</Text>
+
+      {error && (
+        <View className="bg-[#FEE2E2] rounded-xl p-3 mb-4">
+          <Text className="text-[#DC2626] text-sm">{error}</Text>
+        </View>
+      )}
+
+      {/* Stats row */}
+      <View className="flex-row gap-3 mb-6 flex-wrap">
+        <StatCard label="Total Users" value={stats?.users ?? 0} loading={loading} />
+        <StatCard
+          label="Pending Verifications"
+          value={stats?.pendingVerifications ?? 0}
+          loading={loading}
+        />
+        <StatCard
+          label="Active Bookings"
+          value={stats?.activeBookings ?? 0}
+          loading={loading}
+        />
+        <StatCard
+          label="Open Disputes"
+          value={stats?.openDisputes ?? 0}
+          loading={loading}
+        />
+      </View>
+
+      <Text className="text-lg font-semibold text-[#201317] mb-3">Quick Actions</Text>
+      <View className="gap-2">
+        <QuickLink label="View Users" route="/admin/users" />
+        <QuickLink label="View Verifications" route="/admin/verifications" />
+        <QuickLink label="View Bookings" route="/admin/bookings" />
+        <QuickLink label="View Disputes" route="/admin/disputes" />
+        <QuickLink label="Manage Cities" route="/admin/cities" />
+      </View>
+    </ScrollView>
+  )
+}

--- a/app/admin/users.tsx
+++ b/app/admin/users.tsx
@@ -1,0 +1,235 @@
+import { useCallback, useEffect, useState } from 'react'
+import {
+  ActivityIndicator,
+  FlatList,
+  Pressable,
+  Text,
+  TextInput,
+  View,
+} from 'react-native'
+import { useAuth } from '@/contexts/AuthContext'
+import { Badge } from '@/components/ui'
+
+const API_URL = process.env.EXPO_PUBLIC_API_URL || 'http://localhost:3500'
+
+type Role = 'ALL' | 'SEEKER' | 'COMPANION' | 'ADMIN'
+
+interface AdminUser {
+  id: string
+  email: string
+  name: string | null
+  avatar: string | null
+  role: string
+  isVerified: boolean
+  isBanned: boolean
+  createdAt: string
+}
+
+const ROLE_TABS: Role[] = ['ALL', 'SEEKER', 'COMPANION', 'ADMIN']
+
+function roleBadgeVariant(role: string): 'primary' | 'success' | 'warning' | 'neutral' {
+  if (role === 'ADMIN') return 'warning'
+  if (role === 'COMPANION') return 'success'
+  if (role === 'SEEKER') return 'primary'
+  return 'neutral'
+}
+
+function UserRow({ user, token, onAction }: { user: AdminUser; token: string | null; onAction: () => void }) {
+  const [expanded, setExpanded] = useState(false)
+  const [actioning, setActioning] = useState(false)
+
+  async function toggleBan() {
+    try {
+      setActioning(true)
+      const endpoint = user.isBanned ? 'unban' : 'ban'
+      await fetch(`${API_URL}/api/admin/users/${user.id}/${endpoint}`, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      onAction()
+    } catch (err) {
+      console.error(err)
+    } finally {
+      setActioning(false)
+    }
+  }
+
+  return (
+    <Pressable
+      onPress={() => setExpanded((v) => !v)}
+      className="bg-white border-b border-[#F0E6EA] px-4 py-3 active:bg-[#FBF9FA]"
+    >
+      <View className="flex-row items-center gap-3">
+        <View className="w-10 h-10 rounded-full bg-[#FCE7EF] items-center justify-center">
+          <Text className="text-[#C52660] font-bold text-base">
+            {(user.name ?? user.email)[0].toUpperCase()}
+          </Text>
+        </View>
+        <View className="flex-1">
+          <Text className="text-sm font-semibold text-[#201317]">{user.name ?? '—'}</Text>
+          <Text className="text-xs text-[#81656E]">{user.email}</Text>
+        </View>
+        <View className="gap-1 items-end">
+          <Badge label={user.role} variant={roleBadgeVariant(user.role)} />
+          {user.isVerified && <Badge label="Verified" variant="success" />}
+          {user.isBanned && <Badge label="Banned" variant="error" />}
+        </View>
+      </View>
+
+      {expanded && (
+        <View className="mt-3 pt-3 border-t border-[#F0E6EA] flex-row items-center justify-between">
+          <Text className="text-xs text-[#81656E]">
+            Joined {new Date(user.createdAt).toLocaleDateString()}
+          </Text>
+          <Pressable
+            onPress={toggleBan}
+            disabled={actioning}
+            className={`px-4 py-2 rounded-lg ${user.isBanned ? 'bg-[#059669]' : 'bg-[#DC2626]'} active:opacity-80`}
+          >
+            {actioning ? (
+              <ActivityIndicator color="#fff" size="small" />
+            ) : (
+              <Text className="text-white text-sm font-semibold">
+                {user.isBanned ? 'Unban' : 'Ban'}
+              </Text>
+            )}
+          </Pressable>
+        </View>
+      )}
+    </Pressable>
+  )
+}
+
+export default function AdminUsers() {
+  const { token } = useAuth()
+  const [search, setSearch] = useState('')
+  const [roleTab, setRoleTab] = useState<Role>('ALL')
+  const [users, setUsers] = useState<AdminUser[]>([])
+  const [loading, setLoading] = useState(true)
+  const [loadingMore, setLoadingMore] = useState(false)
+  const [page, setPage] = useState(1)
+  const [total, setTotal] = useState(0)
+  const [error, setError] = useState<string | null>(null)
+
+  const fetchUsers = useCallback(
+    async (nextPage = 1, append = false) => {
+      try {
+        if (nextPage === 1) setLoading(true)
+        else setLoadingMore(true)
+        setError(null)
+
+        const params = new URLSearchParams({
+          page: String(nextPage),
+          limit: '20',
+          ...(search ? { search } : {}),
+          ...(roleTab !== 'ALL' ? { role: roleTab } : {}),
+        })
+
+        const res = await fetch(`${API_URL}/api/admin/users?${params}`, {
+          headers: { Authorization: `Bearer ${token}` },
+        })
+        if (!res.ok) throw new Error(`HTTP ${res.status}`)
+        const data = await res.json()
+
+        setTotal(data.total)
+        setUsers((prev) => (append ? [...prev, ...data.users] : data.users))
+        setPage(nextPage)
+      } catch (err) {
+        setError('Failed to load users')
+        console.error(err)
+      } finally {
+        setLoading(false)
+        setLoadingMore(false)
+      }
+    },
+    [token, search, roleTab]
+  )
+
+  useEffect(() => {
+    fetchUsers(1)
+  }, [fetchUsers])
+
+  function loadMore() {
+    if (loadingMore || users.length >= total) return
+    fetchUsers(page + 1, true)
+  }
+
+  return (
+    <View className="flex-1 bg-[#FBF9FA]">
+      {/* Search */}
+      <View className="px-4 pt-3 pb-2 bg-[#FBF9FA]">
+        <TextInput
+          value={search}
+          onChangeText={setSearch}
+          placeholder="Search name or email…"
+          placeholderTextColor="#81656E"
+          className="bg-white border border-[#F0E6EA] rounded-xl px-4 py-2.5 text-sm text-[#201317]"
+          returnKeyType="search"
+          onSubmitEditing={() => fetchUsers(1)}
+        />
+      </View>
+
+      {/* Role tabs */}
+      <View className="flex-row px-4 pb-2 gap-2">
+        {ROLE_TABS.map((r) => (
+          <Pressable
+            key={r}
+            onPress={() => setRoleTab(r)}
+            className={`px-3 py-1.5 rounded-full border ${
+              roleTab === r
+                ? 'bg-[#C52660] border-[#C52660]'
+                : 'bg-white border-[#F0E6EA]'
+            }`}
+          >
+            <Text
+              className={`text-xs font-semibold ${
+                roleTab === r ? 'text-white' : 'text-[#81656E]'
+              }`}
+            >
+              {r}
+            </Text>
+          </Pressable>
+        ))}
+      </View>
+
+      {error && (
+        <View className="mx-4 mb-2 bg-[#FEE2E2] rounded-xl p-3">
+          <Text className="text-[#DC2626] text-sm">{error}</Text>
+        </View>
+      )}
+
+      {loading ? (
+        <View className="flex-1 items-center justify-center">
+          <ActivityIndicator color="#C52660" />
+        </View>
+      ) : users.length === 0 ? (
+        <View className="flex-1 items-center justify-center">
+          <Text className="text-[#81656E]">No users found</Text>
+        </View>
+      ) : (
+        <FlatList
+          data={users}
+          keyExtractor={(u) => u.id}
+          renderItem={({ item }) => (
+            <UserRow user={item} token={token} onAction={() => fetchUsers(1)} />
+          )}
+          onEndReached={loadMore}
+          onEndReachedThreshold={0.3}
+          ListFooterComponent={
+            loadingMore ? (
+              <View className="py-4 items-center">
+                <ActivityIndicator color="#C52660" />
+              </View>
+            ) : null
+          }
+        />
+      )}
+
+      <View className="px-4 py-2 bg-white border-t border-[#F0E6EA]">
+        <Text className="text-xs text-[#81656E]">
+          {users.length} of {total} users
+        </Text>
+      </View>
+    </View>
+  )
+}

--- a/app/admin/verifications.tsx
+++ b/app/admin/verifications.tsx
@@ -1,0 +1,238 @@
+import { useCallback, useEffect, useState } from 'react'
+import {
+  ActivityIndicator,
+  Alert,
+  FlatList,
+  Image,
+  Pressable,
+  Text,
+  TextInput,
+  View,
+} from 'react-native'
+import { useAuth } from '@/contexts/AuthContext'
+import { Badge } from '@/components/ui'
+
+const API_URL = process.env.EXPO_PUBLIC_API_URL || 'http://localhost:3500'
+
+type StatusTab = 'PENDING' | 'APPROVED' | 'REJECTED'
+
+interface VerificationUser {
+  id: string
+  email: string
+  name: string | null
+  role: string
+}
+
+interface Verification {
+  id: string
+  type: string
+  status: string
+  documents: { urls?: string[] } | null
+  createdAt: string
+  user: VerificationUser
+}
+
+const STATUS_TABS: StatusTab[] = ['PENDING', 'APPROVED', 'REJECTED']
+
+function VerificationCard({
+  item,
+  token,
+  onUpdate,
+}: {
+  item: Verification
+  token: string | null
+  onUpdate: (id: string) => void
+}) {
+  const [actioning, setActioning] = useState<null | 'approve' | 'reject'>(null)
+
+  async function approve() {
+    try {
+      setActioning('approve')
+      const res = await fetch(`${API_URL}/api/admin/verifications/${item.id}/approve`, {
+        method: 'PUT',
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      if (res.ok) onUpdate(item.id)
+    } catch (err) {
+      console.error(err)
+    } finally {
+      setActioning(null)
+    }
+  }
+
+  function promptReject() {
+    Alert.prompt(
+      'Reject Verification',
+      'Enter rejection reason:',
+      async (reason) => {
+        if (reason === null) return
+        try {
+          setActioning('reject')
+          const res = await fetch(`${API_URL}/api/admin/verifications/${item.id}/reject`, {
+            method: 'PUT',
+            headers: {
+              Authorization: `Bearer ${token}`,
+              'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({ reason }),
+          })
+          if (res.ok) onUpdate(item.id)
+        } catch (err) {
+          console.error(err)
+        } finally {
+          setActioning(null)
+        }
+      },
+      'plain-text'
+    )
+  }
+
+  const docs: string[] = item.documents?.urls ?? []
+
+  return (
+    <View className="bg-white mx-4 mb-3 rounded-2xl border border-[#F0E6EA] p-4">
+      <View className="flex-row items-start justify-between mb-2">
+        <View className="flex-1">
+          <Text className="text-sm font-semibold text-[#201317]">{item.user.name ?? '—'}</Text>
+          <Text className="text-xs text-[#81656E]">{item.user.email}</Text>
+          <Text className="text-xs text-[#81656E] mt-0.5">
+            Submitted {new Date(item.createdAt).toLocaleDateString()}
+          </Text>
+        </View>
+        <View className="gap-1 items-end">
+          <Badge label={item.type} variant="primary" />
+          <Badge label={item.status} variant={item.status === 'PENDING' ? 'warning' : item.status === 'APPROVED' ? 'success' : 'error'} />
+        </View>
+      </View>
+
+      {/* Document thumbnails */}
+      {docs.length > 0 && (
+        <View className="flex-row gap-2 mb-3 flex-wrap">
+          {docs.map((url, i) => (
+            <Image
+              key={i}
+              source={{ uri: url }}
+              className="w-20 h-20 rounded-lg bg-[#F5EEF0]"
+              resizeMode="cover"
+            />
+          ))}
+        </View>
+      )}
+
+      {/* Actions — only for pending */}
+      {item.status === 'PENDING' && (
+        <View className="flex-row gap-2 mt-2">
+          <Pressable
+            onPress={approve}
+            disabled={actioning !== null}
+            className="flex-1 bg-[#059669] rounded-xl py-2.5 items-center active:opacity-80"
+          >
+            {actioning === 'approve' ? (
+              <ActivityIndicator color="#fff" size="small" />
+            ) : (
+              <Text className="text-white text-sm font-semibold">Approve</Text>
+            )}
+          </Pressable>
+          <Pressable
+            onPress={promptReject}
+            disabled={actioning !== null}
+            className="flex-1 bg-[#DC2626] rounded-xl py-2.5 items-center active:opacity-80"
+          >
+            {actioning === 'reject' ? (
+              <ActivityIndicator color="#fff" size="small" />
+            ) : (
+              <Text className="text-white text-sm font-semibold">Reject</Text>
+            )}
+          </Pressable>
+        </View>
+      )}
+    </View>
+  )
+}
+
+export default function AdminVerifications() {
+  const { token } = useAuth()
+  const [tab, setTab] = useState<StatusTab>('PENDING')
+  const [verifications, setVerifications] = useState<Verification[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const fetchVerifications = useCallback(
+    async (status: StatusTab) => {
+      try {
+        setLoading(true)
+        setError(null)
+        const res = await fetch(`${API_URL}/api/admin/verifications?status=${status}`, {
+          headers: { Authorization: `Bearer ${token}` },
+        })
+        if (!res.ok) throw new Error(`HTTP ${res.status}`)
+        const data = await res.json()
+        setVerifications(data.verifications)
+      } catch (err) {
+        setError('Failed to load verifications')
+        console.error(err)
+      } finally {
+        setLoading(false)
+      }
+    },
+    [token]
+  )
+
+  useEffect(() => {
+    fetchVerifications(tab)
+  }, [tab, fetchVerifications])
+
+  function removeItem(id: string) {
+    setVerifications((prev) => prev.filter((v) => v.id !== id))
+  }
+
+  return (
+    <View className="flex-1 bg-[#FBF9FA]">
+      {/* Tabs */}
+      <View className="flex-row px-4 pt-3 pb-2 gap-2">
+        {STATUS_TABS.map((s) => (
+          <Pressable
+            key={s}
+            onPress={() => setTab(s)}
+            className={`flex-1 py-2 rounded-full border items-center ${
+              tab === s ? 'bg-[#C52660] border-[#C52660]' : 'bg-white border-[#F0E6EA]'
+            }`}
+          >
+            <Text
+              className={`text-xs font-semibold ${
+                tab === s ? 'text-white' : 'text-[#81656E]'
+              }`}
+            >
+              {s}
+            </Text>
+          </Pressable>
+        ))}
+      </View>
+
+      {error && (
+        <View className="mx-4 mb-2 bg-[#FEE2E2] rounded-xl p-3">
+          <Text className="text-[#DC2626] text-sm">{error}</Text>
+        </View>
+      )}
+
+      {loading ? (
+        <View className="flex-1 items-center justify-center">
+          <ActivityIndicator color="#C52660" />
+        </View>
+      ) : verifications.length === 0 ? (
+        <View className="flex-1 items-center justify-center">
+          <Text className="text-[#81656E]">No {tab.toLowerCase()} verifications</Text>
+        </View>
+      ) : (
+        <FlatList
+          data={verifications}
+          keyExtractor={(v) => v.id}
+          contentContainerClassName="pt-2 pb-6"
+          renderItem={({ item }) => (
+            <VerificationCard item={item} token={token} onUpdate={removeItem} />
+          )}
+        />
+      )}
+    </View>
+  )
+}


### PR DESCRIPTION
## Summary
- 6 admin screens under `app/admin/` with rose header Stack layout and ADMIN role guard
- Admin dashboard with 4 stat cards (users, pending verifications, active bookings, open disputes)
- Users list with search + role filter tabs + expandable ban/unban rows
- Verifications queue (Pending/Approved/Rejected tabs) with approve + reject (reason prompt)
- Bookings list with 7 status filters + cancel action
- Disputes screen with seeker/companion resolution buttons
- Cities management with active/inactive toggle + inline add form
- 13 admin API endpoints in `api/src/routes/admin.ts`, all guarded by `requireAdmin` (DB role lookup)

## Notes
- `isBanned` and `Dispute` model are stubs (field not in Prisma schema yet) — ban/unban returns success, disputes returns empty array
- API TS errors for express/prisma are pre-existing (no node_modules in worktree) — not introduced by this PR

## Test plan
- [ ] Sign in as ADMIN user → navigate to /admin
- [ ] Non-admin user → redirected to home
- [ ] Stats cards load from `/api/admin/stats`
- [ ] Users: search, role filter, expand row, ban/unban
- [ ] Verifications: tab switch, approve, reject with reason
- [ ] Bookings: filter by status, cancel eligible booking
- [ ] Cities: toggle active, add new city
- [ ] `npx tsc --noEmit` on root = 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)